### PR TITLE
Bump plugin + dependencies to version 1.0.0.0-beta1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,37 +33,37 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-alpha2'
+          ref: '1.0.0-beta1'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: '1.0.0-alpha2'
+          ref: '1.0.0-beta1'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha2
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
         with:
-          ref: '1.0.0-alpha2'
+          ref: '1.0.0-beta1'
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha2 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1 -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.0.0-alpha2 -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.0.0-beta1 -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd
@@ -75,11 +75,11 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0-alpha2
+          ./gradlew build -Dopensearch.version=1.0.0-beta1
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha2
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0-alpha2")
-        common_utils_version = '1.0.0.0-alpha2'
-        job_scheduler_version = '1.0.0.0-alpha2'
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0-beta1")
+        common_utils_version = '1.0.0.0-beta1'
+        job_scheduler_version = '1.0.0.0-beta1'
     }
 
     repositories {
@@ -66,7 +66,7 @@ ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
-version = "${opensearchVersion}.0-alpha2"
+version = "${opensearchVersion}.0-beta1"
 
 apply plugin: 'java'
 apply plugin: 'idea'

--- a/release-notes/opensearch-anomaly-detection.release-notes-1.0.0.0-beta1.md
+++ b/release-notes/opensearch-anomaly-detection.release-notes-1.0.0.0-beta1.md
@@ -14,3 +14,4 @@ Compatible with OpenSearch 1.0.0
 
 * Migrating plugin to work with OpenSearch ([#1](https://github.com/opensearch-project/anomaly-detection/pull/1))
 * Rename plugin to opensearch-anomaly-detection; bump plugin to 1.0.0-alpha2 ([#28](https://github.com/opensearch-project/anomaly-detection/pull/28))
+* Bump plugin + dependencies to version 1.0.0.0-beta1 ([#32](https://github.com/opensearch-project/anomaly-detection/pull/32))


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Bumps the plugin to version `1.0.0.0-beta1` and its related dependencies (`common-utils`, `job-scheduler`). Also updates CI workflow to updated `1.0.0.0-beta1` versions.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
