### PR TITLE
use main branch of OpenSearch in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: 'main'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false

--- a/build.gradle
+++ b/build.gradle
@@ -362,7 +362,7 @@ check.dependsOn jacocoTestCoverageVerification
 jacocoTestCoverageVerification.dependsOn jacocoTestReport
 
 checkstyle {
-    toolVersion = '8.20'
+    toolVersion = '8.29'
 }
 
 dependencies {


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Change to `main` branch for OpenSearch to pass build.
Check this [build](https://github.com/opensearch-project/anomaly-detection/pull/47/checks?check_run_id=2615441771), it will throw such exception when build with beta1
```
positiveTimeSetting(String,Setting<TimeValue>,Property,Property)
        .positiveTimeSetting(
        ^
    method Setting.positiveTimeSetting(String,TimeValue,Property...) is not applicable
      (argument mismatch; Setting<TimeValue> cannot be converted to TimeValue)
    method Setting.positiveTimeSetting(String,Setting<TimeValue>,TimeValue,Property...) is not applicable
      (argument mismatch; Property cannot be converted to TimeValue)
```

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
