### PR TITLE
Add a queue for HCAD model cold start.

### DIFF
--- a/src/main/java/org/opensearch/ad/caching/DoorKeeper.java
+++ b/src/main/java/org/opensearch/ad/caching/DoorKeeper.java
@@ -38,9 +38,7 @@ import com.google.common.hash.BloomFilter;
 import com.google.common.hash.Funnels;
 
 /**
- * A bloom filter placed in front of inactive entity cache to
- * filter out unpopular items that are not likely to appear more
- * than once.
+ * A bloom filter with regular reset.
  *
  * Reference: https://arxiv.org/abs/1512.00727
  *

--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -36,11 +36,12 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
@@ -52,27 +53,30 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.MaintenanceState;
 import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.caching.DoorKeeper;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.dataprocessor.Interpolator;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
-import org.opensearch.common.lease.Releasable;
+import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
+import org.opensearch.ad.ratelimit.SegmentPriority;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
 
 import com.amazon.randomcutforest.RandomCutForest;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 /**
- * Training models for multi-entity detectors
+ * Training models for HCAD detectors
  *
  */
-public class EntityColdStarter {
+public class EntityColdStarter implements MaintenanceState {
     private static final Logger logger = LogManager.getLogger(EntityColdStarter.class);
     private final Clock clock;
     private final ThreadPool threadPool;
@@ -94,9 +98,12 @@ public class EntityColdStarter {
     private final int shingleSize;
     private Instant lastThrottledColdStartTime;
     private final FeatureManager featureManager;
-    private final Cache<String, Instant> lastColdStartTime;
-    private final CheckpointDao checkpointDao;
     private int coolDownMinutes;
+    // A bloom filter checked before cold start to ensure we don't repeatedly
+    // retry cold start of the same model.
+    private Map<String, DoorKeeper> doorKeepers;
+    private final Duration modelTtl;
+    private final CheckpointWriteQueue checkpointWriteQueue;
 
     /**
      * Constructor
@@ -121,10 +128,11 @@ public class EntityColdStarter {
      * @param thresholdDownsamples the number of samples to keep during downsampling
      * @param thresholdMaxSamples the max number of samples before downsampling
      * @param featureManager Used to create features for models.
-     * @param lastColdStartTimestampTtl max time to retain last cold start timestamp
-     * @param maxCacheSize max cache size
-     * @param checkpointDao utility to interact with the checkpoint index
      * @param settings ES settings accessor
+     * @param modelTtl time-to-leave before last access time of the cold start cache.
+     *   We have a cache to record entities that have run cold starts to avoid
+     *   repeated unsuccessful cold start.
+     * @param checkpointWriteQueue queue to insert model checkpoints
      */
     public EntityColdStarter(
         Clock clock,
@@ -146,10 +154,9 @@ public class EntityColdStarter {
         int thresholdDownsamples,
         long thresholdMaxSamples,
         FeatureManager featureManager,
-        Duration lastColdStartTimestampTtl,
-        long maxCacheSize,
-        CheckpointDao checkpointDao,
-        Settings settings
+        Settings settings,
+        Duration modelTtl,
+        CheckpointWriteQueue checkpointWriteQueue
     ) {
         this.clock = clock;
         this.lastThrottledColdStartTime = Instant.MIN;
@@ -171,98 +178,148 @@ public class EntityColdStarter {
         this.thresholdDownsamples = thresholdDownsamples;
         this.thresholdMaxSamples = thresholdMaxSamples;
         this.featureManager = featureManager;
-
-        this.lastColdStartTime = CacheBuilder
-            .newBuilder()
-            .expireAfterAccess(lastColdStartTimestampTtl.toHours(), TimeUnit.HOURS)
-            .maximumSize(maxCacheSize)
-            .concurrencyLevel(1)
-            .build();
-        this.checkpointDao = checkpointDao;
         this.coolDownMinutes = (int) (COOLDOWN_MINUTES.get(settings).getMinutes());
+        this.doorKeepers = new ConcurrentHashMap<>();
+        this.modelTtl = modelTtl;
+        this.checkpointWriteQueue = checkpointWriteQueue;
+    }
+
+    private ActionListener<Optional<AnomalyDetector>> onGetDetector(
+        String modelId,
+        Entity entity,
+        String detectorId,
+        ModelState<EntityModel> modelState,
+        ActionListener<Void> listener
+    ) {
+        return ActionListener.wrap(detectorOptional -> {
+            boolean earlyExit = true;
+            try {
+                if (false == detectorOptional.isPresent()) {
+                    logger.warn(new ParameterizedMessage("AnomalyDetector [{}] is not available.", detectorId));
+                    return;
+                }
+
+                AnomalyDetector detector = detectorOptional.get();
+
+                DoorKeeper doorKeeper = doorKeepers
+                    .computeIfAbsent(
+                        detectorId,
+                        id -> {
+                            // reset every 60 intervals
+                            return new DoorKeeper(
+                                AnomalyDetectorSettings.DOOR_KEEPER_FOR_COLD_STARTER_MAX_INSERTION,
+                                AnomalyDetectorSettings.DOOR_KEEPER_FAULSE_POSITIVE_RATE,
+                                detector.getDetectionIntervalDuration().multipliedBy(AnomalyDetectorSettings.DOOR_KEEPER_MAINTENANCE_FREQ),
+                                clock
+                            );
+                        }
+                    );
+
+                // Won't retry cold start within 60 intervals for an entity
+                if (doorKeeper.mightContain(modelId)) {
+                    return;
+                }
+
+                doorKeeper.put(modelId);
+
+                ActionListener<Optional<List<double[][]>>> coldStartCallBack = ActionListener.wrap(trainingData -> {
+                    try {
+                        if (trainingData.isPresent()) {
+                            List<double[][]> dataPoints = trainingData.get();
+                            // only train models if we have enough samples
+                            if (hasEnoughSample(dataPoints, modelState) == false) {
+                                combineTrainSamples(dataPoints, modelId, modelState);
+                            } else {
+                                trainModelFromDataSegments(dataPoints, entity, modelState);
+                            }
+                            logger.info("Succeeded in training entity: {}", modelId);
+                        } else {
+                            logger.info("Cannot get training data for {}", modelId);
+                        }
+                    } finally {
+                        listener.onResponse(null);
+                    }
+
+                }, exception -> {
+                    try {
+                        logger.error(new ParameterizedMessage("Error while cold start {}", modelId), exception);
+                        Throwable cause = Throwables.getRootCause(exception);
+                        if (cause instanceof RejectedExecutionException) {
+                            logger.error("too many requests");
+                            lastThrottledColdStartTime = Instant.now();
+                        } else if (cause instanceof AnomalyDetectionException || exception instanceof AnomalyDetectionException) {
+                            // e.g., cannot find anomaly detector
+                            nodeStateManager.setException(detectorId, exception);
+                        } else {
+                            nodeStateManager.setException(detectorId, new AnomalyDetectionException(detectorId, cause));
+                        }
+                    } finally {
+                        listener.onFailure(exception);
+                    }
+                });
+
+                threadPool
+                    .executor(AnomalyDetectorPlugin.AD_THREAD_POOL_NAME)
+                    .execute(
+                        () -> getEntityColdStartData(
+                            detectorId,
+                            entity,
+                            shingleSize,
+                            new ThreadedActionListener<>(
+                                logger,
+                                threadPool,
+                                AnomalyDetectorPlugin.AD_THREAD_POOL_NAME,
+                                coldStartCallBack,
+                                false
+                            )
+                        )
+                    );
+                earlyExit = false;
+            } finally {
+                if (earlyExit) {
+                    listener.onResponse(null);
+                }
+            }
+
+        }, exception -> {
+            logger.error(new ParameterizedMessage("fail to get detector [{}]", detectorId), exception);
+            listener.onFailure(exception);
+        });
     }
 
     /**
      * Training model for an entity
      * @param modelId model Id corresponding to the entity
-     * @param entityName the entity's name
+     * @param entity the entity's information
      * @param detectorId the detector Id corresponding to the entity
      * @param modelState model state associated with the entity
+     * @param listener call back to call after cold start
      */
-    private void coldStart(String modelId, String entityName, String detectorId, ModelState<EntityModel> modelState) {
-        // Rate limiting: if last cold start of the detector is not finished, we don't trigger another one.
-        if (nodeStateManager.isColdStartRunning(detectorId)) {
+    private void coldStart(
+        String modelId,
+        Entity entity,
+        String detectorId,
+        ModelState<EntityModel> modelState,
+        ActionListener<Void> listener
+    ) {
+        logger.debug("Trigger cold start for {}", modelId);
+
+        if (lastThrottledColdStartTime.plus(Duration.ofMinutes(coolDownMinutes)).isAfter(clock.instant())) {
+            listener.onResponse(null);
             return;
         }
 
-        // Won't retry cold start within one hour for an entity; if threadpool queue is full, won't retry within 5 minutes
-        // 5 minutes is derived by 1000 (threadpool queue size) / 4 (1 cold start per 4 seconds according to the Http logs
-        // experiment) = 250 seconds.
-        if (lastColdStartTime.getIfPresent(modelId) == null
-            && lastThrottledColdStartTime.plus(Duration.ofMinutes(coolDownMinutes)).isBefore(clock.instant())) {
-
-            final Releasable coldStartFinishingCallback = nodeStateManager.markColdStartRunning(detectorId);
-
-            logger.debug("Trigger cold start for {}", modelId);
-
-            ActionListener<Optional<List<double[][]>>> nestedListener = ActionListener.wrap(trainingData -> {
-                if (trainingData.isPresent()) {
-                    List<double[][]> dataPoints = trainingData.get();
-                    // only train models if we have enough samples
-                    if (hasEnoughSample(dataPoints, modelState) == false) {
-                        combineTrainSamples(dataPoints, modelId, modelState);
-                    } else {
-                        trainModelFromDataSegments(dataPoints, modelId, modelState);
-                    }
-                    logger.info("Succeeded in training entity: {}", modelId);
-                } else {
-                    logger.info("Cannot get training data for {}", modelId);
-                }
-            }, exception -> {
-                Throwable cause = Throwables.getRootCause(exception);
-                if (cause instanceof RejectedExecutionException) {
-                    logger.error("too many requests");
-                    lastThrottledColdStartTime = Instant.now();
-                } else if (cause instanceof AnomalyDetectionException || exception instanceof AnomalyDetectionException) {
-                    // e.g., cannot find anomaly detector
-                    nodeStateManager.setLastColdStartException(detectorId, (AnomalyDetectionException) exception);
-                } else {
-                    logger.error(new ParameterizedMessage("Error while cold start {}", modelId), exception);
-                }
-            });
-
-            final ActionListener<Optional<List<double[][]>>> listenerWithReleaseCallback = ActionListener
-                .runAfter(nestedListener, coldStartFinishingCallback::close);
-
-            threadPool
-                .executor(AnomalyDetectorPlugin.AD_THREAD_POOL_NAME)
-                .execute(
-                    () -> getEntityColdStartData(
-                        detectorId,
-                        entityName,
-                        shingleSize,
-                        new ThreadedActionListener<>(
-                            logger,
-                            threadPool,
-                            AnomalyDetectorPlugin.AD_THREAD_POOL_NAME,
-                            listenerWithReleaseCallback,
-                            false
-                        )
-                    )
-                );
-
-            lastColdStartTime.put(modelId, Instant.now());
-        }
+        nodeStateManager.getAnomalyDetector(detectorId, onGetDetector(modelId, entity, detectorId, modelState, listener));
     }
 
     /**
      * Train model using given data points.
      *
      * @param dataPoints List of continuous data points, in ascending order of timestamps
-     * @param modelId The model Id
+     * @param entity Entity instance
      * @param entityState Entity state associated with the model Id
      */
-    private void trainModelFromDataSegments(List<double[][]> dataPoints, String modelId, ModelState<EntityModel> entityState) {
+    private void trainModelFromDataSegments(List<double[][]> dataPoints, Entity entity, ModelState<EntityModel> entityState) {
         if (dataPoints == null || dataPoints.size() == 0 || dataPoints.get(0) == null || dataPoints.get(0).length == 0) {
             throw new IllegalArgumentException("Data points must not be empty.");
         }
@@ -281,14 +338,14 @@ public class EntityColdStarter {
         int totalLength = 0;
         // get continuous data points and send for training
         for (double[][] continuousDataPoints : dataPoints) {
-            double[] scores = trainRCFModel(continuousDataPoints, modelId, rcf);
+            double[] scores = trainRCFModel(continuousDataPoints, rcf);
             allScores.add(scores);
             totalLength += scores.length;
         }
 
         EntityModel model = entityState.getModel();
         if (model == null) {
-            model = new EntityModel(modelId, new ArrayDeque<>(), null, null);
+            model = new EntityModel(entity, new ArrayDeque<>(), null, null);
         }
         model.setRcf(rcf);
         double[] joinedScores = new double[totalLength];
@@ -314,17 +371,16 @@ public class EntityColdStarter {
         entityState.setLastUsedTime(clock.instant());
 
         // save to checkpoint
-        checkpointDao.write(entityState, modelId, true);
+        checkpointWriteQueue.write(entityState, true, SegmentPriority.MEDIUM);
     }
 
     /**
      * Train the RCF model using given data points
      * @param dataPoints Data points
-     * @param modelId The model Id
      * @param rcf RCF model to be trained
      * @return scores returned by RCF models
      */
-    private double[] trainRCFModel(double[][] dataPoints, String modelId, RandomCutForest rcf) {
+    private double[] trainRCFModel(double[][] dataPoints, RandomCutForest rcf) {
         if (dataPoints.length == 0 || dataPoints[0].length == 0) {
             throw new IllegalArgumentException("Data points must not be empty.");
         }
@@ -349,20 +405,19 @@ public class EntityColdStarter {
      * points to shingles. Finally, full shingles will be used for cold start.
      *
      * @param detectorId detector Id
-     * @param entityName entity's name
+     * @param entity the entity's information
      * @param entityShingleSize model's shingle size
      * @param listener listener to return training data
      */
     private void getEntityColdStartData(
         String detectorId,
-        String entityName,
+        Entity entity,
         int entityShingleSize,
         ActionListener<Optional<List<double[][]>>> listener
     ) {
         ActionListener<Optional<AnomalyDetector>> getDetectorListener = ActionListener.wrap(detectorOp -> {
             if (!detectorOp.isPresent()) {
-                nodeStateManager
-                    .setLastColdStartException(detectorId, new EndRunException(detectorId, "AnomalyDetector is not available.", true));
+                nodeStateManager.setException(detectorId, new EndRunException(detectorId, "AnomalyDetector is not available.", true));
                 return;
             }
             List<double[][]> coldStartData = new ArrayList<>();
@@ -427,7 +482,7 @@ public class EntityColdStarter {
                         .getColdStartSamplesForPeriods(
                             detector,
                             sampleRanges,
-                            entityName,
+                            entity,
                             false,
                             new ThreadedActionListener<>(
                                 logger,
@@ -447,7 +502,7 @@ public class EntityColdStarter {
             searchFeatureDao
                 .getEntityMinMaxDataTime(
                     detector,
-                    entityName,
+                    entity,
                     new ThreadedActionListener<>(logger, threadPool, AnomalyDetectorPlugin.AD_THREAD_POOL_NAME, minMaxTimeListener, false)
                 );
 
@@ -491,25 +546,40 @@ public class EntityColdStarter {
 
     /**
      * Train models for the given entity
-     * @param samples Recent sample history
-     * @param modelId Model Id
-     * @param entityName The entity's name
+     * @param entity The entity info
      * @param detectorId Detector Id
      * @param modelState Model state associated with the entity
+     * @param listener callback before the method returns whenever EntityColdStarter
+     * finishes training or encounters exceptions.  The listener helps notify the
+     * cold start queue to pull another request (if any) to execute.
      */
-    public void trainModel(
-        Queue<double[]> samples,
-        String modelId,
-        String entityName,
-        String detectorId,
-        ModelState<EntityModel> modelState
-    ) {
+    public void trainModel(Entity entity, String detectorId, ModelState<EntityModel> modelState, ActionListener<Void> listener) {
+        Queue<double[]> samples = modelState.getModel().getSamples();
+        String modelId = modelState.getModelId();
+
         if (samples.size() < this.numMinSamples) {
             // we cannot get last RCF score since cold start happens asynchronously
-            coldStart(modelId, entityName, detectorId, modelState);
+            coldStart(modelId, entity, detectorId, modelState, listener);
         } else {
+            try {
+                double[][] trainData = featureManager.batchShingle(samples.toArray(new double[0][0]), this.shingleSize);
+                trainModelFromDataSegments(Collections.singletonList(trainData), entity, modelState);
+            } finally {
+                listener.onResponse(null);
+            }
+        }
+    }
+
+    public void trainModelFromExistingSamples(ModelState<EntityModel> modelState) {
+        if (modelState == null || modelState.getModel() == null || modelState.getModel().getSamples() == null) {
+            return;
+        }
+
+        EntityModel model = modelState.getModel();
+        Queue<double[]> samples = model.getSamples();
+        if (samples.size() >= this.numMinSamples) {
             double[][] trainData = featureManager.batchShingle(samples.toArray(new double[0][0]), this.shingleSize);
-            trainModelFromDataSegments(Collections.singletonList(trainData), modelId, modelState);
+            trainModelFromDataSegments(Collections.singletonList(trainData), model.getEntity().orElse(null), modelState);
         }
     }
 
@@ -548,7 +618,7 @@ public class EntityColdStarter {
     private void combineTrainSamples(List<double[][]> coldstartDatapoints, String modelId, ModelState<EntityModel> entityState) {
         EntityModel model = entityState.getModel();
         if (model == null) {
-            model = new EntityModel(modelId, new ArrayDeque<>(), null, null);
+            model = new EntityModel(null, new ArrayDeque<>(), null, null);
         }
         for (double[][] consecutivePoints : coldstartDatapoints) {
             for (int i = 0; i < consecutivePoints.length; i++) {
@@ -556,6 +626,19 @@ public class EntityColdStarter {
             }
         }
         // save to checkpoint
-        checkpointDao.write(entityState, modelId, true);
+        checkpointWriteQueue.write(entityState, true, SegmentPriority.MEDIUM);
+    }
+
+    @Override
+    public void maintenance() {
+        doorKeepers.entrySet().stream().forEach(doorKeeperEntry -> {
+            String detectorId = doorKeeperEntry.getKey();
+            DoorKeeper doorKeeper = doorKeeperEntry.getValue();
+            if (doorKeeper.expired(modelTtl)) {
+                doorKeepers.remove(detectorId);
+            } else {
+                doorKeeper.maintenance();
+            }
+        });
     }
 }

--- a/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartQueue.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartQueue.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.COLD_ENTITY_QUEUE_CONCURRENCY;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.ml.EntityColdStarter;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelManager.ModelType;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.ad.util.ClientUtil;
+import org.opensearch.ad.util.ExceptionUtil;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * A queue for HCAD model training (a.k.a. cold start). As model training is a
+ * pretty expensive operation, we pull cold start requests from the queue in a
+ * serial fashion. Each detector has an equal chance of being pulled. The equal
+ * probability is achieved by putting model training requests for different
+ * detectors into different segments and pulling requests from segments in a
+ * round-robin fashion.
+ *
+ */
+public class EntityColdStartQueue extends SingleRequestQueue<EntityRequest> {
+    private static final Logger LOG = LogManager.getLogger(EntityColdStartQueue.class);
+
+    private final EntityColdStarter entityColdStarter;
+
+    public EntityColdStartQueue(
+        long heapSizeInBytes,
+        int singleRequestSizeInBytes,
+        Setting<Float> maxHeapPercentForQueueSetting,
+        ClusterService clusterService,
+        Random random,
+        ADCircuitBreakerService adCircuitBreakerService,
+        ThreadPool threadPool,
+        Settings settings,
+        float maxQueuedTaskRatio,
+        Clock clock,
+        float mediumSegmentPruneRatio,
+        float lowSegmentPruneRatio,
+        int maintenanceFreqConstant,
+        ClientUtil clientUtil,
+        Duration executionTtl,
+        EntityColdStarter entityColdStarter,
+        Duration stateTtl,
+        NodeStateManager nodeStateManager
+    ) {
+        super(
+            "cold-start",
+            heapSizeInBytes,
+            singleRequestSizeInBytes,
+            maxHeapPercentForQueueSetting,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            maxQueuedTaskRatio,
+            clock,
+            mediumSegmentPruneRatio,
+            lowSegmentPruneRatio,
+            maintenanceFreqConstant,
+            clientUtil,
+            COLD_ENTITY_QUEUE_CONCURRENCY,
+            executionTtl,
+            stateTtl,
+            nodeStateManager
+        );
+        this.entityColdStarter = entityColdStarter;
+    }
+
+    @Override
+    protected void executeRequest(EntityRequest coldStartRequest, ActionListener<Void> listener) {
+        String detectorId = coldStartRequest.getDetectorId();
+
+        Optional<String> modelId = coldStartRequest.getModelId();
+
+        if (false == modelId.isPresent()) {
+            String error = String.format(Locale.ROOT, "Fail to get model id for request %s", coldStartRequest);
+            LOG.warn(error);
+            listener.onFailure(new RuntimeException(error));
+            return;
+        }
+
+        ModelState<EntityModel> modelState = new ModelState<>(
+            new EntityModel(coldStartRequest.getEntity(), new ArrayDeque<>(), null, null),
+            modelId.get(),
+            detectorId,
+            ModelType.ENTITY.getName(),
+            clock,
+            0
+        );
+
+        ActionListener<Void> failureListener = ActionListener.delegateResponse(listener, (delegateListener, e) -> {
+            if (ExceptionUtil.isOverloaded(e)) {
+                LOG.error("ES is overloaded");
+                setCoolDownStart();
+            }
+            nodeStateManager.setException(detectorId, e);
+            delegateListener.onFailure(e);
+        });
+
+        entityColdStarter.trainModel(coldStartRequest.getEntity(), detectorId, modelState, failureListener);
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartWorker.java
@@ -45,12 +45,12 @@ import org.opensearch.threadpool.ThreadPool;
  * round-robin fashion.
  *
  */
-public class EntityColdStartQueue extends SingleRequestQueue<EntityRequest> {
-    private static final Logger LOG = LogManager.getLogger(EntityColdStartQueue.class);
+public class EntityColdStartWorker extends SingleRequestWorker<EntityRequest> {
+    private static final Logger LOG = LogManager.getLogger(EntityColdStartWorker.class);
 
     private final EntityColdStarter entityColdStarter;
 
-    public EntityColdStartQueue(
+    public EntityColdStartWorker(
         long heapSizeInBytes,
         int singleRequestSizeInBytes,
         Setting<Float> maxHeapPercentForQueueSetting,
@@ -118,7 +118,7 @@ public class EntityColdStartQueue extends SingleRequestQueue<EntityRequest> {
 
         ActionListener<Void> failureListener = ActionListener.delegateResponse(listener, (delegateListener, e) -> {
             if (ExceptionUtil.isOverloaded(e)) {
-                LOG.error("ES is overloaded");
+                LOG.error("OpenSearch is overloaded");
                 setCoolDownStart();
             }
             nodeStateManager.setException(detectorId, e);

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -66,7 +66,7 @@ import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
-import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
+import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.client.Client;
@@ -98,7 +98,7 @@ public class EntityColdStarterTests extends AbstractADTest {
     Runnable releaseSemaphore;
     ActionListener<Void> listener;
     CountDownLatch inProgressLatch;
-    CheckpointWriteQueue checkpointWriteQueue;
+    CheckpointWriteWorker checkpointWriteQueue;
     Entity entity;
 
     @SuppressWarnings("unchecked")
@@ -164,7 +164,7 @@ public class EntityColdStarterTests extends AbstractADTest {
             AnomalyDetectorPlugin.AD_THREAD_POOL_NAME
         );
 
-        checkpointWriteQueue = mock(CheckpointWriteQueue.class);
+        checkpointWriteQueue = mock(CheckpointWriteWorker.class);
 
         entityColdStarter = new EntityColdStarter(
             clock,

--- a/src/test/java/org/opensearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/CronTransportActionTests.java
@@ -44,6 +44,7 @@ import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.feature.FeatureManager;
+import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -83,6 +84,7 @@ public class CronTransportActionTests extends AbstractADTest {
         FeatureManager featureManager = mock(FeatureManager.class);
         CacheProvider cacheProvider = mock(CacheProvider.class);
         EntityCache entityCache = mock(EntityCache.class);
+        EntityColdStarter entityColdStarter = mock(EntityColdStarter.class);
         when(cacheProvider.get()).thenReturn(entityCache);
 
         action = new CronTransportAction(
@@ -93,7 +95,8 @@ public class CronTransportActionTests extends AbstractADTest {
             tarnsportStatemanager,
             modelManager,
             featureManager,
-            cacheProvider
+            cacheProvider,
+            entityColdStarter
         );
     }
 


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved. Now the code is missing unit tests. Posting PRs now to meet the cutoff date (June 1). Will add unit tests, run performance tests, and fix bugs before the official release.

### Description
This PR adds a queue for HCAD model training (a.k.a. cold start). As model training is a pretty expensive operation, we pull cold start requests from the queue in a serial fashion. Each detector has an equal chance of being pulled. The equal probability is achieved by putting model training requests for different detectors into different segments and pulling requests from segments in a round-robin fashion.

To accommodate the model training queue, we need to add a listener as an input to EntityColdStarter's trainModel method, the utility class for model training. The listener needs to be invoked whenever EntityColdStarter finishes training or encounters exceptions. The listener helps notify the cold start queue to pull another request (if any) to execute.

Some of the rate-limiting logic in EntityColdStarter is removed as we have a cold start queue now.

We have also changed to use DoorKeeper to limit the cold start an entity can trigger in a certain period.  DoorKeeper is a bloom filter that is used elsewhere in the package. Reusing the logic reduces the amount of code we have to maintain. The DoorKeeper needs to be constantly maintained. Thus, I let EntityColdStarter implement MaintenanceState and make CronTransportAction clean DoorKeeper regularly.

Testing done:
1. Manual tests using 10 HCAD detectors and 12,000 entities in a 3 node cluster.
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
