### PR TITLE
Add queues for checkpoint and result write

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
@@ -26,24 +26,20 @@
 
 package org.opensearch.ad.ml;
 
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,11 +47,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
-import org.opensearch.action.DocWriteRequest;
-import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkItemResponse;
-import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
@@ -66,7 +58,7 @@ import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.indices.ADIndex;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
-import org.opensearch.ad.util.BulkUtil;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.client.Client;
 import org.opensearch.index.IndexNotFoundException;
@@ -78,7 +70,6 @@ import org.opensearch.index.reindex.ScrollableHitSource;
 
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
-import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -116,15 +107,12 @@ public class CheckpointDao {
     private Gson gson;
     private RandomCutForestSerDe rcfSerde;
 
-    private ConcurrentLinkedQueue<DocWriteRequest<?>> requests;
-    private final ReentrantLock lock;
     private final Class<? extends ThresholdingModel> thresholdingModelClass;
-    private final Duration checkpointInterval;
-    private final Clock clock;
+
     private final AnomalyDetectionIndices indexUtil;
-    private final RateLimiter bulkRateLimiter;
-    private final int maxBulkRequestSize;
     private final JsonParser parser = new JsonParser();
+    // we won't read/write a checkpoint larger than a threshold
+    private final int maxCheckpointBytes;
 
     /**
      * Constructor with dependencies and configuration.
@@ -135,11 +123,8 @@ public class CheckpointDao {
      * @param gson accessor to Gson functionality
      * @param rcfSerde accessor to rcf serialization/deserialization
      * @param thresholdingModelClass thresholding model's class
-     * @param clock a UTC clock
-     * @param checkpointInterval how often we should save a checkpoint
      * @param indexUtil Index utility methods
-     * @param maxBulkRequestSize max number of index request a bulk can contain
-     * @param bulkPerSecond bulk requests per second
+     * @param maxCheckpointBytes max checkpoint size in bytes
      */
     public CheckpointDao(
         Client client,
@@ -148,28 +133,17 @@ public class CheckpointDao {
         Gson gson,
         RandomCutForestSerDe rcfSerde,
         Class<? extends ThresholdingModel> thresholdingModelClass,
-        Clock clock,
-        Duration checkpointInterval,
         AnomalyDetectionIndices indexUtil,
-        int maxBulkRequestSize,
-        double bulkPerSecond
+        int maxCheckpointBytes
     ) {
         this.client = client;
         this.clientUtil = clientUtil;
         this.indexName = indexName;
         this.gson = gson;
         this.rcfSerde = rcfSerde;
-        this.requests = new ConcurrentLinkedQueue<>();
-        this.lock = new ReentrantLock();
         this.thresholdingModelClass = thresholdingModelClass;
-        this.clock = clock;
-        this.checkpointInterval = checkpointInterval;
         this.indexUtil = indexUtil;
-        // each checkpoint with model initialized is roughly 250 KB if we are using shingle size 1 with 1 feature
-        // 1k limit will send 250 KB * 1000 = 250 MB
-        this.maxBulkRequestSize = maxBulkRequestSize;
-        // 1 bulk request per 1/bulkPerSecond seconds.
-        this.bulkRateLimiter = RateLimiter.create(bulkPerSecond);
+        this.maxCheckpointBytes = maxCheckpointBytes;
     }
 
     /**
@@ -250,122 +224,37 @@ public class CheckpointDao {
     }
 
     /**
-     * Bulk writing model states prepared previously
+     * Prepare for index request using the contents of the given model state
+     * @param modelState an entity model state
+     * @return serialized JSON map or empty map if the state is too bloated
+     * @throws IOException  when serialization fails
      */
-    public void flush() {
-        try {
-            // in case that other threads are doing bulk as well.
-            if (!lock.tryLock()) {
-                return;
-            }
-            if (requests.size() > 0 && bulkRateLimiter.tryAcquire()) {
-                final BulkRequest bulkRequest = new BulkRequest();
-                // at most 1000 index requests per bulk
-                for (int i = 0; i < maxBulkRequestSize; i++) {
-                    DocWriteRequest<?> req = requests.poll();
-                    if (req == null) {
-                        break;
-                    }
-
-                    bulkRequest.add(req);
-                }
-                if (indexUtil.doesCheckpointIndexExist()) {
-                    flush(bulkRequest);
-                } else {
-                    indexUtil.initCheckpointIndex(ActionListener.wrap(initResponse -> {
-                        if (initResponse.isAcknowledged()) {
-                            flush(bulkRequest);
-                        } else {
-                            throw new RuntimeException("Creating checkpoint with mappings call not acknowledged.");
-                        }
-                    }, exception -> {
-                        if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {
-                            // It is possible the index has been created while we sending the create request
-                            flush(bulkRequest);
-                        } else {
-                            logger.error(String.format(Locale.ROOT, "Unexpected error creating index %s", indexName), exception);
-                        }
-                    }));
-                }
-            }
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+    public Map<String, Object> toIndexSource(ModelState<EntityModel> modelState) throws IOException {
+        Map<String, Object> source = new HashMap<>();
+        EntityModel model = modelState.getModel();
+        String serializedModel = toCheckpoint(model);
+        if (serializedModel == null || serializedModel.length() > maxCheckpointBytes) {
+            logger
+                .warn(
+                    new ParameterizedMessage(
+                        "[{}]'s model empty or too large: [{}] bytes",
+                        modelState.getModelId(),
+                        serializedModel == null ? 0 : serializedModel.length()
+                    )
+                );
+            return source;
         }
-    }
-
-    private void flush(BulkRequest bulkRequest) {
-        clientUtil.<BulkRequest, BulkResponse>execute(BulkAction.INSTANCE, bulkRequest, ActionListener.wrap(r -> {
-            if (r.hasFailures()) {
-                requests.addAll(BulkUtil.getIndexRequestToRetry(bulkRequest, r));
-            } else if (requests.size() >= maxBulkRequestSize / 2) {
-                // during maintenance, we may have much more waiting in the queue.
-                // trigger another flush if that's the case.
-                flush();
-            }
-        }, e -> {
-            logger.error("Failed bulking checkpoints", e);
-            // retry during next bulk.
-            for (DocWriteRequest<?> req : bulkRequest.requests()) {
-                requests.add(req);
-            }
-        }));
-    }
-
-    /**
-     * Prepare bulking the input model state to the checkpoint index.
-     * We don't save checkpoints within checkpointInterval again.
-     * @param modelState Model state
-     * @param modelId Model Id
-     */
-    public void write(ModelState<EntityModel> modelState, String modelId) {
-        write(modelState, modelId, false);
-    }
-
-    /**
-     * Prepare bulking the input model state to the checkpoint index.
-     * We don't save checkpoints within checkpointInterval again, except this
-     * is from cold start. This method will update the input state's last
-     *  checkpoint time if the checkpoint is staged (ready to be written in the
-     *  next batch).
-     * @param modelState Model state
-     * @param modelId Model Id
-     * @param coldStart whether the checkpoint comes from cold start
-     */
-    public void write(ModelState<EntityModel> modelState, String modelId, boolean coldStart) {
-        Instant instant = modelState.getLastCheckpointTime();
-        // Instant.MIN is the default value. We don't save until we are sure.
-        if ((instant == Instant.MIN || instant.plus(checkpointInterval).isAfter(clock.instant())) && !coldStart) {
-            return;
+        String detectorId = modelState.getDetectorId();
+        source.put(DETECTOR_ID, detectorId);
+        source.put(FIELD_MODEL, serializedModel);
+        source.put(TIMESTAMP, ZonedDateTime.now(ZoneOffset.UTC));
+        source.put(CommonName.SCHEMA_VERSION_FIELD, indexUtil.getSchemaVersion(ADIndex.CHECKPOINT));
+        Optional<Entity> entity = model.getEntity();
+        if (entity.isPresent()) {
+            source.put(CommonName.ENTITY_KEY, entity.get());
         }
-        // It is possible 2 states of the same model id gets saved: one overwrite another.
-        // This can happen if previous checkpoint hasn't been saved to disk, while the
-        // 1st one creates a new state without restoring.
-        if (modelState.getModel() != null) {
-            try {
-                // we can have ConcurrentModificationException when calling toCheckpoint
-                // and updating rcf model at the same time. To prevent this,
-                // we need to have a deep copy of models or have a lock. Both
-                // options are costly.
-                // As we are gonna retry serializing either when the entity is
-                // evicted out of cache or during the next maintenance period,
-                // don't do anything when the exception happens.
-                String serializedModel = toCheckpoint(modelState.getModel());
-                Map<String, Object> source = new HashMap<>();
-                source.put(DETECTOR_ID, modelState.getDetectorId());
-                source.put(FIELD_MODEL, serializedModel);
-                source.put(TIMESTAMP, ZonedDateTime.now(ZoneOffset.UTC));
-                source.put(CommonName.SCHEMA_VERSION_FIELD, indexUtil.getSchemaVersion(ADIndex.CHECKPOINT));
-                requests.add(new IndexRequest(indexName).id(modelId).source(source));
-                modelState.setLastCheckpointTime(clock.instant());
-                if (requests.size() >= maxBulkRequestSize) {
-                    flush();
-                }
-            } catch (ConcurrentModificationException e) {
-                logger.info(new ParameterizedMessage("Concurrent modification while serializing models for [{}]", modelId), e);
-            }
-        }
+
+        return source;
     }
 
     /**
@@ -385,8 +274,12 @@ public class CheckpointDao {
             .map(source -> (String) source.get(FIELD_MODEL));
     }
 
-    String toCheckpoint(EntityModel model) {
+    public String toCheckpoint(EntityModel model) {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> {
+            if (model == null) {
+                logger.warn("Empty model");
+                return null;
+            }
             JsonObject json = new JsonObject();
             json.add(ENTITY_SAMPLE, gson.toJsonTree(model.getSamples()));
             if (model.getRcf() != null) {
@@ -475,28 +368,52 @@ public class CheckpointDao {
         }
     }
 
-    private Entry<EntityModel, Instant> fromEntityModelCheckpoint(Map<String, Object> checkpoint, String modelId) {
+    /**
+     * Load json checkpoint into models
+     *
+     * @param checkpoint json checkpoint contents
+     * @param modelId Model Id
+     * @return a pair of entity model and its last checkpoint time; or empty if
+     *  the raw checkpoint is too large
+     */
+    public Optional<Entry<EntityModel, Instant>> fromEntityModelCheckpoint(Map<String, Object> checkpoint, String modelId) {
         try {
-            return AccessController.doPrivileged((PrivilegedAction<Entry<EntityModel, Instant>>) () -> {
+            return AccessController.doPrivileged((PrivilegedAction<Optional<Entry<EntityModel, Instant>>>) () -> {
                 String model = (String) (checkpoint.get(FIELD_MODEL));
+                if (model.length() > maxCheckpointBytes) {
+                    logger.warn(new ParameterizedMessage("[{}]'s model too large: [{}] bytes", modelId, model.length()));
+                    return Optional.empty();
+                }
                 JsonObject json = parser.parse(model).getAsJsonObject();
+                // verified, don't need privileged call to get permission
                 ArrayDeque<double[]> samples = new ArrayDeque<>(
                     Arrays.asList(this.gson.fromJson(json.getAsJsonArray(ENTITY_SAMPLE), new double[0][0].getClass()))
                 );
                 RandomCutForest rcf = null;
                 if (json.has(ENTITY_RCF)) {
+                    // verified, don't need privileged call to get permission
                     rcf = rcfSerde.fromJson(json.getAsJsonPrimitive(ENTITY_RCF).getAsString());
                 }
                 ThresholdingModel threshold = null;
                 if (json.has(ENTITY_THRESHOLD)) {
+                    // verified, don't need privileged call to get permission
                     threshold = this.gson.fromJson(json.getAsJsonPrimitive(ENTITY_THRESHOLD).getAsString(), thresholdingModelClass);
                 }
 
                 String lastCheckpointTimeString = (String) (checkpoint.get(TIMESTAMP));
                 Instant timestamp = Instant.parse(lastCheckpointTimeString);
-                return new SimpleImmutableEntry<>(new EntityModel(modelId, samples, rcf, threshold), timestamp);
+                Entity entity = null;
+                Object serializedEntity = checkpoint.get(CommonName.ENTITY_KEY);
+                if (serializedEntity != null) {
+                    try {
+                        entity = Entity.fromJsonArray(serializedEntity);
+                    } catch (Exception e) {
+                        logger.error(new ParameterizedMessage("fail to parse entity", serializedEntity), e);
+                    }
+                }
+                return Optional.of(new SimpleImmutableEntry<>(new EntityModel(entity, samples, rcf, threshold), timestamp));
             });
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             logger.warn("Exception while deserializing checkpoint", e);
             throw e;
         }
@@ -511,7 +428,7 @@ public class CheckpointDao {
         clientUtil.<GetRequest, GetResponse>asyncRequest(new GetRequest(indexName, modelId), client::get, ActionListener.wrap(response -> {
             Optional<Map<String, Object>> checkpointString = processRawCheckpoint(response);
             if (checkpointString.isPresent()) {
-                listener.onResponse(Optional.of(fromEntityModelCheckpoint(checkpointString.get(), modelId)));
+                listener.onResponse(fromEntityModelCheckpoint(checkpointString.get(), modelId));
             } else {
                 listener.onResponse(Optional.empty());
             }
@@ -541,7 +458,7 @@ public class CheckpointDao {
             .map(source -> (String) source.get(FIELD_MODEL));
     }
 
-    private Optional<Map<String, Object>> processRawCheckpoint(GetResponse response) {
+    public Optional<Map<String, Object>> processRawCheckpoint(GetResponse response) {
         return Optional.ofNullable(response).filter(GetResponse::isExists).map(GetResponse::getSource);
     }
 }

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteRequest.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteRequest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import org.opensearch.action.index.IndexRequest;
+
+public class CheckpointWriteRequest extends QueuedRequest {
+    private final IndexRequest indexRequest;
+
+    public CheckpointWriteRequest(long expirationEpochMs, String detectorId, RequestPriority priority, IndexRequest indexRequest) {
+        super(expirationEpochMs, detectorId, priority);
+        this.indexRequest = indexRequest;
+    }
+
+    public IndexRequest getIndexRequest() {
+        return indexRequest;
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
@@ -1,0 +1,299 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_CONCURRENCY;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.ResourceAlreadyExistsException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.bulk.BulkAction;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.indices.AnomalyDetectionIndices;
+import org.opensearch.ad.ml.CheckpointDao;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.util.ClientUtil;
+import org.opensearch.ad.util.ExceptionUtil;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+
+public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, BulkRequest, BulkResponse> {
+    private static final Logger LOG = LogManager.getLogger(CheckpointWriteWorker.class);
+
+    private final AnomalyDetectionIndices indexUtil;
+    private final CheckpointDao checkpoint;
+    private final String indexName;
+    private final Duration checkpointInterval;
+
+    public CheckpointWriteWorker(
+        long heapSizeInBytes,
+        int singleRequestSizeInBytes,
+        Setting<Float> maxHeapPercentForQueueSetting,
+        ClusterService clusterService,
+        Random random,
+        ADCircuitBreakerService adCircuitBreakerService,
+        ThreadPool threadPool,
+        Settings settings,
+        float maxQueuedTaskRatio,
+        Clock clock,
+        float mediumSegmentPruneRatio,
+        float lowSegmentPruneRatio,
+        int maintenanceFreqConstant,
+        ClientUtil clientUtil,
+        Duration executionTtl,
+        AnomalyDetectionIndices indexUtil,
+        CheckpointDao checkpoint,
+        String indexName,
+        Duration checkpointInterval,
+        NodeStateManager stateManager,
+        Duration stateTtl
+    ) {
+        super(
+            "checkpoint-write",
+            heapSizeInBytes,
+            singleRequestSizeInBytes,
+            maxHeapPercentForQueueSetting,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            maxQueuedTaskRatio,
+            clock,
+            mediumSegmentPruneRatio,
+            lowSegmentPruneRatio,
+            maintenanceFreqConstant,
+            clientUtil,
+            CHECKPOINT_WRITE_QUEUE_CONCURRENCY,
+            executionTtl,
+            CHECKPOINT_WRITE_QUEUE_BATCH_SIZE,
+            stateTtl,
+            stateManager
+        );
+        this.indexUtil = indexUtil;
+        this.checkpoint = checkpoint;
+        this.indexName = indexName;
+        this.checkpointInterval = checkpointInterval;
+    }
+
+    @Override
+    protected void executeBatchRequest(BulkRequest request, ActionListener<BulkResponse> listener) {
+        if (indexUtil.doesCheckpointIndexExist()) {
+            clientUtil.<BulkRequest, BulkResponse>execute(BulkAction.INSTANCE, request, listener);
+        } else {
+            indexUtil.initCheckpointIndex(ActionListener.wrap(initResponse -> {
+                if (initResponse.isAcknowledged()) {
+                    clientUtil.<BulkRequest, BulkResponse>execute(BulkAction.INSTANCE, request, listener);
+                } else {
+                    throw new RuntimeException("Creating checkpoint with mappings call not acknowledged.");
+                }
+            }, exception -> {
+                if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {
+                    // It is possible the index has been created while we sending the create request
+                    clientUtil.<BulkRequest, BulkResponse>execute(BulkAction.INSTANCE, request, listener);
+                } else {
+                    LOG.error(String.format(Locale.ROOT, "Unexpected error creating checkpoint index"), exception);
+                    listener.onFailure(exception);
+                }
+            }));
+        }
+    }
+
+    @Override
+    protected BulkRequest toBatchRequest(List<CheckpointWriteRequest> toProcess) {
+        final BulkRequest bulkRequest = new BulkRequest();
+        for (CheckpointWriteRequest request : toProcess) {
+            bulkRequest.add(request.getIndexRequest());
+        }
+        return bulkRequest;
+    }
+
+    @Override
+    protected ActionListener<BulkResponse> getResponseListener(List<CheckpointWriteRequest> toProcess, BulkRequest batchRequest) {
+        return ActionListener.wrap(response -> {
+            for (BulkItemResponse r : response.getItems()) {
+                if (r.getFailureMessage() != null) {
+                    // maybe indicating a bug
+                    // don't retry failed requests since checkpoints are too large (250KB+)
+                    // Later maintenance window or cold start will retry saving
+                    LOG.error(r.getFailureMessage());
+                }
+            }
+        }, exception -> {
+            if (ExceptionUtil.isOverloaded(exception)) {
+                LOG.error("too many get AD model checkpoint requests or shard not avialble");
+                setCoolDownStart();
+            }
+
+            for (CheckpointWriteRequest request : toProcess) {
+                nodeStateManager.setException(request.getDetectorId(), exception);
+            }
+
+            // don't retry failed requests since checkpoints are too large (250KB+)
+            // Later maintenance window or cold start will retry saving
+            LOG.error("Fail to save models", exception);
+        });
+    }
+
+    /**
+     * Prepare bulking the input model state to the checkpoint index.
+     * We don't save checkpoints within checkpointInterval again, except this
+     * is a high priority request (e.g., from cold start).
+     * This method will update the input state's last checkpoint time if the
+     *  checkpoint is staged (ready to be written in the next batch).
+     * @param modelState Model state
+     * @param forceWrite whether we should write no matter what
+     * @param priority how urgent the write is
+     */
+    public void write(ModelState<EntityModel> modelState, boolean forceWrite, RequestPriority priority) {
+        Instant instant = modelState.getLastCheckpointTime();
+        if ((instant == Instant.MIN || instant.plus(checkpointInterval).isAfter(clock.instant())) && !forceWrite) {
+            return;
+        }
+
+        if (modelState.getModel() != null) {
+            try {
+                String detectorId = modelState.getDetectorId();
+                String modelId = modelState.getModelId();
+                if (modelId == null || detectorId == null) {
+                    return;
+                }
+
+                nodeStateManager.getAnomalyDetector(detectorId, onGetDetector(detectorId, modelId, modelState, priority));
+            } catch (ConcurrentModificationException e) {
+                LOG.info(new ParameterizedMessage("Concurrent modification while serializing models for [{}]", modelState), e);
+            }
+        }
+    }
+
+    private ActionListener<Optional<AnomalyDetector>> onGetDetector(
+        String detectorId,
+        String modelId,
+        ModelState<EntityModel> modelState,
+        RequestPriority priority
+    ) {
+        return ActionListener.wrap(detectorOptional -> {
+            if (false == detectorOptional.isPresent()) {
+                LOG.warn(new ParameterizedMessage("AnomalyDetector [{}] is not available.", detectorId));
+                return;
+            }
+
+            AnomalyDetector detector = detectorOptional.get();
+            try {
+                Map<String, Object> source = checkpoint.toIndexSource(modelState);
+
+                // the model state is bloated or we have bugs, skip
+                if (source == null || source.isEmpty()) {
+                    return;
+                }
+
+                CheckpointWriteRequest request = new CheckpointWriteRequest(
+                    System.currentTimeMillis() + detector.getDetectorIntervalInMilliseconds(),
+                    detectorId,
+                    priority,
+                    new IndexRequest(indexName).id(modelId).source(source)
+                );
+
+                put(request);
+            } catch (Exception e) {
+                // Example exception:
+                // ConcurrentModificationException when calling toCheckpoint
+                // and updating rcf model at the same time. To prevent this,
+                // we need to have a deep copy of models or have a lock. Both
+                // options are costly.
+                // As we are gonna retry serializing either when the entity is
+                // evicted out of cache or during the next maintenance period,
+                // don't do anything when the exception happens.
+                LOG.info(new ParameterizedMessage("Exception while serializing models for [{}]", modelId), e);
+            }
+
+        }, exception -> { LOG.error(new ParameterizedMessage("fail to get detector [{}]", detectorId), exception); });
+    }
+
+    public void writeAll(List<ModelState<EntityModel>> modelStates, String detectorId, boolean forceWrite, RequestPriority priority) {
+        ActionListener<Optional<AnomalyDetector>> onGetForAll = ActionListener.wrap(detectorOptional -> {
+            if (false == detectorOptional.isPresent()) {
+                LOG.warn(new ParameterizedMessage("AnomalyDetector [{}] is not available.", detectorId));
+                return;
+            }
+
+            AnomalyDetector detector = detectorOptional.get();
+            try {
+                List<CheckpointWriteRequest> allRequests = new ArrayList<>();
+                for (ModelState<EntityModel> state : modelStates) {
+                    Instant instant = state.getLastCheckpointTime();
+                    if ((instant == Instant.MIN || instant.plus(checkpointInterval).isAfter(clock.instant())) && !forceWrite) {
+                        continue;
+                    }
+
+                    Map<String, Object> source = checkpoint.toIndexSource(state);
+                    String modelId = state.getModelId();
+
+                    // the model state is bloated, skip
+                    if (source == null || source.isEmpty() || Strings.isEmpty(modelId)) {
+                        continue;
+                    }
+
+                    allRequests
+                        .add(
+                            new CheckpointWriteRequest(
+                                System.currentTimeMillis() + detector.getDetectorIntervalInMilliseconds(),
+                                detectorId,
+                                priority,
+                                new IndexRequest(indexName).id(modelId).source(source)
+                            )
+                        );
+                }
+
+                putAll(allRequests);
+            } catch (Exception e) {
+                // Example exception:
+                // ConcurrentModificationException when calling toCheckpoint
+                // and updating rcf model at the same time. To prevent this,
+                // we need to have a deep copy of models or have a lock. Both
+                // options are costly.
+                // As we are gonna retry serializing either when the entity is
+                // evicted out of cache or during the next maintenance period,
+                // don't do anything when the exception happens.
+                LOG.info(new ParameterizedMessage("Exception while serializing models for [{}]", detectorId), e);
+            }
+
+        }, exception -> { LOG.error(new ParameterizedMessage("fail to get detector [{}]", detectorId), exception); });
+
+        nodeStateManager.getAnomalyDetector(detectorId, onGetForAll);
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteRequest.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteRequest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import org.opensearch.ad.model.AnomalyResult;
+
+public class ResultWriteRequest extends QueuedRequest {
+    private final AnomalyResult result;
+
+    public ResultWriteRequest(long expirationEpochMs, String detectorId, RequestPriority priority, AnomalyResult result) {
+        super(expirationEpochMs, detectorId, priority);
+        this.result = result;
+    }
+
+    public AnomalyResult getResult() {
+        return result;
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.RESULT_WRITE_QUEUE_BATCH_SIZE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.RESULT_WRITE_QUEUE_CONCURRENCY;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.transport.ADResultBulkRequest;
+import org.opensearch.ad.transport.ADResultBulkResponse;
+import org.opensearch.ad.transport.handler.MultiEntityResultHandler;
+import org.opensearch.ad.util.ClientUtil;
+import org.opensearch.ad.util.ExceptionUtil;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.threadpool.ThreadPool;
+
+public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultBulkRequest, ADResultBulkResponse> {
+    private static final Logger LOG = LogManager.getLogger(ResultWriteWorker.class);
+
+    private final MultiEntityResultHandler resultHandler;
+    private NamedXContentRegistry xContentRegistry;
+
+    public ResultWriteWorker(
+        long heapSizeInBytes,
+        int singleRequestSizeInBytes,
+        Setting<Float> maxHeapPercentForQueueSetting,
+        ClusterService clusterService,
+        Random random,
+        ADCircuitBreakerService adCircuitBreakerService,
+        ThreadPool threadPool,
+        Settings settings,
+        float maxQueuedTaskRatio,
+        Clock clock,
+        float mediumSegmentPruneRatio,
+        float lowSegmentPruneRatio,
+        int maintenanceFreqConstant,
+        ClientUtil clientUtil,
+        Duration executionTtl,
+        MultiEntityResultHandler resultHandler,
+        NamedXContentRegistry xContentRegistry,
+        NodeStateManager stateManager,
+        Duration stateTtl
+    ) {
+        super(
+            "result-write",
+            heapSizeInBytes,
+            singleRequestSizeInBytes,
+            maxHeapPercentForQueueSetting,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            maxQueuedTaskRatio,
+            clock,
+            mediumSegmentPruneRatio,
+            lowSegmentPruneRatio,
+            maintenanceFreqConstant,
+            clientUtil,
+            RESULT_WRITE_QUEUE_CONCURRENCY,
+            executionTtl,
+            RESULT_WRITE_QUEUE_BATCH_SIZE,
+            stateTtl,
+            stateManager
+        );
+        this.resultHandler = resultHandler;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    @Override
+    protected void executeBatchRequest(ADResultBulkRequest request, ActionListener<ADResultBulkResponse> listener) {
+        if (request.numberOfActions() < 1) {
+            listener.onResponse(null);
+            return;
+        }
+        resultHandler.flush(request, listener);
+    }
+
+    @Override
+    protected ADResultBulkRequest toBatchRequest(List<ResultWriteRequest> toProcess) {
+        final ADResultBulkRequest bulkRequest = new ADResultBulkRequest();
+        for (ResultWriteRequest request : toProcess) {
+            bulkRequest.add(request.getResult());
+        }
+        return bulkRequest;
+    }
+
+    @Override
+    protected ActionListener<ADResultBulkResponse> getResponseListener(
+        List<ResultWriteRequest> toProcess,
+        ADResultBulkRequest bulkRequest
+    ) {
+        return ActionListener.wrap(adResultBulkResponse -> {
+            if (adResultBulkResponse == null || false == adResultBulkResponse.getRetryRequests().isPresent()) {
+                // all successful
+                return;
+            }
+
+            enqueueRetryRequestIteration(adResultBulkResponse.getRetryRequests().get(), 0);
+        }, exception -> {
+            if (ExceptionUtil.isOverloaded(exception)) {
+                LOG.error("too many get AD model checkpoint requests or shard not avialble");
+                setCoolDownStart();
+            }
+
+            if (ExceptionUtil.isRetryAble(exception)) {
+                // retry all of them
+                super.putAll(toProcess);
+            } else {
+                for (ResultWriteRequest request : toProcess) {
+                    nodeStateManager.setException(request.getDetectorId(), exception);
+                }
+                LOG.error("Fail to save results", exception);
+            }
+        });
+    }
+
+    private void enqueueRetryRequestIteration(List<IndexRequest> requestToRetry, int index) {
+        if (index >= requestToRetry.size()) {
+            return;
+        }
+        DocWriteRequest<?> currentRequest = requestToRetry.get(index);
+        Optional<AnomalyResult> resultToRetry = getAnomalyResult(currentRequest);
+        if (false == resultToRetry.isPresent()) {
+            enqueueRetryRequestIteration(requestToRetry, index + 1);
+            return;
+        }
+        AnomalyResult result = resultToRetry.get();
+        String detectorId = result.getDetectorId();
+        nodeStateManager.getAnomalyDetector(detectorId, onGetDetector(requestToRetry, index, detectorId, result));
+    }
+
+    private ActionListener<Optional<AnomalyDetector>> onGetDetector(
+        List<IndexRequest> requestToRetry,
+        int index,
+        String detectorId,
+        AnomalyResult resultToRetry
+    ) {
+        return ActionListener.wrap(detectorOptional -> {
+            if (false == detectorOptional.isPresent()) {
+                LOG.warn(new ParameterizedMessage("AnomalyDetector [{}] is not available.", detectorId));
+                enqueueRetryRequestIteration(requestToRetry, index + 1);
+                return;
+            }
+
+            AnomalyDetector detector = detectorOptional.get();
+
+            super.put(
+                new ResultWriteRequest(
+                    // expire based on execute start time
+                    resultToRetry.getExecutionStartTime().toEpochMilli() + detector.getDetectorIntervalInMilliseconds(),
+                    detectorId,
+                    resultToRetry.getAnomalyGrade() > 0 ? RequestPriority.HIGH : RequestPriority.MEDIUM,
+                    resultToRetry
+                )
+            );
+
+            enqueueRetryRequestIteration(requestToRetry, index + 1);
+
+        }, exception -> {
+            LOG.error(new ParameterizedMessage("fail to get detector [{}]", detectorId), exception);
+            enqueueRetryRequestIteration(requestToRetry, index + 1);
+        });
+    }
+
+    private Optional<AnomalyResult> getAnomalyResult(DocWriteRequest<?> request) {
+        try {
+            if (false == (request instanceof IndexRequest)) {
+                LOG.error(new ParameterizedMessage("We should only send IndexRquest, but get [{}].", request));
+                return Optional.empty();
+            }
+            // we send IndexRequest previously
+            IndexRequest indexRequest = (IndexRequest) request;
+            BytesReference indexSource = indexRequest.source();
+            XContentType indexContentType = indexRequest.getContentType();
+            try (
+                XContentParser xContentParser = XContentHelper
+                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, indexSource, indexContentType)
+            ) {
+                // the first character is null. Without skipping it, we get
+                // org.opensearch.common.ParsingException: Failed to parse object: expecting token of type [START_OBJECT] but found
+                // [null]
+                xContentParser.nextToken();
+                return Optional.of(AnomalyResult.parse(xContentParser));
+            }
+        } catch (Exception e) {
+            LOG.error(new ParameterizedMessage("Fail to parse index request [{}]", request), e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
@@ -33,7 +33,6 @@ import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.transport.ADResultBulkRequest;
 import org.opensearch.ad.transport.ADResultBulkResponse;
 import org.opensearch.ad.transport.handler.MultiEntityResultHandler;
-import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.ad.util.ExceptionUtil;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
@@ -66,7 +65,6 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
         float mediumSegmentPruneRatio,
         float lowSegmentPruneRatio,
         int maintenanceFreqConstant,
-        ClientUtil clientUtil,
         Duration executionTtl,
         MultiEntityResultHandler resultHandler,
         NamedXContentRegistry xContentRegistry,
@@ -88,7 +86,6 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
             mediumSegmentPruneRatio,
             lowSegmentPruneRatio,
             maintenanceFreqConstant,
-            clientUtil,
             RESULT_WRITE_QUEUE_CONCURRENCY,
             executionTtl,
             RESULT_WRITE_QUEUE_BATCH_SIZE,

--- a/src/main/java/org/opensearch/ad/transport/ADResultBulkAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADResultBulkAction.java
@@ -27,19 +27,18 @@
 package org.opensearch.ad.transport;
 
 import org.opensearch.action.ActionType;
-import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.transport.TransportRequestOptions;
 
-public class ADResultBulkAction extends ActionType<BulkResponse> {
+public class ADResultBulkAction extends ActionType<ADResultBulkResponse> {
 
     // Internal Action which is not used for public facing RestAPIs.
     public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "write/bulk";
     public static final ADResultBulkAction INSTANCE = new ADResultBulkAction();
 
     private ADResultBulkAction() {
-        super(NAME, BulkResponse::new);
+        super(NAME, ADResultBulkResponse::new);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/ADResultBulkResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/ADResultBulkResponse.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.ad.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+public class ADResultBulkResponse extends ActionResponse {
+    public static final String RETRY_REQUESTS_JSON_KEY = "retry_requests";
+
+    private List<IndexRequest> retryRequests;
+
+    /**
+     *
+     * @param retryRequests a list of requests to retry
+     */
+    public ADResultBulkResponse(List<IndexRequest> retryRequests) {
+        this.retryRequests = retryRequests;
+    }
+
+    public ADResultBulkResponse() {
+        this.retryRequests = null;
+    }
+
+    public ADResultBulkResponse(StreamInput in) throws IOException {
+        int size = in.readInt();
+        if (size > 0) {
+            retryRequests = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                retryRequests.add(new IndexRequest(in));
+            }
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (retryRequests == null || retryRequests.size() == 0) {
+            out.writeInt(0);
+        } else {
+            out.writeInt(retryRequests.size());
+            for (IndexRequest result : retryRequests) {
+                result.writeTo(out);
+            }
+        }
+    }
+
+    public boolean hasFailures() {
+        return retryRequests != null && retryRequests.size() > 0;
+    }
+
+    public Optional<List<IndexRequest>> getRetryRequests() {
+        return Optional.ofNullable(retryRequests);
+    }
+}

--- a/src/main/java/org/opensearch/ad/transport/ADResultBulkTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADResultBulkTransportAction.java
@@ -26,11 +26,13 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.INDEX_PRESSURE_HARD_LIMIT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.INDEX_PRESSURE_SOFT_LIMIT;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.index.IndexingPressure.MAX_INDEXING_BYTES;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 
@@ -45,6 +47,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.util.BulkUtil;
 import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -56,14 +59,16 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
-public class ADResultBulkTransportAction extends HandledTransportAction<ADResultBulkRequest, BulkResponse> {
+public class ADResultBulkTransportAction extends HandledTransportAction<ADResultBulkRequest, ADResultBulkResponse> {
 
     private static final Logger LOG = LogManager.getLogger(ADResultBulkTransportAction.class);
     private IndexingPressure indexingPressure;
     private final long primaryAndCoordinatingLimits;
     private float softLimit;
+    private float hardLimit;
     private String indexName;
     private Client client;
+    private Random random;
 
     @Inject
     public ADResultBulkTransportAction(
@@ -78,53 +83,64 @@ public class ADResultBulkTransportAction extends HandledTransportAction<ADResult
         this.indexingPressure = indexingPressure;
         this.primaryAndCoordinatingLimits = MAX_INDEXING_BYTES.get(settings).getBytes();
         this.softLimit = INDEX_PRESSURE_SOFT_LIMIT.get(settings);
+        this.hardLimit = INDEX_PRESSURE_HARD_LIMIT.get(settings);
         this.indexName = CommonName.ANOMALY_RESULT_INDEX_ALIAS;
         this.client = client;
         clusterService.getClusterSettings().addSettingsUpdateConsumer(INDEX_PRESSURE_SOFT_LIMIT, it -> softLimit = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(INDEX_PRESSURE_HARD_LIMIT, it -> hardLimit = it);
+        // random seed is 42. Can be any number
+        this.random = new Random(42);
     }
 
     @Override
-    protected void doExecute(Task task, ADResultBulkRequest request, ActionListener<BulkResponse> listener) {
+    protected void doExecute(Task task, ADResultBulkRequest request, ActionListener<ADResultBulkResponse> listener) {
         // Concurrent indexing memory limit = 10% of heap
         // indexing pressure = indexing bytes / indexing limit
         // Write all until index pressure (global indexing memory pressure) is less than 80% of 10% of heap. Otherwise, index
         // all non-zero anomaly grade index requests and index zero anomaly grade index requests with probability (1 - index pressure).
         long totalBytes = indexingPressure.getCurrentCombinedCoordinatingAndPrimaryBytes() + indexingPressure.getCurrentReplicaBytes();
         float indexingPressurePercent = (float) totalBytes / primaryAndCoordinatingLimits;
+        List<AnomalyResult> results = request.getAnomalyResults();
+
+        if (results == null || results.size() < 1) {
+            listener.onResponse(new ADResultBulkResponse());
+        }
 
         BulkRequest bulkRequest = new BulkRequest();
 
         if (indexingPressurePercent <= softLimit) {
-            for (AnomalyResult result : request.getAnomalyResults()) {
+            for (AnomalyResult result : results) {
                 addResult(bulkRequest, result);
             }
-        } else if (Float.compare(indexingPressurePercent, 1.0f) < 0) {
-            // exceed soft limit (80%) but smaller than hard limit (100%)
-            // random seed is 42. Can be any number
-            Random random = new Random(42);
+        } else if (indexingPressurePercent <= hardLimit) {
+            // exceed soft limit (60%) but smaller than hard limit (90%)
             float acceptProbability = 1 - indexingPressurePercent;
-            for (AnomalyResult result : request.getAnomalyResults()) {
-                if (result.getAnomalyGrade() > 0 || random.nextFloat() < acceptProbability) {
+            for (AnomalyResult result : results) {
+                if (isHighPriorityRequest(result) || random.nextFloat() < acceptProbability) {
                     addResult(bulkRequest, result);
                 }
             }
         } else {
-            // if exceeding 100% of hard limit, try our luck and only index non-zero grade result
-            for (AnomalyResult result : request.getAnomalyResults()) {
-                if (result.getAnomalyGrade() > 0) {
+            // if exceeding hard limit, only index non-zero grade or error result
+            for (AnomalyResult result : results) {
+                if (isHighPriorityRequest(result)) {
                     addResult(bulkRequest, result);
                 }
             }
         }
 
         if (bulkRequest.numberOfActions() > 0) {
-            client
-                .execute(
-                    BulkAction.INSTANCE,
-                    bulkRequest,
-                    ActionListener.<BulkResponse>wrap(response -> listener.onResponse(response), listener::onFailure)
-                );
+            client.execute(BulkAction.INSTANCE, bulkRequest, ActionListener.<BulkResponse>wrap(bulkResponse -> {
+                List<IndexRequest> failedRequests = BulkUtil.getFailedIndexRequest(bulkRequest, bulkResponse);
+                listener.onResponse(new ADResultBulkResponse(failedRequests));
+            }, listener::onFailure));
+        } else {
+            listener.onResponse(new ADResultBulkResponse());
         }
+    }
+
+    private boolean isHighPriorityRequest(AnomalyResult result) {
+        return result.getAnomalyGrade() > 0 || result.getError() != null;
     }
 
     private void addResult(BulkRequest bulkRequest, AnomalyResult result) {

--- a/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
+++ b/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
@@ -34,10 +34,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ad.ml.CheckpointDao.FIELD_MODEL;
@@ -70,32 +68,23 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
-import org.opensearch.action.DocWriteRequest;
-import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
-import org.opensearch.action.bulk.BulkAction;
-import org.opensearch.action.bulk.BulkItemResponse;
-import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.client.Client;
-import org.opensearch.index.engine.VersionConflictEngineException;
-import org.opensearch.index.shard.ShardId;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
 
 import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
 import com.google.gson.Gson;
@@ -136,7 +125,8 @@ public class CheckpointDaoTests {
 
     private Gson gson;
     private Class<? extends ThresholdingModel> thresholdingModelClass;
-    private int maxBulkSize;
+
+    private int maxCheckpointBytes = 1_000_000;
 
     @Before
     public void setup() {
@@ -150,8 +140,6 @@ public class CheckpointDaoTests {
 
         when(clock.instant()).thenReturn(Instant.now());
 
-        maxBulkSize = 10;
-
         checkpointDao = new CheckpointDao(
             client,
             clientUtil,
@@ -159,11 +147,8 @@ public class CheckpointDaoTests {
             gson,
             rcfSerde,
             thresholdingModelClass,
-            clock,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             indexUtil,
-            maxBulkSize,
-            200.0
+            maxCheckpointBytes
         );
 
         when(indexUtil.doesCheckpointIndexExist()).thenReturn(true);
@@ -438,227 +423,10 @@ public class CheckpointDaoTests {
         assertEquals(null, response);
     }
 
-    private BulkResponse createBulkResponse(int succeeded, int failed, String[] failedId) {
-        BulkItemResponse[] bulkItemResponses = new BulkItemResponse[succeeded + failed];
-
-        ShardId shardId = new ShardId(CommonName.CHECKPOINT_INDEX_NAME, "", 1);
-        int i = 0;
-        for (; i < failed; i++) {
-            bulkItemResponses[i] = new BulkItemResponse(
-                i,
-                DocWriteRequest.OpType.UPDATE,
-                new BulkItemResponse.Failure(
-                    CommonName.CHECKPOINT_INDEX_NAME,
-                    CommonName.MAPPING_TYPE,
-                    failedId[i],
-                    new VersionConflictEngineException(shardId, "id", "test")
-                )
-            );
-        }
-
-        for (; i < failed + succeeded; i++) {
-            bulkItemResponses[i] = new BulkItemResponse(
-                i,
-                DocWriteRequest.OpType.UPDATE,
-                new UpdateResponse(shardId, CommonName.MAPPING_TYPE, "1", 0L, 1L, 1L, DocWriteResponse.Result.CREATED)
-            );
-        }
-
-        return new BulkResponse(bulkItemResponses, 507);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void flush_less_than_1k() {
-        int writeRequests = maxBulkSize - 1;
-        for (int i = 0; i < writeRequests; i++) {
-            ModelState<EntityModel> state = MLUtil.randomModelState();
-            checkpointDao.write(state, state.getModelId(), true);
-        }
-
-        doAnswer(invocation -> {
-            BulkRequest request = invocation.getArgument(1);
-            assertEquals(writeRequests, request.numberOfActions());
-            ActionListener<BulkResponse> listener = invocation.getArgument(2);
-
-            listener.onResponse(createBulkResponse(request.numberOfActions(), 0, null));
-            return null;
-        }).when(clientUtil).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-
-        checkpointDao.flush();
-
-        verify(clientUtil, times(1)).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
-    @SuppressWarnings("unchecked")
-    public void flush_more_than_1k() {
-        int writeRequests = maxBulkSize + 1;
-
-        doAnswer(invocation -> {
-            BulkRequest request = invocation.getArgument(1);
-            assertEquals(maxBulkSize, request.numberOfActions());
-            ActionListener<BulkResponse> listener = invocation.getArgument(2);
-
-            listener.onResponse(createBulkResponse(request.numberOfActions(), 0, null));
-            return null;
-        }).when(clientUtil).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-
-        for (int i = 0; i < writeRequests; i++) {
-            ModelState<EntityModel> state = MLUtil.randomModelState();
-            // should trigger auto flush
-            checkpointDao.write(state, state.getModelId(), true);
-        }
-
-        verify(clientUtil, times(1)).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
-    @Test
-    public void flush_more_than_1k_has_index() {
-        flush_more_than_1k();
-    }
-
-    @Test
-    public void flush_more_than_1k_no_index() {
-        when(indexUtil.doesCheckpointIndexExist()).thenReturn(false);
-
-        doAnswer(invocation -> {
-            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
-            listener.onResponse(new CreateIndexResponse(true, true, CommonName.CHECKPOINT_INDEX_NAME));
-            return null;
-        }).when(indexUtil).initCheckpointIndex(any());
-
-        flush_more_than_1k();
-    }
-
-    @Test
-    public void flush_more_than_1k_race_condition() {
-        when(indexUtil.doesCheckpointIndexExist()).thenReturn(false);
-
-        doAnswer(invocation -> {
-            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
-            listener.onFailure(new ResourceAlreadyExistsException(CommonName.CHECKPOINT_INDEX_NAME));
-            return null;
-        }).when(indexUtil).initCheckpointIndex(any());
-
-        flush_more_than_1k();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void flush_more_than_1k_unexpected_exception() {
-        when(indexUtil.doesCheckpointIndexExist()).thenReturn(false);
-
-        doAnswer(invocation -> {
-            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
-            listener.onFailure(new RuntimeException(""));
-            return null;
-        }).when(indexUtil).initCheckpointIndex(any());
-
-        verify(clientUtil, never()).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void bulk_has_failure() throws InterruptedException {
-        int writeRequests = maxBulkSize - 1;
-        int failureCount = 1;
-        String[] failedId = new String[failureCount];
-        for (int i = 0; i < writeRequests; i++) {
-            ModelState<EntityModel> state = MLUtil.randomModelState();
-            checkpointDao.write(state, state.getModelId(), true);
-            if (i < failureCount) {
-                failedId[i] = state.getModelId();
-            }
-        }
-
-        doAnswer(invocation -> {
-            BulkRequest request = invocation.getArgument(1);
-            assertEquals(writeRequests, request.numberOfActions());
-            ActionListener<BulkResponse> listener = invocation.getArgument(2);
-
-            listener.onResponse(createBulkResponse(request.numberOfActions(), failureCount, failedId));
-            return null;
-        }).when(clientUtil).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-
-        checkpointDao.flush();
-
-        doAnswer(invocation -> {
-            BulkRequest request = invocation.getArgument(1);
-            assertEquals(failureCount, request.numberOfActions());
-            ActionListener<BulkResponse> listener = invocation.getArgument(2);
-
-            listener.onResponse(createBulkResponse(request.numberOfActions(), 0, null));
-            return null;
-        }).when(clientUtil).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-
-        checkpointDao.flush();
-
-        verify(clientUtil, times(2)).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void bulk_all_failure() throws InterruptedException {
-        int writeRequests = maxBulkSize - 1;
-        for (int i = 0; i < writeRequests; i++) {
-            ModelState<EntityModel> state = MLUtil.randomModelState();
-            checkpointDao.write(state, state.getModelId(), true);
-        }
-
-        doAnswer(invocation -> {
-            BulkRequest request = invocation.getArgument(1);
-            assertEquals(writeRequests, request.numberOfActions());
-            ActionListener<BulkResponse> listener = invocation.getArgument(2);
-
-            listener.onFailure(new RuntimeException(""));
-            return null;
-        }).when(clientUtil).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-
-        checkpointDao.flush();
-
-        doAnswer(invocation -> {
-            BulkRequest request = invocation.getArgument(1);
-            assertEquals(writeRequests, request.numberOfActions());
-            ActionListener<BulkResponse> listener = invocation.getArgument(2);
-
-            listener.onResponse(createBulkResponse(request.numberOfActions(), 0, null));
-            return null;
-        }).when(clientUtil).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-
-        checkpointDao.flush();
-
-        verify(clientUtil, times(2)).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void checkpoint_saved_less_than_1_hr() {
-        ModelState<EntityModel> state = MLUtil.randomModelState();
-        state.setLastCheckpointTime(Instant.now());
-        checkpointDao.write(state, state.getModelId());
-
-        checkpointDao.flush();
-
-        verify(clientUtil, never()).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void checkpoint_coldstart_checkpoint() {
-        ModelState<EntityModel> state = MLUtil.randomModelState();
-        state.setLastCheckpointTime(Instant.now());
-        // cold start checkpoint will save whatever
-        checkpointDao.write(state, state.getModelId(), true);
-
-        checkpointDao.flush();
-
-        verify(clientUtil, times(1)).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any(ActionListener.class));
-    }
-
     @SuppressWarnings("unchecked")
     @Test
     public void restore() throws IOException {
-        ModelState<EntityModel> state = MLUtil.randomNonEmptyModelState();
+        ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
         EntityModel modelToSave = state.getModel();
 
         checkpointDao = new CheckpointDao(
@@ -668,11 +436,8 @@ public class CheckpointDaoTests {
             new Gson(),
             new RandomCutForestSerDe(),
             thresholdingModelClass,
-            clock,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             indexUtil,
-            maxBulkSize,
-            2
+            maxCheckpointBytes
         );
 
         GetResponse getResponse = mock(GetResponse.class);

--- a/src/test/java/org/opensearch/ad/ml/CheckpointDeleteTests.java
+++ b/src/test/java/org/opensearch/ad/ml/CheckpointDeleteTests.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -43,7 +42,6 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.client.Client;
 import org.opensearch.index.IndexNotFoundException;
@@ -73,9 +71,9 @@ public class CheckpointDeleteTests extends AbstractADTest {
     private ClientUtil clientUtil;
     private Gson gson;
     private RandomCutForestSerDe rcfSerde;
-    private Clock clock;
     private AnomalyDetectionIndices indexUtil;
     private String detectorId;
+    private int maxCheckpointBytes;
 
     @Override
     @Before
@@ -87,9 +85,9 @@ public class CheckpointDeleteTests extends AbstractADTest {
         clientUtil = mock(ClientUtil.class);
         gson = null;
         rcfSerde = mock(RandomCutForestSerDe.class);
-        clock = mock(Clock.class);
         indexUtil = mock(AnomalyDetectionIndices.class);
         detectorId = "123";
+        maxCheckpointBytes = 1_000_000;
 
         checkpointDao = new CheckpointDao(
             client,
@@ -98,11 +96,8 @@ public class CheckpointDeleteTests extends AbstractADTest {
             gson,
             rcfSerde,
             HybridThresholdingModel.class,
-            clock,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             indexUtil,
-            AnomalyDetectorSettings.MAX_BULK_CHECKPOINT_SIZE,
-            AnomalyDetectorSettings.CHECKPOINT_BULK_PER_SECOND
+            maxCheckpointBytes
         );
     }
 


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved. Now the code is missing unit tests. Will add unit tests, run performance tests, and fix bugs before the official release.

### Description
This PR adds queues for writing model checkpoints and detection result.  The write is a batch request. 

Failure tolerance like retrying requests is handled. To retry failed result bulk requests, we also added the index request to retry in ADResultBulkResponse.  

Testing done:
1. Manual tests using 10 HCAD detectors and 12,000 entities in a 3 node cluster.
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
