### PR TITLE
Make dedicated cache’s size adjustable

### DIFF
--- a/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
@@ -29,9 +29,11 @@ package org.opensearch.ad.caching;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -40,13 +42,13 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.ExpiringState;
-import org.opensearch.ad.MaintenanceState;
 import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.MemoryTracker.Origin;
-import org.opensearch.ad.ml.CheckpointDao;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.InitProgressProfile;
+import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
+import org.opensearch.ad.ratelimit.SegmentPriority;
 
 /**
  * We use a layered cache to manage active entities’ states.  We have a two-level
@@ -66,54 +68,53 @@ import org.opensearch.ad.model.InitProgressProfile;
  * top minimumCapacity active entities (last X entities in priorityList) as in dedicated
  * cache and all others in shared cache.
  */
-public class CacheBuffer implements ExpiringState, MaintenanceState {
+public class CacheBuffer implements ExpiringState {
     private static final Logger LOG = LogManager.getLogger(CacheBuffer.class);
 
     // max entities to track per detector
     private final int MAX_TRACKING_ENTITIES = 1000000;
 
-    private final int minimumCapacity;
+    private int minimumCapacity;
+
     // key -> value
     private final ConcurrentHashMap<String, ModelState<EntityModel>> items;
     // memory consumption per entity
     private final long memoryConsumptionPerEntity;
     private final MemoryTracker memoryTracker;
-    private final CheckpointDao checkpointDao;
     private final Duration modelTtl;
     private final String detectorId;
     private Instant lastUsedTime;
-    private final long reservedBytes;
+    private long reservedBytes;
     private final PriorityTracker priorityTracker;
     private final Clock clock;
+    private final CheckpointWriteQueue checkpointWriteQueue;
+    private final Random random;
 
     public CacheBuffer(
         int minimumCapacity,
         long intervalSecs,
-        CheckpointDao checkpointDao,
         long memoryConsumptionPerEntity,
         MemoryTracker memoryTracker,
         Clock clock,
         Duration modelTtl,
-        String detectorId
+        String detectorId,
+        CheckpointWriteQueue checkpointWriteQueue,
+        Random random
     ) {
-        if (minimumCapacity <= 0) {
-            throw new IllegalArgumentException("minimum capacity should be larger than 0");
-        }
-        this.minimumCapacity = minimumCapacity;
+        this.memoryConsumptionPerEntity = memoryConsumptionPerEntity;
+        setMinimumCapacity(minimumCapacity);
 
         this.items = new ConcurrentHashMap<>();
-
-        this.memoryConsumptionPerEntity = memoryConsumptionPerEntity;
         this.memoryTracker = memoryTracker;
 
-        this.checkpointDao = checkpointDao;
         this.modelTtl = modelTtl;
         this.detectorId = detectorId;
         this.lastUsedTime = clock.instant();
 
-        this.reservedBytes = memoryConsumptionPerEntity * minimumCapacity;
         this.clock = clock;
         this.priorityTracker = new PriorityTracker(clock, intervalSecs, clock.instant().getEpochSecond(), MAX_TRACKING_ENTITIES);
+        this.checkpointWriteQueue = checkpointWriteQueue;
+        this.random = random;
     }
 
     /**
@@ -166,7 +167,7 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
             // Since we have already considered them while allocating CacheBuffer,
             // skip bookkeeping.
             if (!sharedCacheEmpty()) {
-                memoryTracker.consumeMemory(memoryConsumptionPerEntity, false, Origin.MULTI_ENTITY_DETECTOR);
+                memoryTracker.consumeMemory(memoryConsumptionPerEntity, false, Origin.HC_DETECTOR);
             }
         } else {
             update(entityModelId);
@@ -240,16 +241,26 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
         ModelState<EntityModel> valueRemoved = items.remove(keyToRemove);
 
         if (valueRemoved != null) {
-            // if we releasing a shared cache item, release memory as well.
-            if (!reserved) {
-                memoryTracker.releaseMemory(memoryConsumptionPerEntity, false, Origin.MULTI_ENTITY_DETECTOR);
+            if (reserved) {
+                // release in reserved memory
+                memoryTracker.releaseMemory(memoryConsumptionPerEntity, true, Origin.HC_DETECTOR);
+            } else {
+                // release in shared memory
+                memoryTracker.releaseMemory(memoryConsumptionPerEntity, false, Origin.HC_DETECTOR);
             }
-            checkpointDao.write(valueRemoved, keyToRemove);
-        }
 
-        EntityModel modelRemoved = valueRemoved.getModel();
-        if (modelRemoved != null) {
-            modelRemoved.clear();
+            EntityModel modelRemoved = valueRemoved.getModel();
+            if (modelRemoved != null) {
+                if (modelRemoved.getRcf() == null || modelRemoved.getThreshold() == null) {
+                    // only have samples. If we don't save, we throw the new samples and might
+                    // never be able to initialize the model
+                    checkpointWriteQueue.write(valueRemoved, true, SegmentPriority.MEDIUM);
+                } else {
+                    checkpointWriteQueue.write(valueRemoved, false, SegmentPriority.MEDIUM);
+                }
+
+                modelRemoved.clear();
+            }
         }
 
         return valueRemoved;
@@ -306,8 +317,13 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
         return replaced;
     }
 
-    @Override
-    public void maintenance() {
+    /**
+     * Remove expired state and save checkpoints of existing states
+     * @return removed states
+     */
+    public List<ModelState<EntityModel>> maintenance() {
+        List<ModelState<EntityModel>> modelsToSave = new ArrayList<>();
+        List<ModelState<EntityModel>> removedStates = new ArrayList<>();
         items.entrySet().stream().forEach(entry -> {
             String entityModelId = entry.getKey();
             try {
@@ -324,21 +340,21 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
                     // put: not a problem as we are unlikely to maintain an entry that's not
                     // already in the cache
                     // remove method saves checkpoint as well
-                    remove(entityModelId);
-                } else {
-                    // we can have ConcurrentModificationException when serializing
-                    // and updating rcf model at the same time. To prevent this,
-                    // we need to have a deep copy of models or have a lock. Both
-                    // options are costly.
-                    // As we are gonna retry serializing either when the entity is
-                    // evicted out of cache or during the next maintenance period,
-                    // don't do anything when the exception happens.
-                    checkpointDao.write(modelState, entityModelId);
+                    removedStates.add(remove(entityModelId));
+                } else if (random.nextInt(6) == 0) {
+                    // checkpoint is relatively big compared to other queued requests
+                    // save checkpoints with 1/6 probability as we expect to save
+                    // all every 6 hours statistically
+                    modelsToSave.add(modelState);
                 }
+
             } catch (Exception e) {
                 LOG.warn("Failed to finish maintenance for model id " + entityModelId, e);
             }
         });
+
+        checkpointWriteQueue.writeAll(modelsToSave, detectorId, false, SegmentPriority.MEDIUM);
+        return removedStates;
     }
 
     /**
@@ -388,9 +404,9 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
         // not a problem as we are releasing memory in MemoryTracker.
         // The newly added one loses references and soon GC will collect it.
         // We have memory tracking correction to fix incorrect memory usage record.
-        memoryTracker.releaseMemory(getReservedBytes(), true, Origin.MULTI_ENTITY_DETECTOR);
+        memoryTracker.releaseMemory(getReservedBytes(), true, Origin.HC_DETECTOR);
         if (!sharedCacheEmpty()) {
-            memoryTracker.releaseMemory(getBytesInSharedCache(), false, Origin.MULTI_ENTITY_DETECTOR);
+            memoryTracker.releaseMemory(getBytesInSharedCache(), false, Origin.HC_DETECTOR);
         }
         items.clear();
         priorityTracker.clearPriority();
@@ -449,11 +465,19 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
         return detectorId;
     }
 
-    public List<ModelState<?>> getAllModels() {
+    public List<ModelState<EntityModel>> getAllModels() {
         return items.values().stream().collect(Collectors.toList());
     }
 
     public PriorityTracker getPriorityTracker() {
         return priorityTracker;
+    }
+
+    public void setMinimumCapacity(int minimumCapacity) {
+        if (minimumCapacity < 0) {
+            throw new IllegalArgumentException("minimum capacity should be larger than or equals 0");
+        }
+        this.minimumCapacity = minimumCapacity;
+        this.reservedBytes = memoryConsumptionPerEntity * minimumCapacity;
     }
 }

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -82,7 +82,7 @@ public class PriorityCache implements EntityCache {
     // detector id -> CacheBuffer, weight based
     private final Map<String, CacheBuffer> activeEnities;
     private final CheckpointDao checkpointDao;
-    private int dedicatedCacheSize;
+    private volatile int dedicatedCacheSize;
     // LRU Cache
     private Cache<String, ModelState<EntityModel>> inActiveEntities;
     private final MemoryTracker memoryTracker;

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -26,34 +26,34 @@
 
 package org.opensearch.ad.caching;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.COOLDOWN_MINUTES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CACHE_MISS_HANDLING_PER_SECOND;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.DEDICATED_CACHE_SIZE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Queue;
+import java.util.PriorityQueue;
 import java.util.Random;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.Throwables;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.OpenSearchException;
-import org.opensearch.action.ActionListener;
-import org.opensearch.action.support.TransportActions;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.MemoryTracker.Origin;
@@ -61,20 +61,20 @@ import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.CheckpointDao;
 import org.opensearch.ad.ml.EntityModel;
-import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.Entity;
+import org.opensearch.ad.model.ModelProfile;
+import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.Settings;
+import org.opensearch.common.Strings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.util.concurrent.RateLimiter;
 
 public class PriorityCache implements EntityCache {
     private final Logger LOG = LogManager.getLogger(PriorityCache.class);
@@ -82,22 +82,25 @@ public class PriorityCache implements EntityCache {
     // detector id -> CacheBuffer, weight based
     private final Map<String, CacheBuffer> activeEnities;
     private final CheckpointDao checkpointDao;
-    private final int dedicatedCacheSize;
+    private int dedicatedCacheSize;
     // LRU Cache
     private Cache<String, ModelState<EntityModel>> inActiveEntities;
     private final MemoryTracker memoryTracker;
-    private final ModelManager modelManager;
     private final ReentrantLock maintenanceLock;
     private final int numberOfTrees;
     private final Clock clock;
     private final Duration modelTtl;
-    private final int numMinSamples;
+    // A bloom filter placed in front of inactive entity cache to
+    // filter out unpopular items that are not likely to appear more
+    // than once.
     private Map<String, DoorKeeper> doorKeepers;
-    private Instant cooldownStart;
-    private int coolDownMinutes;
     private ThreadPool threadPool;
     private Random random;
-    private RateLimiter cacheMissHandlingLimiter;
+    private CheckpointWriteQueue checkpointWriteQueue;
+    // iterating through all of inactive entities is heavy. We don't want to do
+    // it again and again for no obvious benefits.
+    private Instant lastInActiveEntityMaintenance;
+    protected int maintenanceFreqConstant;
 
     public PriorityCache(
         CheckpointDao checkpointDao,
@@ -105,26 +108,30 @@ public class PriorityCache implements EntityCache {
         Duration inactiveEntityTtl,
         int maxInactiveStates,
         MemoryTracker memoryTracker,
-        ModelManager modelManager,
         int numberOfTrees,
         Clock clock,
         ClusterService clusterService,
         Duration modelTtl,
-        int numMinSamples,
-        Settings settings,
         ThreadPool threadPool,
-        int cacheMissRateHandlingLimiter
+        CheckpointWriteQueue checkpointWriteQueue,
+        int maintenanceFreqConstant
     ) {
         this.checkpointDao = checkpointDao;
-        this.dedicatedCacheSize = dedicatedCacheSize;
+
         this.activeEnities = new ConcurrentHashMap<>();
+        this.dedicatedCacheSize = dedicatedCacheSize;
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(DEDICATED_CACHE_SIZE, (it) -> {
+            this.dedicatedCacheSize = it;
+            this.setDedicatedCacheSizeListener();
+            this.tryClearUpMemory();
+        }, this::validateDedicatedCacheSize);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> this.tryClearUpMemory());
+
         this.memoryTracker = memoryTracker;
-        this.modelManager = modelManager;
         this.maintenanceLock = new ReentrantLock();
         this.numberOfTrees = numberOfTrees;
         this.clock = clock;
         this.modelTtl = modelTtl;
-        this.numMinSamples = numMinSamples;
         this.doorKeepers = new ConcurrentHashMap<>();
 
         this.inActiveEntities = CacheBuilder
@@ -134,34 +141,30 @@ public class PriorityCache implements EntityCache {
             .concurrencyLevel(1)
             .build();
 
-        this.cooldownStart = Instant.MIN;
-        this.coolDownMinutes = (int) (COOLDOWN_MINUTES.get(settings).getMinutes());
         this.threadPool = threadPool;
         this.random = new Random(42);
-
-        this.cacheMissHandlingLimiter = RateLimiter.create(cacheMissRateHandlingLimiter);
-        clusterService
-            .getClusterSettings()
-            .addSettingsUpdateConsumer(MAX_CACHE_MISS_HANDLING_PER_SECOND, it -> this.cacheMissHandlingLimiter = RateLimiter.create(it));
+        this.checkpointWriteQueue = checkpointWriteQueue;
+        this.lastInActiveEntityMaintenance = Instant.MIN;
+        this.maintenanceFreqConstant = maintenanceFreqConstant;
     }
 
     @Override
-    public ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName) {
+    public ModelState<EntityModel> get(String modelId, AnomalyDetector detector) {
         String detectorId = detector.getDetectorId();
         CacheBuffer buffer = computeBufferIfAbsent(detector, detectorId);
         ModelState<EntityModel> modelState = buffer.get(modelId);
 
         // during maintenance period, stop putting new entries
-        if (modelState == null) {
+        if (!maintenanceLock.isLocked() && modelState == null) {
             DoorKeeper doorKeeper = doorKeepers
                 .computeIfAbsent(
                     detectorId,
                     id -> {
                         // reset every 60 intervals
                         return new DoorKeeper(
-                            AnomalyDetectorSettings.DOOR_KEEPER_MAX_INSERTION,
+                            AnomalyDetectorSettings.DOOR_KEEPER_FOR_CACHE_MAX_INSERTION,
                             AnomalyDetectorSettings.DOOR_KEEPER_FAULSE_POSITIVE_RATE,
-                            detector.getDetectionIntervalDuration().multipliedBy(60),
+                            detector.getDetectionIntervalDuration().multipliedBy(AnomalyDetectorSettings.DOOR_KEEPER_MAINTENANCE_FREQ),
                             clock
                         );
                     }
@@ -173,188 +176,293 @@ public class PriorityCache implements EntityCache {
                 return null;
             }
 
-            ModelState<EntityModel> state = inActiveEntities.getIfPresent(modelId);
+            try {
+                ModelState<EntityModel> state = inActiveEntities.get(modelId, new Callable<ModelState<EntityModel>>() {
+                    @Override
+                    public ModelState<EntityModel> call() {
+                        return new ModelState<>(null, modelId, detectorId, ModelType.ENTITY.getName(), clock, 0);
+                    }
+                });
 
-            // compute updated priority
-            // We don’t want to admit the latest entity for correctness by throwing out a
-            // hot entity. We have a priority (time-decayed count) sensitive to
-            // the number of hits, length of time, and sampling interval. Examples:
-            // 1) an entity from a 5-minute interval detector that is hit 5 times in the
-            // past 25 minutes should have an equal chance of using the cache along with
-            // an entity from a 1-minute interval detector that is hit 5 times in the past
-            // 5 minutes.
-            // 2) It might be the case that the frequency of entities changes dynamically
-            // during run-time. For example, entity A showed up for the first 500 times,
-            // but entity B showed up for the next 500 times. Our priority should give
-            // entity B higher priority than entity A as time goes by.
-            // 3) Entity A will have a higher priority than entity B if A runs
-            // for a longer time given other things are equal.
-            //
-            // We ensure fairness by using periods instead of absolute duration. Entity A
-            // accessed once three intervals ago should have the same priority with entity B
-            // accessed once three periods ago, though they belong to detectors of different
-            // intervals.
-            float priority = 0;
-            if (state != null) {
-                priority = state.getPriority();
-            }
-            priority = buffer.getPriorityTracker().getUpdatedPriority(priority);
+                // make sure no model has been stored due to previous race conditions
+                state.setModel(null);
 
-            // update state using new priority or create a new one
-            if (state != null) {
-                state.setPriority(priority);
-            } else {
-                EntityModel model = new EntityModel(modelId, new ArrayDeque<>(), null, null);
-                state = new ModelState<>(model, modelId, detectorId, ModelType.ENTITY.getName(), clock, priority);
+                // compute updated priority
+                // We don’t want to admit the latest entity for correctness by throwing out a
+                // hot entity. We have a priority (time-decayed count) sensitive to
+                // the number of hits, length of time, and sampling interval. Examples:
+                // 1) an entity from a 5-minute interval detector that is hit 5 times in the
+                // past 25 minutes should have an equal chance of using the cache along with
+                // an entity from a 1-minute interval detector that is hit 5 times in the past
+                // 5 minutes.
+                // 2) It might be the case that the frequency of entities changes dynamically
+                // during run-time. For example, entity A showed up for the first 500 times,
+                // but entity B showed up for the next 500 times. Our priority should give
+                // entity B higher priority than entity A as time goes by.
+                // 3) Entity A will have a higher priority than entity B if A runs
+                // for a longer time given other things are equal.
+                //
+                // We ensure fairness by using periods instead of absolute duration. Entity A
+                // accessed once three intervals ago should have the same priority with entity B
+                // accessed once three periods ago, though they belong to detectors of different
+                // intervals.
+
+                // update state using new priority or create a new one
+                state.setPriority(buffer.getPriorityTracker().getUpdatedPriority(state.getPriority()));
+
+                // adjust shared memory in case we have used dedicated cache memory for other detectors
+                if (random.nextInt(maintenanceFreqConstant) == 1) {
+                    tryClearUpMemory();
+                }
+            } catch (Exception e) {
+                LOG.error(new ParameterizedMessage("Fail to update priority of [{}]", modelId), e);
             }
 
-            if (random.nextInt(10_000) == 1) {
-                // clear up memory with 1/10000 probability since this operation is costly, but we have to do it from time to time.
-                // e.g., we need to adjust shared entity memory size if some reserved memory gets allocated. Use 10_000 since our
-                // query limit is 1k by default and we can have 10 detectors: 10 * 1k. We also do this in hourly maintenance window no
-                // matter what.
-                tryClearUpMemory();
-            }
-            if (!maintenanceLock.isLocked()
-                && cacheMissHandlingLimiter.tryAcquire()
-                && hostIfPossible(buffer, detectorId, modelId, entityName, detector, state, priority)) {
-                addSample(state, datapoint);
-                inActiveEntities.invalidate(modelId);
-            } else {
-                // put to inactive cache if we cannot host or get the lock or get rate permits
-                // only keep weights in inactive cache to keep it small.
-                // It can be dangerous to exceed a few dozen MBs, especially
-                // in small heap machine like t2.
-                inActiveEntities.put(modelId, state);
-            }
         }
 
         return modelState;
     }
 
-    /**
-     * Whether host an entity is possible
-     * @param buffer the destination buffer for the given entity
-     * @param detectorId Detector Id
-     * @param modelId Model Id
-     * @param entityName Entity's name
-     * @param detector Detector Config
-     * @param state State to host
-     * @param priority The entity's priority
-     * @return true if possible; false otherwise
-     */
-    private boolean hostIfPossible(
-        CacheBuffer buffer,
+    private Optional<ModelState<EntityModel>> getStateFromInactiveEntiiyCache(String modelId) {
+        if (modelId == null) {
+            return Optional.empty();
+        }
+
+        // null if not even recorded in inActiveEntities yet because of doorKeeper
+        return Optional.ofNullable(inActiveEntities.getIfPresent(modelId));
+    }
+
+    @Override
+    public boolean hostIfPossible(AnomalyDetector detector, ModelState<EntityModel> toUpdate) {
+        if (toUpdate == null) {
+            return false;
+        }
+        String modelId = toUpdate.getModelId();
+        String detectorId = toUpdate.getDetectorId();
+
+        if (Strings.isEmpty(modelId) || Strings.isEmpty(detectorId)) {
+            return false;
+        }
+
+        CacheBuffer buffer = computeBufferIfAbsent(detector, detectorId);
+
+        Optional<ModelState<EntityModel>> state = getStateFromInactiveEntiiyCache(modelId);
+        if (false == state.isPresent()) {
+            return false;
+        }
+
+        ModelState<EntityModel> modelState = state.get();
+
+        float priority = modelState.getPriority();
+
+        toUpdate.setLastUsedTime(clock.instant());
+        toUpdate.setPriority(priority);
+
+        // current buffer's dedicated cache has free slots or can allocate in shared cache
+        if (buffer.dedicatedCacheAvailable() || memoryTracker.canAllocate(buffer.getMemoryConsumptionPerEntity())) {
+            // buffer.put will call MemoryTracker.consumeMemory
+            buffer.put(modelId, toUpdate);
+            return true;
+        }
+
+        if (memoryTracker.canAllocate(buffer.getMemoryConsumptionPerEntity())) {
+            // buffer.put will call MemoryTracker.consumeMemory
+            buffer.put(modelId, toUpdate);
+            return true;
+        }
+
+        // can replace an entity in the same CacheBuffer living in reserved or shared cache
+        if (buffer.canReplaceWithinDetector(priority)) {
+            ModelState<EntityModel> removed = buffer.replace(modelId, toUpdate);
+            // null in the case of some other threads have emptied the queue at
+            // the same time so there is nothing to replace
+            if (removed != null) {
+                addIntoInactiveCache(removed);
+                return true;
+            }
+        }
+
+        // If two threads try to remove the same entity and add their own state, the 2nd remove
+        // returns null and only the first one succeeds.
+        float scaledPriority = buffer.getPriorityTracker().getScaledPriority(priority);
+        Triple<CacheBuffer, String, Float> bufferToRemoveEntity = canReplaceInSharedCache(buffer, scaledPriority);
+        CacheBuffer bufferToRemove = bufferToRemoveEntity.getLeft();
+        String entityModelId = bufferToRemoveEntity.getMiddle();
+        ModelState<EntityModel> removed = null;
+        if (bufferToRemove != null && ((removed = bufferToRemove.remove(entityModelId)) != null)) {
+            buffer.put(modelId, toUpdate);
+            addIntoInactiveCache(removed);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void addIntoInactiveCache(ModelState<EntityModel> removed) {
+        if (removed == null) {
+            return;
+        }
+        // set last used time for profile API so that we know when an entities is evicted
+        removed.setLastUsedTime(clock.instant());
+        removed.setModel(null);
+        inActiveEntities.put(removed.getModelId(), removed);
+    }
+
+    private void addEntity(List<Entity> destination, Entity entity, String detectorId) {
+        // It's possible our doorkeepr prevented the entity from entering inactive entities cache
+        if (entity != null) {
+            Optional<String> modelId = entity.getModelId(detectorId);
+            if (modelId.isPresent() && inActiveEntities.getIfPresent(modelId.get()) != null) {
+                destination.add(entity);
+            }
+        }
+    }
+
+    @Override
+    public Pair<List<Entity>, List<Entity>> selectUpdateCandidate(
+        Collection<Entity> cacheMissEntities,
         String detectorId,
-        String modelId,
-        String entityName,
-        AnomalyDetector detector,
-        ModelState<EntityModel> state,
-        float priority
+        AnomalyDetector detector
     ) {
+        List<Entity> hotEntities = new ArrayList<>();
+        CacheBuffer buffer = computeBufferIfAbsent(detector, detectorId);
+        Iterator<Entity> cacheMissEntitiesIter = cacheMissEntities.iterator();
         // current buffer's dedicated cache has free slots
-        // thread safe as each detector has one thread at one time and only the
-        // thread can access its buffer.
-        if (buffer.dedicatedCacheAvailable()) {
-            buffer.put(modelId, state);
-        } else if (memoryTracker.canAllocate(buffer.getMemoryConsumptionPerEntity())) {
+        while (cacheMissEntitiesIter.hasNext() && buffer.dedicatedCacheAvailable()) {
+            addEntity(hotEntities, cacheMissEntitiesIter.next(), detectorId);
+        }
+
+        while (cacheMissEntitiesIter.hasNext() && memoryTracker.canAllocate(buffer.getMemoryConsumptionPerEntity())) {
             // can allocate in shared cache
             // race conditions can happen when multiple threads evaluating this condition.
             // This is a problem as our AD memory usage is close to full and we put
-            // more things than we planned. One model in multi-entity case is small,
+            // more things than we planned. One model in HCAD is small,
             // it is fine we exceed a little. We have regular maintenance to remove
             // extra memory usage.
-            buffer.put(modelId, state);
-        } else if (buffer.canReplaceWithinDetector(priority)) {
+            addEntity(hotEntities, cacheMissEntitiesIter.next(), detectorId);
+        }
+
+        // check if we can replace anything in dedicated or shared cache
+        // have a copy since we need to do the iteration twice: one for
+        // dedicated cache and one for shared cache
+        List<Entity> otherBufferReplaceCandidates = new ArrayList<>();
+
+        while (cacheMissEntitiesIter.hasNext()) {
             // can replace an entity in the same CacheBuffer living in reserved
             // or shared cache
             // thread safe as each detector has one thread at one time and only the
             // thread can access its buffer.
-            ModelState<EntityModel> removed = buffer.replace(modelId, state);
-            if (removed != null) {
-                // set last used time for profile API so that we know when an entities is evicted
-                removed.setLastUsedTime(clock.instant());
-                inActiveEntities.put(removed.getModelId(), removed);
+            Entity entity = cacheMissEntitiesIter.next();
+            Optional<String> modelId = entity.getModelId(detectorId);
+
+            if (false == modelId.isPresent()) {
+                continue;
             }
-        } else {
+
+            Optional<ModelState<EntityModel>> state = getStateFromInactiveEntiiyCache(modelId.get());
+            if (false == state.isPresent()) {
+                // not even recorded in inActiveEntities yet because of doorKeeper
+                continue;
+            }
+
+            ModelState<EntityModel> modelState = state.get();
+            float priority = modelState.getPriority();
+
+            if (buffer.canReplaceWithinDetector(priority)) {
+                addEntity(hotEntities, entity, detectorId);
+            } else {
+                // re-evaluate replacement condition in other buffers
+                otherBufferReplaceCandidates.add(entity);
+            }
+        }
+
+        // record current minimum priority among all detectors to save redundant
+        // scanning of all CacheBuffers
+        CacheBuffer bufferToRemove = null;
+        float minPriority = Float.MIN_VALUE;
+
+        // check if we can replace in other CacheBuffer
+        cacheMissEntitiesIter = otherBufferReplaceCandidates.iterator();
+
+        List<Entity> coldEntities = new ArrayList<>();
+
+        while (cacheMissEntitiesIter.hasNext()) {
             // If two threads try to remove the same entity and add their own state, the 2nd remove
             // returns null and only the first one succeeds.
+            Entity entity = cacheMissEntitiesIter.next();
+            Optional<String> modelId = entity.getModelId(detectorId);
+
+            if (false == modelId.isPresent()) {
+                continue;
+            }
+
+            Optional<ModelState<EntityModel>> inactiveState = getStateFromInactiveEntiiyCache(modelId.get());
+            if (false == inactiveState.isPresent()) {
+                // empty state should not stand a chance to replace others
+                continue;
+            }
+
+            ModelState<EntityModel> state = inactiveState.get();
+
+            float priority = state.getPriority();
             float scaledPriority = buffer.getPriorityTracker().getScaledPriority(priority);
-            Entry<CacheBuffer, String> bufferToRemoveEntity = canReplaceInSharedCache(buffer, scaledPriority);
-            CacheBuffer bufferToRemove = bufferToRemoveEntity.getKey();
-            String entityModelId = bufferToRemoveEntity.getValue();
-            ModelState<EntityModel> removed = null;
-            if (bufferToRemove != null && ((removed = bufferToRemove.remove(entityModelId)) != null)) {
-                buffer.put(modelId, state);
-                // set last used time for profile API so that we know when an entities is evicted
-                removed.setLastUsedTime(clock.instant());
-                inActiveEntities.put(removed.getModelId(), removed);
+
+            if (scaledPriority <= minPriority) {
+                // not even larger than the minPriority, we can put this to coldEntities
+                addEntity(coldEntities, entity, detectorId);
+                continue;
+            }
+
+            // Float.MIN_VALUE means we need to re-iterate through all CacheBuffers
+            if (minPriority == Float.MIN_VALUE) {
+                Triple<CacheBuffer, String, Float> bufferToRemoveEntity = canReplaceInSharedCache(buffer, scaledPriority);
+                bufferToRemove = bufferToRemoveEntity.getLeft();
+                minPriority = bufferToRemoveEntity.getRight();
+            }
+
+            if (bufferToRemove != null) {
+                addEntity(hotEntities, entity, detectorId);
+                // reset minPriority after the replacement so that we need to iterate all CacheBuffer
+                // again
+                minPriority = Float.MIN_VALUE;
             } else {
-                return false;
+                // after trying everything, we can now safely put this to cold entities list
+                addEntity(coldEntities, entity, detectorId);
             }
         }
 
-        maybeRestoreOrTrainModel(modelId, entityName, state);
-        return true;
-    }
-
-    private void addSample(ModelState<EntityModel> stateToPromote, double[] datapoint) {
-        // add samples
-        Queue<double[]> samples = stateToPromote.getModel().getSamples();
-        samples.add(datapoint);
-        // only keep the recent numMinSamples
-        while (samples.size() > this.numMinSamples) {
-            samples.remove();
-        }
-    }
-
-    private void maybeRestoreOrTrainModel(String modelId, String entityName, ModelState<EntityModel> state) {
-        EntityModel entityModel = state.getModel();
-        // rate limit in case of OpenSearchRejectedExecutionException from get threadpool whose queue capacity is 1k
-        if (entityModel != null
-            && (entityModel.getRcf() == null || entityModel.getThreshold() == null)
-            && cooldownStart.plus(Duration.ofMinutes(coolDownMinutes)).isBefore(clock.instant())) {
-            checkpointDao
-                .restoreModelCheckpoint(
-                    modelId,
-                    ActionListener
-                        .wrap(checkpoint -> modelManager.processEntityCheckpoint(checkpoint, modelId, entityName, state), exception -> {
-                            Throwable cause = Throwables.getRootCause(exception);
-                            if (cause instanceof IndexNotFoundException) {
-                                modelManager.processEntityCheckpoint(Optional.empty(), modelId, entityName, state);
-                            } else if (cause instanceof RejectedExecutionException
-                                || TransportActions.isShardNotAvailableException(cause)) {
-                                LOG.error("too many get AD model checkpoint requests or shard not avialble");
-                                cooldownStart = clock.instant();
-                            } else {
-                                LOG.error("Fail to restore models for " + modelId, exception);
-                            }
-                        })
-                );
-        }
+        return Pair.of(hotEntities, coldEntities);
     }
 
     private CacheBuffer computeBufferIfAbsent(AnomalyDetector detector, String detectorId) {
-        return activeEnities.computeIfAbsent(detectorId, k -> {
+        CacheBuffer buffer = activeEnities.get(detectorId);
+        if (buffer == null) {
             long requiredBytes = getReservedDetectorMemory(detector);
-            tryClearUpMemory();
-            if (memoryTracker.canAllocateReserved(detectorId, requiredBytes)) {
-                memoryTracker.consumeMemory(requiredBytes, true, Origin.MULTI_ENTITY_DETECTOR);
+            if (memoryTracker.canAllocateReserved(requiredBytes)) {
+                memoryTracker.consumeMemory(requiredBytes, true, Origin.HC_DETECTOR);
                 long intervalSecs = detector.getDetectorIntervalInSeconds();
-                return new CacheBuffer(
+                buffer = new CacheBuffer(
                     dedicatedCacheSize,
                     intervalSecs,
-                    checkpointDao,
                     memoryTracker.estimateModelSize(detector, numberOfTrees),
                     memoryTracker,
                     clock,
                     modelTtl,
-                    detectorId
+                    detectorId,
+                    checkpointWriteQueue,
+                    random
                 );
+                activeEnities.put(detectorId, buffer);
+                // There can be race conditions between tryClearUpMemory and
+                // activeEntities.put above as tryClearUpMemory accesses activeEnities too.
+                // Put tryClearUpMemory after consumeMemory to prevent that.
+                tryClearUpMemory();
+            } else {
+                throw new LimitExceededException(detectorId, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG);
             }
-            // if hosting not allowed, exception will be thrown by isHostingAllowed
-            throw new LimitExceededException(detectorId, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG);
-        });
+
+        }
+        return buffer;
     }
 
     private long getReservedDetectorMemory(AnomalyDetector detector) {
@@ -372,9 +480,9 @@ public class PriorityCache implements EntityCache {
      * @param candidatePriority the candidate entity's priority
      * @return the CacheBuffer if we can find a CacheBuffer to make room for the candidate entity
      */
-    private Entry<CacheBuffer, String> canReplaceInSharedCache(CacheBuffer originBuffer, float candidatePriority) {
+    private Triple<CacheBuffer, String, Float> canReplaceInSharedCache(CacheBuffer originBuffer, float candidatePriority) {
         CacheBuffer minPriorityBuffer = null;
-        float minPriority = Float.MAX_VALUE;
+        float minPriority = candidatePriority;
         String minPriorityEntityModelId = null;
         for (Map.Entry<String, CacheBuffer> entry : activeEnities.entrySet()) {
             CacheBuffer buffer = entry.getValue();
@@ -388,13 +496,18 @@ public class PriorityCache implements EntityCache {
                 }
             }
         }
-        return new SimpleImmutableEntry<>(minPriorityBuffer, minPriorityEntityModelId);
+        return Triple.of(minPriorityBuffer, minPriorityEntityModelId, minPriority);
     }
 
+    /**
+     * Clear up overused memory.  Can happen due to race condition or other detectors
+     * consumes resources from shared memory.
+     * tryClearUpMemory is ran using AD threadpool because the function is expensive.
+     */
     private void tryClearUpMemory() {
         try {
             if (maintenanceLock.tryLock()) {
-                clearMemory();
+                threadPool.executor(AnomalyDetectorPlugin.AD_THREAD_POOL_NAME).execute(() -> clearMemory());
             } else {
                 threadPool.schedule(() -> {
                     try {
@@ -414,29 +527,41 @@ public class PriorityCache implements EntityCache {
     private void clearMemory() {
         recalculateUsedMemory();
         long memoryToShed = memoryTracker.memoryToShed();
-        float minPriority = Float.MAX_VALUE;
-        CacheBuffer minPriorityBuffer = null;
-        String minPriorityEntityModelId = null;
-        while (memoryToShed > 0) {
+        PriorityQueue<Triple<Float, CacheBuffer, String>> removalCandiates = null;
+        if (memoryToShed > 0) {
+            // sort the triple in an ascending order of priority
+            removalCandiates = new PriorityQueue<>((x, y) -> Float.compare(x.getLeft(), y.getLeft()));
             for (Map.Entry<String, CacheBuffer> entry : activeEnities.entrySet()) {
                 CacheBuffer buffer = entry.getValue();
                 Entry<String, Float> priorityEntry = buffer.getPriorityTracker().getMinimumScaledPriority();
                 float priority = priorityEntry.getValue();
-                if (buffer.canRemove() && priority < minPriority) {
-                    minPriority = priority;
-                    minPriorityBuffer = buffer;
-                    minPriorityEntityModelId = priorityEntry.getKey();
+                if (buffer.canRemove()) {
+                    removalCandiates.add(Triple.of(priority, buffer, priorityEntry.getKey()));
                 }
             }
-            if (minPriorityBuffer != null) {
-                minPriorityBuffer.remove(minPriorityEntityModelId);
-                long memoryReleased = minPriorityBuffer.getMemoryConsumptionPerEntity();
-                memoryTracker.releaseMemory(memoryReleased, false, Origin.MULTI_ENTITY_DETECTOR);
-                memoryToShed -= memoryReleased;
-            } else {
+        }
+        while (memoryToShed > 0) {
+            if (false == removalCandiates.isEmpty()) {
+                Triple<Float, CacheBuffer, String> toRemove = removalCandiates.poll();
+                CacheBuffer minPriorityBuffer = toRemove.getMiddle();
+                String minPriorityEntityModelId = toRemove.getRight();
+
+                ModelState<EntityModel> removed = minPriorityBuffer.remove(minPriorityEntityModelId);
+                memoryToShed -= minPriorityBuffer.getMemoryConsumptionPerEntity();
+                addIntoInactiveCache(removed);
+
+                if (minPriorityBuffer.canRemove()) {
+                    // can remove another one
+                    Entry<String, Float> priorityEntry = minPriorityBuffer.getPriorityTracker().getMinimumScaledPriority();
+                    removalCandiates.add(Triple.of(priorityEntry.getValue(), minPriorityBuffer, priorityEntry.getKey()));
+                }
+            }
+
+            if (removalCandiates.isEmpty()) {
                 break;
             }
         }
+
     }
 
     /**
@@ -450,7 +575,7 @@ public class PriorityCache implements EntityCache {
             reserved += buffer.getReservedBytes();
             shared += buffer.getBytesInSharedCache();
         }
-        memoryTracker.syncMemoryState(Origin.MULTI_ENTITY_DETECTOR, reserved + shared, reserved);
+        memoryTracker.syncMemoryState(Origin.HC_DETECTOR, reserved + shared, reserved);
     }
 
     /**
@@ -473,10 +598,15 @@ public class PriorityCache implements EntityCache {
                     activeEnities.remove(detectorId);
                     cacheBuffer.clear();
                 } else {
-                    cacheBuffer.maintenance();
+                    List<ModelState<EntityModel>> removedStates = cacheBuffer.maintenance();
+                    for (ModelState<EntityModel> state : removedStates) {
+                        addIntoInactiveCache(state);
+                    }
                 }
             });
-            checkpointDao.flush();
+
+            maintainInactiveCache();
+
             doorKeepers.entrySet().stream().forEach(doorKeeperEntry -> {
                 String detectorId = doorKeeperEntry.getKey();
                 DoorKeeper doorKeeper = doorKeeperEntry.getValue();
@@ -607,22 +737,6 @@ public class PriorityCache implements EntityCache {
         return res;
     }
 
-    @Override
-    /**
-     * Gets an entity's model state
-     *
-     * @param detectorId detector id
-     * @param entityModelId  entity model id
-     * @return the model state
-     */
-    public long getModelSize(String detectorId, String entityModelId) {
-        CacheBuffer cacheBuffer = activeEnities.get(detectorId);
-        if (cacheBuffer != null && cacheBuffer.getModel(entityModelId).isPresent()) {
-            return cacheBuffer.getMemoryConsumptionPerEntity();
-        }
-        return -1L;
-    }
-
     /**
      * Return the last active time of an entity's state.
      *
@@ -647,5 +761,114 @@ public class PriorityCache implements EntityCache {
             return stateInActive.getLastUsedTime().getEpochSecond();
         }
         return -1L;
+    }
+
+    @Override
+    public void releaseMemoryForOpenCircuitBreaker() {
+        maintainInactiveCache();
+
+        tryClearUpMemory();
+        activeEnities.values().stream().forEach(cacheBuffer -> {
+            if (cacheBuffer.canRemove()) {
+                ModelState<EntityModel> removed = cacheBuffer.remove();
+                addIntoInactiveCache(removed);
+            }
+        });
+    }
+
+    private void maintainInactiveCache() {
+        if (lastInActiveEntityMaintenance.plus(this.modelTtl).isAfter(clock.instant())) {
+            // don't scan inactive cache too frequently as it is costly
+            return;
+        }
+
+        // force maintenance of the cache. ref: https://tinyurl.com/pyy3p9v6
+        inActiveEntities.cleanUp();
+
+        // // make sure no model has been stored due to bugs
+        for (ModelState<EntityModel> state : inActiveEntities.asMap().values()) {
+            EntityModel model = state.getModel();
+            if (model != null && (model.getRcf() != null || model.getThreshold() != null)) {
+                LOG
+                    .warn(
+                        new ParameterizedMessage(
+                            "Inactive entity's model is null: [{}], [{}]. Maybe there are bugs.",
+                            model.getRcf(),
+                            model.getThreshold()
+                        )
+                    );
+                state.setModel(null);
+            }
+        }
+
+        lastInActiveEntityMaintenance = clock.instant();
+    }
+
+    /**
+     * Called when dedicated cache size changes.  Will adjust existing cache buffer's
+     * cache size
+     */
+    private void setDedicatedCacheSizeListener() {
+        activeEnities.values().stream().forEach(cacheBuffer -> cacheBuffer.setMinimumCapacity(dedicatedCacheSize));
+    }
+
+    @Override
+    public List<ModelProfile> getAllModelProfile(String detectorId) {
+        CacheBuffer cacheBuffer = activeEnities.get(detectorId);
+        List<ModelProfile> res = new ArrayList<>();
+        if (cacheBuffer != null) {
+            long size = cacheBuffer.getMemoryConsumptionPerEntity();
+            cacheBuffer.getAllModels().forEach(entry -> {
+                EntityModel model = entry.getModel();
+                Entity entity = null;
+                if (model != null && model.getEntity().isPresent()) {
+                    entity = model.getEntity().get();
+                }
+                res.add(new ModelProfile(entry.getModelId(), entity, size));
+            });
+        }
+        return res;
+    }
+
+    /**
+     * Gets an entity's model state
+     *
+     * @param detectorId detector id
+     * @param entityModelId  entity model id
+     * @return the model state
+     */
+    @Override
+    public Optional<ModelProfile> getModelProfile(String detectorId, String entityModelId) {
+        CacheBuffer cacheBuffer = activeEnities.get(detectorId);
+        if (cacheBuffer != null && cacheBuffer.getModel(entityModelId).isPresent()) {
+            EntityModel model = cacheBuffer.getModel(entityModelId).get();
+            Entity entity = null;
+            if (model != null && model.getEntity().isPresent()) {
+                entity = model.getEntity().get();
+            }
+            return Optional.of(new ModelProfile(entityModelId, entity, cacheBuffer.getMemoryConsumptionPerEntity()));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Throw an IllegalArgumentException even the dedicated size increases cannot
+     * be fulfilled.
+     *
+     * @param newDedicatedCacheSize the new dedicated cache size to validate
+     */
+    private void validateDedicatedCacheSize(Integer newDedicatedCacheSize) {
+        LOG.info("hello:" + newDedicatedCacheSize + " " + dedicatedCacheSize);
+        if (this.dedicatedCacheSize < newDedicatedCacheSize) {
+            int delta = newDedicatedCacheSize - this.dedicatedCacheSize;
+            long totalIncreasedBytes = 0;
+            for (CacheBuffer cacheBuffer : activeEnities.values()) {
+                totalIncreasedBytes += cacheBuffer.getMemoryConsumptionPerEntity() * delta;
+            }
+
+            if (false == memoryTracker.canAllocateReserved(totalIncreasedBytes)) {
+                throw new IllegalArgumentException("We don't have enough memory for the required change");
+            }
+        }
     }
 }

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -66,7 +66,7 @@ import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.ModelProfile;
-import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
+import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
@@ -96,7 +96,7 @@ public class PriorityCache implements EntityCache {
     private Map<String, DoorKeeper> doorKeepers;
     private ThreadPool threadPool;
     private Random random;
-    private CheckpointWriteQueue checkpointWriteQueue;
+    private CheckpointWriteWorker checkpointWriteQueue;
     // iterating through all of inactive entities is heavy. We don't want to do
     // it again and again for no obvious benefits.
     private Instant lastInActiveEntityMaintenance;
@@ -113,7 +113,7 @@ public class PriorityCache implements EntityCache {
         ClusterService clusterService,
         Duration modelTtl,
         ThreadPool threadPool,
-        CheckpointWriteQueue checkpointWriteQueue,
+        CheckpointWriteWorker checkpointWriteQueue,
         int maintenanceFreqConstant
     ) {
         this.checkpointDao = checkpointDao;
@@ -858,7 +858,6 @@ public class PriorityCache implements EntityCache {
      * @param newDedicatedCacheSize the new dedicated cache size to validate
      */
     private void validateDedicatedCacheSize(Integer newDedicatedCacheSize) {
-        LOG.info("hello:" + newDedicatedCacheSize + " " + dedicatedCacheSize);
         if (this.dedicatedCacheSize < newDedicatedCacheSize) {
             int delta = newDedicatedCacheSize - this.dedicatedCacheSize;
             long totalIncreasedBytes = 0;

--- a/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
+++ b/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
@@ -28,7 +28,7 @@ import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
-import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
+import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 
 public class AbstractCacheTest extends AbstractADTest {
@@ -43,7 +43,7 @@ public class AbstractCacheTest extends AbstractADTest {
     protected CacheBuffer cacheBuffer;
     protected long memoryPerEntity;
     protected MemoryTracker memoryTracker;
-    protected CheckpointWriteQueue checkpointWriteQueue;
+    protected CheckpointWriteWorker checkpointWriteQueue;
     protected Random random;
 
     @Override
@@ -73,7 +73,7 @@ public class AbstractCacheTest extends AbstractADTest {
         memoryPerEntity = 81920;
         memoryTracker = mock(MemoryTracker.class);
 
-        checkpointWriteQueue = mock(CheckpointWriteQueue.class);
+        checkpointWriteQueue = mock(CheckpointWriteWorker.class);
 
         cacheBuffer = new CacheBuffer(
             1,

--- a/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
+++ b/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.caching;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Random;
+
+import org.junit.Before;
+import org.opensearch.ad.AbstractADTest;
+import org.opensearch.ad.MemoryTracker;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelManager.ModelType;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.Entity;
+import org.opensearch.ad.ratelimit.CheckpointWriteQueue;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+
+public class AbstractCacheTest extends AbstractADTest {
+    protected String modelId1, modelId2, modelId3, modelId4;
+    protected Entity entity1, entity2, entity3, entity4;
+    protected ModelState<EntityModel> modelState1, modelState2, modelState3, modelState4;
+    protected String detectorId;
+    protected AnomalyDetector detector;
+    protected Clock clock;
+    protected Duration detectorDuration;
+    protected float initialPriority;
+    protected CacheBuffer cacheBuffer;
+    protected long memoryPerEntity;
+    protected MemoryTracker memoryTracker;
+    protected CheckpointWriteQueue checkpointWriteQueue;
+    protected Random random;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        modelId1 = "1";
+        modelId2 = "2";
+        modelId3 = "3";
+        modelId4 = "4";
+
+        detector = mock(AnomalyDetector.class);
+        detectorId = "123";
+        when(detector.getDetectorId()).thenReturn(detectorId);
+        detectorDuration = Duration.ofMinutes(5);
+        when(detector.getDetectionIntervalDuration()).thenReturn(detectorDuration);
+        when(detector.getDetectorIntervalInSeconds()).thenReturn(detectorDuration.getSeconds());
+
+        entity1 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal1");
+        entity2 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal2");
+        entity3 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal3");
+        entity4 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal4");
+
+        clock = mock(Clock.class);
+        when(clock.instant()).thenReturn(Instant.now());
+
+        memoryPerEntity = 81920;
+        memoryTracker = mock(MemoryTracker.class);
+
+        checkpointWriteQueue = mock(CheckpointWriteQueue.class);
+
+        cacheBuffer = new CacheBuffer(
+            1,
+            1,
+            memoryPerEntity,
+            memoryTracker,
+            clock,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            detectorId,
+            checkpointWriteQueue,
+            new Random(42)
+        );
+
+        initialPriority = cacheBuffer.getPriorityTracker().getUpdatedPriority(0);
+
+        modelState1 = new ModelState<>(
+            new EntityModel(entity1, new ArrayDeque<>(), null, null),
+            modelId1,
+            detectorId,
+            ModelType.ENTITY.getName(),
+            clock,
+            0
+        );
+
+        modelState2 = new ModelState<>(
+            new EntityModel(entity2, new ArrayDeque<>(), null, null),
+            modelId2,
+            detectorId,
+            ModelType.ENTITY.getName(),
+            clock,
+            0
+        );
+
+        modelState3 = new ModelState<>(
+            new EntityModel(entity3, new ArrayDeque<>(), null, null),
+            modelId3,
+            detectorId,
+            ModelType.ENTITY.getName(),
+            clock,
+            0
+        );
+
+        modelState4 = new ModelState<>(
+            new EntityModel(entity4, new ArrayDeque<>(), null, null),
+            modelId4,
+            detectorId,
+            ModelType.ENTITY.getName(),
+            clock,
+            0
+        );
+    }
+}

--- a/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
@@ -26,60 +26,22 @@
 
 package org.opensearch.ad.caching;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.ad.MemoryTracker;
-import org.opensearch.ad.ml.CheckpointDao;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
-import org.opensearch.test.OpenSearchTestCase;
 
 import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
 
-public class CacheBufferTests extends OpenSearchTestCase {
-    CacheBuffer cacheBuffer;
-    CheckpointDao checkpointDao;
-    MemoryTracker memoryTracker;
-    Clock clock;
-    String detectorId;
-    float initialPriority;
-    long memoryPerEntity;
-
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-
-        checkpointDao = mock(CheckpointDao.class);
-        memoryTracker = mock(MemoryTracker.class);
-        clock = mock(Clock.class);
-        when(clock.instant()).thenReturn(Instant.now());
-
-        detectorId = "123";
-        memoryPerEntity = 81920;
-
-        cacheBuffer = new CacheBuffer(
-            1,
-            1,
-            checkpointDao,
-            memoryPerEntity,
-            memoryTracker,
-            clock,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            detectorId
-        );
-        initialPriority = cacheBuffer.getPriorityTracker().getUpdatedPriority(0);
-    }
+public class CacheBufferTests extends AbstractCacheTest {
 
     // cache.put(1, 1);
     // cache.put(2, 2);
@@ -92,25 +54,20 @@ public class CacheBufferTests extends OpenSearchTestCase {
     // cache.get(3); // returns 3
     // cache.get(4); // returns 4
     public void testRemovalCandidate() {
-        String modelId1 = "1";
-        String modelId2 = "2";
-        String modelId3 = "3";
-        String modelId4 = "4";
-
-        cacheBuffer.put(modelId1, MLUtil.randomModelState(initialPriority, modelId1));
-        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        cacheBuffer.put(modelId1, modelState1);
+        cacheBuffer.put(modelId2, modelState2);
         assertEquals(modelId1, cacheBuffer.get(modelId1).getModelId());
         Entry<String, Float> removalCandidate = cacheBuffer.getPriorityTracker().getMinimumScaledPriority();
         assertEquals(modelId2, removalCandidate.getKey());
         cacheBuffer.remove();
-        cacheBuffer.put(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        cacheBuffer.put(modelId3, modelState3);
         assertEquals(null, cacheBuffer.get(modelId2));
         assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
         removalCandidate = cacheBuffer.getPriorityTracker().getMinimumScaledPriority();
         assertEquals(modelId1, removalCandidate.getKey());
         cacheBuffer.remove(modelId1);
         assertEquals(null, cacheBuffer.get(modelId1));
-        cacheBuffer.put(modelId4, MLUtil.randomModelState(initialPriority, modelId4));
+        cacheBuffer.put(modelId4, modelState4);
         assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
         assertEquals(modelId4, cacheBuffer.get(modelId4).getModelId());
     }
@@ -121,14 +78,10 @@ public class CacheBufferTests extends OpenSearchTestCase {
     // cache.put(4, 4);
     // cache.get(2) => returns 2
     public void testRemovalCandidate2() throws InterruptedException {
-        String modelId2 = "2";
-        String modelId3 = "3";
-        String modelId4 = "4";
-        float initialPriority = cacheBuffer.getPriorityTracker().getUpdatedPriority(0);
-        cacheBuffer.put(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
-        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
-        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
-        cacheBuffer.put(modelId4, MLUtil.randomModelState(initialPriority, modelId4));
+        cacheBuffer.put(modelId3, modelState3);
+        cacheBuffer.put(modelId2, modelState2);
+        cacheBuffer.put(modelId2, modelState2);
+        cacheBuffer.put(modelId4, modelState4);
         assertTrue(cacheBuffer.getModel(modelId2).isPresent());
 
         ArgumentCaptor<Long> memoryReleased = ArgumentCaptor.forClass(Long.class);
@@ -143,7 +96,7 @@ public class CacheBufferTests extends OpenSearchTestCase {
         assertEquals(3 * memoryPerEntity, capturedMemoryReleased.stream().reduce(0L, (a, b) -> a + b).intValue());
         assertTrue(capturedreserved.get(0));
         assertTrue(!capturedreserved.get(1));
-        assertEquals(MemoryTracker.Origin.MULTI_ENTITY_DETECTOR, capturedOrigin.get(0));
+        assertEquals(MemoryTracker.Origin.HC_DETECTOR, capturedOrigin.get(0));
 
         assertTrue(!cacheBuffer.expired(Duration.ofHours(1)));
     }
@@ -155,13 +108,13 @@ public class CacheBufferTests extends OpenSearchTestCase {
         assertTrue(cacheBuffer.dedicatedCacheAvailable());
         assertTrue(!cacheBuffer.canReplaceWithinDetector(100));
 
-        cacheBuffer.put(modelId1, MLUtil.randomModelState(initialPriority, modelId1));
+        cacheBuffer.put(modelId1, MLUtil.randomModelState(new RandomModelStateConfig.Builder().priority(initialPriority).build()));
         assertTrue(cacheBuffer.canReplaceWithinDetector(100));
         assertTrue(!cacheBuffer.dedicatedCacheAvailable());
         assertTrue(!cacheBuffer.canRemove());
-        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(new RandomModelStateConfig.Builder().priority(initialPriority).build()));
         assertTrue(cacheBuffer.canRemove());
-        cacheBuffer.replace(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        cacheBuffer.replace(modelId3, MLUtil.randomModelState(new RandomModelStateConfig.Builder().priority(initialPriority).build()));
         assertTrue(cacheBuffer.isActive(modelId2));
         assertTrue(cacheBuffer.isActive(modelId3));
         assertEquals(modelId3, cacheBuffer.getPriorityTracker().getHighestPriorityEntityId().get());
@@ -172,9 +125,9 @@ public class CacheBufferTests extends OpenSearchTestCase {
         String modelId1 = "1";
         String modelId2 = "2";
         String modelId3 = "3";
-        cacheBuffer.put(modelId1, MLUtil.randomModelState(initialPriority, modelId1));
-        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
-        cacheBuffer.put(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        cacheBuffer.put(modelId1, MLUtil.randomModelState(new RandomModelStateConfig.Builder().priority(initialPriority).build()));
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(new RandomModelStateConfig.Builder().priority(initialPriority).build()));
+        cacheBuffer.put(modelId3, MLUtil.randomModelState(new RandomModelStateConfig.Builder().priority(initialPriority).build()));
         cacheBuffer.maintenance();
         assertEquals(3, cacheBuffer.getActiveEntities());
         assertEquals(3, cacheBuffer.getAllModels().size());

--- a/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
@@ -135,4 +135,11 @@ public class CacheBufferTests extends AbstractCacheTest {
         cacheBuffer.maintenance();
         assertEquals(0, cacheBuffer.getActiveEntities());
     }
+
+    /**
+     * Test that if we remove a non-existent key, there is no exception
+     */
+    public void testRemovedNull() {
+        assertEquals(null, cacheBuffer.remove("foo"));
+    }
 }


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved. Now the code is missing unit tests. Will add unit tests, run performance tests, and fix bugs before the official release.

### Description
Each detector has its dedicated cache that stores ten entities' states per node. A detector's hottest entities load their states into the dedicated cache. Other detectors cannot use space reserved by a detector's dedicated cache. Previously,  the size of the dedicated cache is not dynamically adjustable by users. This PR creates a dynamic setting AnomalyDetectorSettings.DEDICATED_CACHE_SIZE to make dedicated cache's size flexible. When that setting is changed, if the size decreases, we will release memory if required (e.g., when a user also decreased AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE, the max memory percentage that AD can use); if the size increases, we may reject the setting change if we cannot fulfill that request (e.g., when it will uses more memory than allowed for AD).

This PR also changes the behavior of the PriorityCache.get method. Previously, it will auto-load models if space is available or the external entity’s priority is high enough. Since we have moved the logic of loading models to rate-limited queues, we carry the loading models logic to a separate method and let the callers (i.e., queues) decide how to deal with models. PriorityCache.get will mostly return the existing state and update priority.

Testing done:
* manual testing by increasing/decreasing the setting value
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
