### PR TITLE
Fix nullpointerexception bug

### DIFF
--- a/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
@@ -245,11 +245,11 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
                 memoryTracker.releaseMemory(memoryConsumptionPerEntity, false, Origin.MULTI_ENTITY_DETECTOR);
             }
             checkpointDao.write(valueRemoved, keyToRemove);
-        }
 
-        EntityModel modelRemoved = valueRemoved.getModel();
-        if (modelRemoved != null) {
-            modelRemoved.clear();
+            EntityModel modelRemoved = valueRemoved.getModel();
+            if (modelRemoved != null) {
+                modelRemoved.clear();
+            }
         }
 
         return valueRemoved;

--- a/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
@@ -182,4 +182,11 @@ public class CacheBufferTests extends OpenSearchTestCase {
         cacheBuffer.maintenance();
         assertEquals(0, cacheBuffer.getActiveEntities());
     }
+
+    /**
+     * Test that if we remove a non-existent key, there is no exception
+     */
+    public void testRemovedNull() {
+        assertEquals(null, cacheBuffer.remove("foo"));
+    }
 }


### PR DESCRIPTION
### Description
We cannot invoke "com.amazon.opendistroforelasticsearch.ad.ml.ModelState.getModel()" when "valueRemoved" is null. This PR fixes the bug to guard the getModel call with a null check.

Testing done:
1. added a unit test to reproduce the bug.  
 
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
