### PR TITLE
Only allocate models when circuit breaker is closed

### DIFF
--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -106,7 +106,7 @@ public class ADTaskCacheManager {
         }
         checkRunningTaskLimit();
         long neededCacheSize = calculateADTaskCacheSize(adTask);
-        if (!memoryTracker.canAllocateReserved(adTask.getDetectorId(), neededCacheSize)) {
+        if (!memoryTracker.canAllocateReserved(neededCacheSize)) {
             throw new LimitExceededException("No enough memory to run detector");
         }
         memoryTracker.consumeMemory(neededCacheSize, true, HISTORICAL_SINGLE_ENTITY_DETECTOR);

--- a/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
@@ -28,7 +28,6 @@ package org.opensearch.ad.task;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -88,7 +87,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutTask() throws IOException {
-        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
+        when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(true);
         ADTask adTask = TestHelpers.randomAdTask();
         adTaskCacheManager.add(adTask);
         assertEquals(1, adTaskCacheManager.size());
@@ -104,7 +103,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDuplicateTask() throws IOException {
-        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
+        when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(true);
         ADTask adTask1 = TestHelpers.randomAdTask();
         adTaskCacheManager.add(adTask1);
         assertEquals(1, adTaskCacheManager.size());
@@ -125,7 +124,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutTaskWithMemoryExceedLimit() {
-        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(false);
+        when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(false);
         LimitExceededException exception = expectThrows(
             LimitExceededException.class,
             () -> adTaskCacheManager.add(TestHelpers.randomAdTask())
@@ -134,7 +133,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
     }
 
     public void testThresholdModelTrained() throws IOException {
-        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
+        when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(true);
         ADTask adTask = TestHelpers.randomAdTask();
         adTaskCacheManager.add(adTask);
         assertEquals(1, adTaskCacheManager.size());
@@ -147,7 +146,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
     }
 
     public void testCancel() throws IOException {
-        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
+        when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(true);
         ADTask adTask = TestHelpers.randomAdTask();
         adTaskCacheManager.add(adTask);
         assertEquals(1, adTaskCacheManager.size());
@@ -174,7 +173,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
     }
 
     public void testExceedRunningTaskLimit() throws IOException {
-        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
+        when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(true);
         adTaskCacheManager.add(TestHelpers.randomAdTask());
         adTaskCacheManager.add(TestHelpers.randomAdTask());
         assertEquals(2, adTaskCacheManager.size());


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.  Now the code is missing unit tests.  Will add unit tests, run performance tests, and fix bugs before the official release.

### Description
Previously we may allocate memory when the circuit breaker is open but AD hasn’t used more than 10% of memory yet. This PR disallows any new model creation when the circuit breaker is open, which provides extra safety to prevent OOM.

This PR also differentiates isHostingAllowed and canAllocateReserved. Previously, both of them throw exceptions when allocation is not allowed. But most of the time it is fine to return false and let callers decide what to do if we cannot allocate. isHostingAllowed needs an exception thrown due to the special way the single-stream detector code is written (can be changed). This PR keeps the original exception thrown behavior of isHostingAllowed, but changes canAllocateReserved to return false instead.

Testing done:
1. Tested an open circuit breaker prevented model creation.
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
