### PR TITLE
Add model id in anomaly result.

### DIFF
--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -597,7 +597,8 @@ public class ADBatchTaskRunner {
                     error,
                     null,
                     adTask.getDetector().getUser(),
-                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT)
+                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT),
+                    null
                 );
                 anomalyResults.add(anomalyResult);
             } else {
@@ -638,7 +639,8 @@ public class ADBatchTaskRunner {
                     null,
                     null,
                     adTask.getDetector().getUser(),
-                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT)
+                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT),
+                    null
                 );
                 anomalyResults.add(anomalyResult);
             }

--- a/src/test/java/org/opensearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyResultTests.java
@@ -93,7 +93,8 @@ public class AnomalyResultTests extends OpenSearchSingleNodeTestCase {
             randomAlphaOfLength(5),
             null,
             TestHelpers.randomUser(),
-            CommonValue.NO_SCHEMA_VERSION
+            CommonValue.NO_SCHEMA_VERSION,
+            null
         );
         String detectResultString = TestHelpers
             .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
@@ -131,7 +132,8 @@ public class AnomalyResultTests extends OpenSearchSingleNodeTestCase {
             randomAlphaOfLength(5),
             null,
             null,
-            CommonValue.NO_SCHEMA_VERSION
+            CommonValue.NO_SCHEMA_VERSION,
+            null
         );
         String detectResultString = TestHelpers
             .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.  Now the code is missing unit tests.  Will add unit tests, run performance tests, and fix bugs before the official release.

### Description
The front end needs to query for entities ordered by the descending order of anomaly grades and the number of anomalies. After supporting multi-category fields, it is hard to write such queries since the entity information is stored in a nested object array. Also, the front end has all code/queries/ helper functions in place to rely on a single key per entity combo. This PR adds model id to anomaly result to help the transition to multi-categorical field less painful.

Testing done:
1. Tested HCAD results have model id now.
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
