### PR TITLE
Modify Entity to support multi-category field

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.feature.FeatureManager;
@@ -50,6 +51,7 @@ import org.opensearch.ad.model.EntityAnomalyResult;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
+import org.opensearch.common.util.concurrent.ThreadContext;
 
 /**
  * Runner to trigger an anomaly detector.
@@ -73,11 +75,18 @@ public final class AnomalyDetectorRunner {
      * @param detector  anomaly detector instance
      * @param startTime detection period start time
      * @param endTime   detection period end time
+     * @param context   stored thread context
      * @param listener handle anomaly result
      * @throws IOException - if a user gives wrong query input when defining a detector
      */
-    public void executeDetector(AnomalyDetector detector, Instant startTime, Instant endTime, ActionListener<List<AnomalyResult>> listener)
-        throws IOException {
+    public void executeDetector(
+        AnomalyDetector detector,
+        Instant startTime,
+        Instant endTime,
+        ThreadContext.StoredContext context,
+        ActionListener<List<AnomalyResult>> listener
+    ) throws IOException {
+        context.restore();
         List<String> categoryField = detector.getCategoryField();
         if (categoryField != null && !categoryField.isEmpty()) {
             featureManager.getPreviewEntities(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(entities -> {
@@ -135,6 +144,9 @@ public final class AnomalyDetectorRunner {
         // TODO return exception like IllegalArgumentException to explain data is not enough for preview
         // This also requires front-end change to handle error message correspondingly
         // We return empty list for now to avoid breaking front-end
+        if (e instanceof OpenSearchSecurityException) {
+            listener.onFailure(e);
+        }
         listener.onResponse(Collections.emptyList());
     }
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -96,6 +96,7 @@ public final class AnomalyDetectorRunner {
                     // This also requires front-end change to handle error message correspondingly
                     // We return empty list for now to avoid breaking front-end
                     listener.onResponse(Collections.emptyList());
+                    return;
                 }
                 ActionListener<EntityAnomalyResult> entityAnomalyResultListener = ActionListener
                     .wrap(
@@ -146,6 +147,7 @@ public final class AnomalyDetectorRunner {
         // We return empty list for now to avoid breaking front-end
         if (e instanceof OpenSearchSecurityException) {
             listener.onFailure(e);
+            return;
         }
         listener.onResponse(Collections.emptyList());
     }

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -29,7 +29,6 @@ package org.opensearch.ad;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -111,7 +110,7 @@ public final class AnomalyDetectorRunner {
                             ActionListener.wrap(features -> {
                                 List<ThresholdingResult> entityResults = modelManager.getPreviewResults(features.getProcessedFeatures());
                                 List<AnomalyResult> sampledEntityResults = sample(
-                                    parsePreviewResult(detector, features, entityResults, Arrays.asList(entity)),
+                                    parsePreviewResult(detector, features, entityResults, entity),
                                     maxPreviewResults
                                 );
                                 multiEntitiesResponseListener.onResponse(new EntityAnomalyResult(sampledEntityResults));
@@ -143,7 +142,7 @@ public final class AnomalyDetectorRunner {
         AnomalyDetector detector,
         Features features,
         List<ThresholdingResult> results,
-        List<Entity> entity
+        Entity entity
     ) {
         // unprocessedFeatures[][], each row is for one date range.
         // For example, unprocessedFeatures[0][2] is for the first time range, the third feature

--- a/src/main/java/org/opensearch/ad/feature/FeatureManager.java
+++ b/src/main/java/org/opensearch/ad/feature/FeatureManager.java
@@ -586,13 +586,7 @@ public class FeatureManager implements CleanState {
         ActionListener<Entry<List<Entry<Long, Long>>, double[][]>> listener
     ) throws IOException {
         searchFeatureDao
-            .getColdStartSamplesForPeriods(
-                detector,
-                sampleRanges,
-                entity.getValue(),
-                true,
-                getSamplesRangesListener(sampleRanges, listener)
-            );
+            .getColdStartSamplesForPeriods(detector, sampleRanges, entity, true, getSamplesRangesListener(sampleRanges, listener));
     }
 
     private ActionListener<List<Optional<double[]>>> getSamplesRangesListener(

--- a/src/main/java/org/opensearch/ad/ml/EntityModel.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityModel.java
@@ -26,26 +26,34 @@
 
 package org.opensearch.ad.ml;
 
+import java.util.Optional;
 import java.util.Queue;
+
+import org.opensearch.ad.model.Entity;
 
 import com.amazon.randomcutforest.RandomCutForest;
 
 public class EntityModel {
-    private String modelId;
+    private Entity entity;
     // TODO: sample should record timestamp
     private Queue<double[]> samples;
     private RandomCutForest rcf;
     private ThresholdingModel threshold;
 
-    public EntityModel(String modelId, Queue<double[]> samples, RandomCutForest rcf, ThresholdingModel threshold) {
-        this.modelId = modelId;
+    public EntityModel(Entity entity, Queue<double[]> samples, RandomCutForest rcf, ThresholdingModel threshold) {
+        this.entity = entity;
         this.samples = samples;
         this.rcf = rcf;
         this.threshold = threshold;
     }
 
-    public String getModelId() {
-        return this.modelId;
+    /**
+     * In old checkpoint mapping, we don't have entity. It's fine we are missing
+     * entity as it is mostly used for debugging.
+     * @return entity
+     */
+    public Optional<Entity> getEntity() {
+        return Optional.ofNullable(entity);
     }
 
     public Queue<double[]> getSamples() {

--- a/src/main/java/org/opensearch/ad/model/Entity.java
+++ b/src/main/java/org/opensearch/ad/model/Entity.java
@@ -29,66 +29,146 @@ package org.opensearch.ad.model;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.opensearch.ad.annotation.Generated;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.common.Numbers;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.hash.MurmurHash3;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentParser.Token;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.index.query.TermQueryBuilder;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 
 /**
  * Categorical field name and its value
- * @author kaituo
  *
  */
 public class Entity implements ToXContentObject, Writeable {
-    public static final String ENTITY_NAME_FIELD = "name";
-    public static final String ENTITY_VALUE_FIELD = "value";
+    private static final Logger LOG = LogManager.getLogger(Entity.class);
 
-    private final String name;
-    private final String value;
+    private static final long RANDOM_SEED = 42;
+    private static final String MODEL_ID_INFIX = "_entity_";
 
-    public Entity(String name, String value) {
-        this.name = name;
-        this.value = value;
+    public static final String ATTRIBUTE_NAME_FIELD = "name";
+    public static final String ATTRIBUTE_VALUE_FIELD = "value";
+
+    // model id
+    private SetOnce<String> modelId = new SetOnce<>();
+    // a map from attribute name like "host" to its value like "server_1"
+    // Use SortedMap so that the attributes are ordered and we can derive the unique
+    // string representation used in the hash ring.
+    private final SortedMap<String, String> attributes;
+
+    /**
+     * Create an entity that has multiple attributes
+     * @param detectorId Detector Id
+     * @param attrs what we parsed from query output as a map of attribute and its values.
+     * @return the created entity
+     */
+    public static Entity createEntityByReordering(String detectorId, Map<String, Object> attrs) {
+        SortedMap<String, String> sortedMap = new TreeMap<>();
+        for (Map.Entry<String, Object> categoryValuePair : attrs.entrySet()) {
+            sortedMap.put(categoryValuePair.getKey(), categoryValuePair.getValue().toString());
+        }
+        return new Entity(sortedMap);
+    }
+
+    /**
+     * Create an entity that has only one attribute
+     * @param detectorId Detector Id
+     * @param attributeName the attribute's name
+     * @param attributeVal the attribute's value
+     * @return the created entity
+     */
+    public static Entity createSingleAttributeEntity(String detectorId, String attributeName, String attributeVal) {
+        SortedMap<String, String> sortedMap = new TreeMap<>();
+        sortedMap.put(attributeName, attributeVal);
+        return new Entity(sortedMap);
+    }
+
+    /**
+     * Create an entity from ordered attributes based on attribute names
+     * @param detectorId Detector Id
+     * @param attrs attribute map
+     * @return the created entity
+     */
+    public static Entity createEntityFromOrderedMap(String detectorId, SortedMap<String, String> attrs) {
+        return new Entity(attrs);
+    }
+
+    private Entity(SortedMap<String, String> orderedAttrs) {
+        this.attributes = orderedAttrs;
     }
 
     public Entity(StreamInput input) throws IOException {
-        this.name = input.readString();
-        this.value = input.readString();
+        this.attributes = new TreeMap<>(input.readMap(StreamInput::readString, StreamInput::readString));
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        XContentBuilder xContentBuilder = builder.startObject().field(ENTITY_NAME_FIELD, name).field(ENTITY_VALUE_FIELD, value);
-        return xContentBuilder.endObject();
+        builder.startArray();
+        for (Map.Entry<String, String> attr : attributes.entrySet()) {
+            builder.startObject().field(ATTRIBUTE_NAME_FIELD, attr.getKey()).field(ATTRIBUTE_VALUE_FIELD, attr.getValue()).endObject();
+        }
+        builder.endArray();
+        return builder;
     }
 
     public static Entity parse(XContentParser parser) throws IOException {
+        SortedMap<String, String> entities = new TreeMap<>();
         String parsedValue = null;
         String parsedName = null;
 
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            String fieldName = parser.currentName();
-            parser.nextToken();
-
-            switch (fieldName) {
-                case ENTITY_NAME_FIELD:
-                    parsedName = parser.text();
-                    break;
-                case ENTITY_VALUE_FIELD:
-                    parsedValue = parser.text();
-                    break;
-                default:
-                    break;
+        ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+            while (parser.nextToken() != Token.END_OBJECT) {
+                String fieldName = parser.currentName();
+                // move to the field value
+                parser.nextToken();
+                switch (fieldName) {
+                    case ATTRIBUTE_NAME_FIELD:
+                        parsedName = parser.text();
+                        break;
+                    case ATTRIBUTE_VALUE_FIELD:
+                        parsedValue = parser.text();
+                        if (parsedName != null && parsedValue != null) {
+                            entities.put(parsedName, parsedValue);
+                        }
+                        parsedValue = null;
+                        parsedName = null;
+                        break;
+                    default:
+                        break;
+                }
             }
         }
-        return new Entity(parsedName, parsedValue);
+        return new Entity(entities);
     }
 
     @Generated
@@ -99,28 +179,205 @@ public class Entity implements ToXContentObject, Writeable {
         if (o == null || getClass() != o.getClass())
             return false;
         Entity that = (Entity) o;
-        return Objects.equal(getName(), that.getName()) && Objects.equal(getValue(), that.getValue());
+        return Objects.equal(attributes, that.attributes);
     }
 
     @Generated
     @Override
     public int hashCode() {
-        return Objects.hashCode(getName(), getValue());
-    }
-
-    @Generated
-    public String getName() {
-        return name;
-    }
-
-    @Generated
-    public String getValue() {
-        return value;
+        return Objects.hashCode(attributes);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(name);
-        out.writeString(value);
+        out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("attributes", normalizedAttributes(attributes)).append("modelId", modelId.get()).toString();
+    }
+
+    /**
+    * Return a string of the attributes in the ascending order of attribute names
+    * @return a normalized String corresponding to the Map.  The string is
+    *  deterministic (i.e., no matter in what order we insert values,
+    *  the returned the string is the same).  This is to ensure keys with the
+    *  same content mapped to the same node in our hash ring.
+    *
+    */
+    private static String normalizedAttributes(SortedMap<String, String> attributes) {
+        return Joiner.on(",").withKeyValueSeparator("=").join(attributes);
+    }
+
+    /**
+    * Create model Id out of detector Id and attribute name and value pairs
+    *
+    * HCAD v1 uses the categorical value as part of the model document Id, but
+    *  OpenSearch’s document Id can be at most 512 bytes. Categorical values are
+    *  usually less than 256 characters, but can grow to 32766 in theory.
+    *  HCAD v1 skips an entity if the entity's name is more than 256 characters.
+    *  We cannot do that in v2 as that can reject a lot of entities. To overcome
+    *  the obstacle, we hash categorical values to a 128-bit string (like SHA-1
+    *  that git uses) and use the hash as part of the model document Id.
+    *
+    * We have choices to make regarding when to use the hash as part of a model
+    * document Id: for all HC detectors or a HC detector with multiple categorical
+    * fields. The challenge lies in providing backward compatibility of looking for
+    * a model checkpoint in the case of a HC detector with one categorical field.
+    * If using hashes for all HC detectors, we need two get requests to ensure that
+    * a model checkpoint exists. One uses the document Id without a hash, while one
+    * uses the document Id with a hash. The dual get requests are ineffective. If
+    * limiting hashes to a HC detector with multiple categorical fields, there is
+    * no backward compatibility issue. However, the code will be branchy. One may
+    * wonder if backward compatibility can be ignored; indeed, the old checkpoints
+    * will be gone after a transition period during upgrading. During the transition
+    * period, HC detectors can experience unnecessary cold starts as if the
+    * detectors were just started. Checkpoint index size can double if every model
+    * has two model documents. The transition period can be as long as 3 days since
+    * our checkpoint retention period is 3 days. There is no perfect solution. We
+    * prefer limiting hashes to an HC detector with multiple categorical fields as
+    * its customer impact is none.
+    *
+    * @param detectorId Detector Id
+    * @param attributes Attributes of an entity
+    * @return the model Id
+    */
+    public static Optional<String> getModelId(String detectorId, SortedMap<String, String> attributes) {
+        if (attributes.isEmpty()) {
+            return Optional.empty();
+        } else if (attributes.size() == 1) {
+            for (Map.Entry<String, String> categoryValuePair : attributes.entrySet()) {
+                // For OpenSearch, the limit of the document ID is 512 bytes.
+                // skip an entity if the entity's name is more than 256 characters
+                // since we are using it as part of document id.
+                String categoricalValue = categoryValuePair.getValue().toString();
+                if (categoricalValue.length() > AnomalyDetectorSettings.MAX_ENTITY_LENGTH) {
+                    return Optional.empty();
+                }
+                return Optional.of(detectorId + MODEL_ID_INFIX + categoricalValue);
+            }
+            return Optional.empty();
+        } else {
+            String normalizedFields = normalizedAttributes(attributes);
+            MurmurHash3.Hash128 hashFunc = MurmurHash3
+                .hash128(
+                    normalizedFields.getBytes(StandardCharsets.UTF_8),
+                    0,
+                    normalizedFields.length(),
+                    RANDOM_SEED,
+                    new MurmurHash3.Hash128()
+                );
+            // 16 bytes = 128 bits
+            byte[] bytes = new byte[16];
+            System.arraycopy(Numbers.longToBytes(hashFunc.h1), 0, bytes, 0, 8);
+            System.arraycopy(Numbers.longToBytes(hashFunc.h2), 0, bytes, 8, 8);
+            // Some bytes like 10 in ascii is corrupted in some systems. Base64 ensures we use safe bytes: https://tinyurl.com/mxmrhmhf
+            return Optional.of(detectorId + MODEL_ID_INFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes));
+        }
+    }
+
+    /**
+     * Get the cached model Id if present. Or recompute one if missing.
+     *
+     * @param detectorId Detector Id.  Used as part of model Id.
+     * @return Model Id.  Can be missing (e.g., the field value is too long for single-category detector)
+     */
+    public Optional<String> getModelId(String detectorId) {
+        if (modelId.get() == null) {
+            // computing model id is not cheap and the result is deterministic. We only do it once.
+            Optional<String> computedModelId = Entity.getModelId(detectorId, attributes);
+            if (computedModelId.isPresent()) {
+                this.modelId.set(computedModelId.get());
+            } else {
+                this.modelId.set(null);
+            }
+        }
+        return Optional.ofNullable(modelId.get());
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    /**
+     * Generate multi-term query filter like
+     * GET /company/_search
+        {
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "term": {
+                    "ip": "1.2.3.4"
+                  }
+                },
+                {
+                  "term": {
+                    "name.keyword": "Kaituo"
+                  }
+                }
+              ]
+            }
+          }
+        }
+     *
+     *@return a list of term query builder
+     */
+    public List<TermQueryBuilder> getTermQueryBuilders() {
+        List<TermQueryBuilder> res = new ArrayList<>();
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            res.add(new TermQueryBuilder(attribute.getKey(), attribute.getValue()));
+        }
+        return res;
+    }
+
+    public List<TermQueryBuilder> getTermQueryBuilders(String pathPrefix) {
+        List<TermQueryBuilder> res = new ArrayList<>();
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            res.add(new TermQueryBuilder(pathPrefix + attribute.getKey(), attribute.getValue()));
+        }
+        return res;
+    }
+
+    /**
+     * From json to Entity instance
+     * @param entityValue json array consisting attributes
+     * @return Entity instance
+     * @throws IOException when there is an deserialization issue.
+     */
+    public static Entity fromJsonArray(Object entityValue) throws IOException {
+        XContentBuilder content = JsonXContent.contentBuilder();
+        content.startObject();
+        content.field(CommonName.ENTITY_KEY, entityValue);
+        content.endObject();
+
+        try (
+            InputStream stream = BytesReference.bytes(content).streamInput();
+            XContentParser parser = JsonXContent.jsonXContent
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)
+        ) {
+            // move to content.StartObject
+            parser.nextToken();
+            // move to CommonName.ENTITY_KEY
+            parser.nextToken();
+            // move to start of the array
+            parser.nextToken();
+            return Entity.parse(parser);
+        }
+    }
+
+    public static Optional<Entity> fromJsonObject(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            if (false == CommonName.ENTITY_KEY.equals(parser.currentName())) {
+                // not an object with "entity" as the root key
+                return Optional.empty();
+            }
+            // move to start of the array
+            parser.nextToken();
+            return Optional.of(Entity.parse(parser));
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/opensearch/ad/model/Entity.java
+++ b/src/main/java/org/opensearch/ad/model/Entity.java
@@ -129,6 +129,14 @@ public class Entity implements ToXContentObject, Writeable {
         this.attributes = new TreeMap<>(input.readMap(StreamInput::readString, StreamInput::readString));
     }
 
+    /**
+     * Formatter when serializing to json.  Used in cases when saving anomaly result for HCAD.
+     * The order is Alphabetical sorting (the one used by JDK to compare Strings).
+     * Example:
+     *  z0
+     *  z11
+     *  z2
+     */
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray();
@@ -157,14 +165,15 @@ public class Entity implements ToXContentObject, Writeable {
                         break;
                     case ATTRIBUTE_VALUE_FIELD:
                         parsedValue = parser.text();
-                        if (parsedName != null && parsedValue != null) {
-                            entities.put(parsedName, parsedValue);
-                        }
-                        parsedValue = null;
-                        parsedName = null;
                         break;
                     default:
                         break;
+                }
+                // reset every time I have seen a name-value pair.
+                if (parsedName != null && parsedValue != null) {
+                    entities.put(parsedName, parsedValue);
+                    parsedValue = null;
+                    parsedName = null;
                 }
             }
         }

--- a/src/main/java/org/opensearch/ad/model/Entity.java
+++ b/src/main/java/org/opensearch/ad/model/Entity.java
@@ -169,12 +169,12 @@ public class Entity implements ToXContentObject, Writeable {
                     default:
                         break;
                 }
-                // reset every time I have seen a name-value pair.
-                if (parsedName != null && parsedValue != null) {
-                    entities.put(parsedName, parsedValue);
-                    parsedValue = null;
-                    parsedName = null;
-                }
+            }
+            // reset every time I have seen a name-value pair.
+            if (parsedName != null && parsedValue != null) {
+                entities.put(parsedName, parsedValue);
+                parsedValue = null;
+                parsedName = null;
             }
         }
         return new Entity(entities);

--- a/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
@@ -32,10 +32,13 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
-import org.opensearch.ad.constant.CommonMessageAttributes;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -43,21 +46,22 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 
 public class EntityResultRequest extends ActionRequest implements ToXContentObject {
+    private static final Logger LOG = LogManager.getLogger(EntityResultRequest.class);
 
     private String detectorId;
-    private Map<String, double[]> entities;
+    private Map<Entity, double[]> entities;
     private long start;
     private long end;
 
     public EntityResultRequest(StreamInput in) throws IOException {
         super(in);
         this.detectorId = in.readString();
-        this.entities = in.readMap(StreamInput::readString, StreamInput::readDoubleArray);
+        this.entities = in.readMap(Entity::new, StreamInput::readDoubleArray);
         this.start = in.readLong();
         this.end = in.readLong();
     }
 
-    public EntityResultRequest(String detectorId, Map<String, double[]> entities, long start, long end) {
+    public EntityResultRequest(String detectorId, Map<Entity, double[]> entities, long start, long end) {
         super();
         this.detectorId = detectorId;
         this.entities = entities;
@@ -69,7 +73,7 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
         return this.detectorId;
     }
 
-    public Map<String, double[]> getEntities() {
+    public Map<Entity, double[]> getEntities() {
         return this.entities;
     }
 
@@ -85,7 +89,7 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(this.detectorId);
-        out.writeMap(this.entities, StreamOutput::writeString, StreamOutput::writeDoubleArray);
+        out.writeMap(entities, (s, e) -> e.writeTo(s), StreamOutput::writeDoubleArray);
         out.writeLong(this.start);
         out.writeLong(this.end);
     }
@@ -108,12 +112,19 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(CommonMessageAttributes.ID_JSON_KEY, detectorId);
-        builder.field(CommonMessageAttributes.START_JSON_KEY, start);
-        builder.field(CommonMessageAttributes.END_JSON_KEY, end);
-        for (String entity : entities.keySet()) {
-            builder.field(entity, entities.get(entity));
+        builder.field(CommonName.ID_JSON_KEY, detectorId);
+        builder.field(CommonName.START_JSON_KEY, start);
+        builder.field(CommonName.END_JSON_KEY, end);
+        builder.startArray(CommonName.ENTITIES_JSON_KEY);
+        for (final Map.Entry<Entity, double[]> entry : entities.entrySet()) {
+            if (entry.getKey() != null) {
+                builder.startObject();
+                builder.field(CommonName.ENTITY_KEY, entry.getKey());
+                builder.field(CommonName.VALUE_JSON_KEY, entry.getValue());
+                builder.endObject();
+            }
         }
+        builder.endArray();
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorRequest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 
@@ -42,7 +43,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
     private String typeStr;
     private String rawPath;
     private boolean all;
-    private String entityValue;
+    private Entity entityValue;
 
     public GetAnomalyDetectorRequest(StreamInput in) throws IOException {
         super(in);
@@ -54,7 +55,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         rawPath = in.readString();
         all = in.readBoolean();
         if (in.readBoolean()) {
-            entityValue = in.readString();
+            entityValue = new Entity(in);
         }
     }
 
@@ -66,7 +67,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         String typeStr,
         String rawPath,
         boolean all,
-        String entityValue
+        Entity entityValue
     ) {
         super();
         this.detectorID = detectorID;
@@ -107,7 +108,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         return all;
     }
 
-    public String getEntityValue() {
+    public Entity getEntityValue() {
         return entityValue;
     }
 
@@ -123,7 +124,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         out.writeBoolean(all);
         if (this.entityValue != null) {
             out.writeBoolean(true);
-            out.writeString(entityValue);
+            entityValue.writeTo(out);
         } else {
             out.writeBoolean(false);
         }

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorRequest.java
@@ -43,7 +43,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
     private String typeStr;
     private String rawPath;
     private boolean all;
-    private Entity entityValue;
+    private Entity entity;
 
     public GetAnomalyDetectorRequest(StreamInput in) throws IOException {
         super(in);
@@ -55,7 +55,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         rawPath = in.readString();
         all = in.readBoolean();
         if (in.readBoolean()) {
-            entityValue = new Entity(in);
+            entity = new Entity(in);
         }
     }
 
@@ -67,7 +67,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         String typeStr,
         String rawPath,
         boolean all,
-        Entity entityValue
+        Entity entity
     ) {
         super();
         this.detectorID = detectorID;
@@ -77,7 +77,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         this.typeStr = typeStr;
         this.rawPath = rawPath;
         this.all = all;
-        this.entityValue = entityValue;
+        this.entity = entity;
     }
 
     public String getDetectorID() {
@@ -108,8 +108,8 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         return all;
     }
 
-    public Entity getEntityValue() {
-        return entityValue;
+    public Entity getEntity() {
+        return entity;
     }
 
     @Override
@@ -122,9 +122,9 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         out.writeString(typeStr);
         out.writeString(rawPath);
         out.writeBoolean(all);
-        if (this.entityValue != null) {
+        if (this.entity != null) {
             out.writeBoolean(true);
-            entityValue.writeTo(out);
+            entity.writeTo(out);
         } else {
             out.writeBoolean(false);
         }

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -160,14 +160,14 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         String detectorID = request.getDetectorID();
         String typesStr = request.getTypeStr();
         String rawPath = request.getRawPath();
-        Entity entityValue = request.getEntityValue();
+        Entity entity = request.getEntity();
         boolean all = request.isAll();
         boolean returnJob = request.isReturnJob();
         boolean returnTask = request.isReturnTask();
 
         try {
             if (!Strings.isEmpty(typesStr) || rawPath.endsWith(PROFILE) || rawPath.endsWith(PROFILE + "/")) {
-                if (entityValue != null) {
+                if (entity != null) {
                     Set<EntityProfileName> entityProfilesToCollect = getEntityProfilesToCollect(typesStr, all);
                     EntityProfileRunner profileRunner = new EntityProfileRunner(
                         client,
@@ -177,7 +177,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                     profileRunner
                         .profile(
                             detectorID,
-                            entityValue,
+                            entity,
                             entityProfilesToCollect,
                             ActionListener
                                 .wrap(

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -59,6 +59,7 @@ import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.DetectorProfile;
 import org.opensearch.ad.model.DetectorProfileName;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
@@ -159,7 +160,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         String detectorID = request.getDetectorID();
         String typesStr = request.getTypeStr();
         String rawPath = request.getRawPath();
-        String entityValue = request.getEntityValue();
+        Entity entityValue = request.getEntityValue();
         boolean all = request.isAll();
         boolean returnJob = request.isReturnJob();
         boolean returnTask = request.isReturnTask();

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -56,6 +56,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
@@ -392,12 +393,15 @@ public final class ParseUtils {
     public static SearchSourceBuilder generateEntityColdStartQuery(
         AnomalyDetector detector,
         List<Entry<Long, Long>> ranges,
-        String entityName,
+        Entity entity,
         NamedXContentRegistry xContentRegistry
     ) throws IOException {
 
-        TermQueryBuilder term = new TermQueryBuilder(detector.getCategoryField().get(0), entityName);
-        BoolQueryBuilder internalFilterQuery = QueryBuilders.boolQuery().filter(detector.getFilterQuery()).filter(term);
+        BoolQueryBuilder internalFilterQuery = QueryBuilders.boolQuery().filter(detector.getFilterQuery());
+
+        for (TermQueryBuilder term : entity.getTermQueryBuilders()) {
+            internalFilterQuery.filter(term);
+        }
 
         DateRangeAggregationBuilder dateRangeBuilder = dateRange("date_range").field(detector.getTimeField()).format("epoch_millis");
         for (Entry<Long, Long> range : ranges) {

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -444,6 +444,29 @@ public class TestHelpers {
         );
     }
 
+    public static AnomalyDetector randomAnomalyDetectorWithInterval(TimeConfiguration interval, boolean hcDetector, boolean featureEnabled)
+        throws IOException {
+        List<String> categoryField = hcDetector ? ImmutableList.of(randomAlphaOfLength(5)) : null;
+        return new AnomalyDetector(
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomAlphaOfLength(20),
+            randomAlphaOfLength(30),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+            ImmutableList.of(randomFeature(featureEnabled)),
+            randomQuery(),
+            interval,
+            randomIntervalTimeConfiguration(),
+            randomIntBetween(1, 2000),
+            null,
+            randomInt(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            categoryField,
+            randomUser()
+        );
+    }
+
     public static SearchSourceBuilder randomFeatureQuery() throws IOException {
         String query = "{\"query\":{\"match\":{\"user\":{\"query\":\"kimchy\",\"operator\":\"OR\",\"prefix_length\":0,"
             + "\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\","
@@ -621,11 +644,11 @@ public class TestHelpers {
         );
     }
 
-    public static AnomalyResult randomMultiEntityAnomalyDetectResult(double score, double grade) {
-        return randomMutlEntityAnomalyDetectResult(score, grade, null);
+    public static AnomalyResult randomHCADAnomalyDetectResult(double score, double grade) {
+        return randomHCADAnomalyDetectResult(score, grade, null);
     }
 
-    public static AnomalyResult randomMutlEntityAnomalyDetectResult(double score, double grade, String error) {
+    public static AnomalyResult randomHCADAnomalyDetectResult(double score, double grade, String error) {
         return new AnomalyResult(
             randomAlphaOfLength(5),
             score,

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -616,7 +616,8 @@ public class TestHelpers {
             error,
             null,
             user,
-            CommonValue.NO_SCHEMA_VERSION
+            CommonValue.NO_SCHEMA_VERSION,
+            null
         );
     }
 
@@ -636,7 +637,7 @@ public class TestHelpers {
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             error,
-            Arrays.asList(new Entity(randomAlphaOfLength(5), randomAlphaOfLength(5))),
+            Entity.createSingleAttributeEntity(randomAlphaOfLength(5), randomAlphaOfLength(5), randomAlphaOfLength(5)),
             randomUser(),
             CommonValue.NO_SCHEMA_VERSION
         );

--- a/src/test/java/org/opensearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/org/opensearch/ad/feature/FeatureManagerTests.java
@@ -119,6 +119,8 @@ public class FeatureManagerTests {
 
     private FeatureManager featureManager;
 
+    private String detectorId;
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -134,7 +136,8 @@ public class FeatureManagerTests {
         maxPreviewSamples = 2;
         featureBufferTtl = Duration.ofMillis(1_000L);
 
-        when(detector.getDetectorId()).thenReturn("id");
+        detectorId = "id";
+        when(detector.getDetectorId()).thenReturn(detectorId);
         when(detector.getShingleSize()).thenReturn(shingleSize);
         IntervalTimeConfiguration detectorIntervalTimeConfig = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);
         intervalInMilliseconds = detectorIntervalTimeConfig.toDuration().toMillis();
@@ -524,7 +527,7 @@ public class FeatureManagerTests {
     public void getPreviewFeatureForEntity() throws IOException {
         long start = 0L;
         long end = 240_000L;
-        Entity entity = new Entity("fieldName", "value");
+        Entity entity = Entity.createSingleAttributeEntity(detectorId, "fieldName", "value");
 
         List<Optional<double[]>> coldStartSamples = new ArrayList<>();
         coldStartSamples.add(Optional.of(new double[] { 10.0 }));
@@ -552,7 +555,7 @@ public class FeatureManagerTests {
     public void getPreviewFeatureForEntity_noDataToPreview() throws IOException {
         long start = 0L;
         long end = 240_000L;
-        Entity entity = new Entity("fieldName", "value");
+        Entity entity = Entity.createSingleAttributeEntity(detectorId, "fieldName", "value");
 
         doAnswer(invocation -> {
             ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
@@ -572,8 +575,8 @@ public class FeatureManagerTests {
         long start = 0L;
         long end = 240_000L;
 
-        Entity entity1 = new Entity("fieldName", "value1");
-        Entity entity2 = new Entity("fieldName", "value2");
+        Entity entity1 = Entity.createSingleAttributeEntity(detectorId, "fieldName", "value1");
+        Entity entity2 = Entity.createSingleAttributeEntity(detectorId, "fieldName", "value2");
         List<Entity> entities = asList(entity1, entity2);
         doAnswer(invocation -> {
             ActionListener<List<Entity>> listener = invocation.getArgument(3);

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
@@ -47,6 +47,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
@@ -66,10 +67,12 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
     private GetAnomalyDetectorRequest request;
     private String detectorId = "yecrdnUBqurvo9uKU_d8";
     private String entityValue = "app_0";
+    private String categoryField = "categoryField";
     private String typeStr;
     private String rawPath;
     private PlainActionFuture<GetAnomalyDetectorResponse> future;
     private ADTaskManager adTaskManager;
+    private Entity entity;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -120,6 +123,8 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
             xContentRegistry(),
             adTaskManager
         );
+
+        entity = Entity.createSingleAttributeEntity(detectorId, categoryField, entityValue);
     }
 
     public void testInvalidRequest() throws IOException {
@@ -127,7 +132,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         rawPath = "_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile";
 
-        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, false, typeStr, rawPath, false, entityValue);
+        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, false, typeStr, rawPath, false, entity);
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);
@@ -152,7 +157,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         rawPath = "_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile";
 
-        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, false, typeStr, rawPath, false, entityValue);
+        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, false, typeStr, rawPath, false, entity);
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -177,7 +177,7 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
         request.writeTo(out);
         StreamInput input = out.bytes().streamInput();
         GetAnomalyDetectorRequest newRequest = new GetAnomalyDetectorRequest(input);
-        Assert.assertNull(newRequest.getEntityValue());
+        Assert.assertNull(newRequest.getEntity());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -43,10 +43,13 @@ import org.mockito.Mockito;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfile;
+import org.opensearch.ad.model.InitProgressProfile;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
@@ -68,10 +71,14 @@ import org.opensearch.transport.TransportService;
 import com.google.common.collect.ImmutableMap;
 
 public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNodeTestCase {
+
     private GetAnomalyDetectorTransportAction action;
     private Task task;
     private ActionListener<GetAnomalyDetectorResponse> response;
     private ADTaskManager adTaskManager;
+    private Entity entity;
+    private String categoryField;
+    private String categoryValue;
 
     @Override
     @Before
@@ -105,6 +112,9 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
             @Override
             public void onFailure(Exception e) {}
         };
+        categoryField = "catField";
+        categoryValue = "app-0";
+        entity = Entity.createSingleAttributeEntity("detectorId", categoryField, categoryValue);
     }
 
     @Override
@@ -150,7 +160,7 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
 
     @Test
     public void testGetAnomalyDetectorRequest() throws IOException {
-        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest("1234", 4321, true, false, "", "abcd", false, "value");
+        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest("1234", 4321, true, false, "", "abcd", false, entity);
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         StreamInput input = out.bytes().streamInput();
@@ -203,12 +213,14 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
         Assert.assertEquals(map1.get("name"), detector.getName());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testGetAnomalyDetectorProfileResponse() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
         AnomalyDetectorJob adJob = TestHelpers.randomAnomalyDetectorJob();
-        EntityProfile entityProfile = new EntityProfile.Builder("catField", "app-0").build();
+        InitProgressProfile initProgress = new InitProgressProfile("99%", 2L, 2);
+        EntityProfile entityProfile = new EntityProfile.Builder().initProgress(initProgress).build();
         GetAnomalyDetectorResponse response = new GetAnomalyDetectorResponse(
             4321,
             "1234",
@@ -230,8 +242,19 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
         XContentBuilder builder = TestHelpers.builder();
         Assert.assertNotNull(newResponse.toXContent(builder, ToXContent.EMPTY_PARAMS));
 
+        // {init_progress={percentage=99%, estimated_minutes_left=2, needed_shingles=2}}
         Map<String, Object> map = TestHelpers.XContentBuilderToMap(builder);
-        Assert.assertEquals(map.get(EntityProfile.CATEGORY_FIELD), "catField");
-        Assert.assertEquals(map.get(EntityProfile.ENTITY_VALUE), "app-0");
+        Map<String, Object> parsedInitProgress = (Map<String, Object>) (map.get(CommonName.INIT_PROGRESS));
+        Assert.assertEquals(initProgress.getPercentage(), parsedInitProgress.get(InitProgressProfile.PERCENTAGE).toString());
+        Assert
+            .assertEquals(
+                String.valueOf(initProgress.getEstimatedMinutesLeft()),
+                parsedInitProgress.get(InitProgressProfile.ESTIMATED_MINUTES_LEFT).toString()
+            );
+        Assert
+            .assertEquals(
+                String.valueOf(initProgress.getNeededDataPoints()),
+                parsedInitProgress.get(InitProgressProfile.NEEDED_SHINGLES).toString()
+            );
     }
 }


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved. Now the code is missing unit tests. Will add unit tests, run performance tests, and fix bugs before the official release.

### Description
This PR modified Entity to include multiple categorical fields.  One key change is to not use categorical values directly in the model document Id. The problem is that HCAD v1 uses the categorical value as part of the model document Id, but ES’s document Id can be at most 512 bytes. Categorical values are usually less than 256 characters, but can grow to 32766 in theory. HCAD v1 skips an entity if the entity's name is more than 256 characters. We cannot do that in v2 as that can reject a lot of entities. To overcome the obstacle, we hash categorical values to a 128-bit string (like SHA-1 that git uses) and use the hash as part of the model document Id.

We have choices to make regarding when to use the hash as part of a model document Id: for all HC detectors or a HC detector with multiple categorical fields. The challenge lies in providing backward compatibility of looking for a model checkpoint in the case of a HC detector with one categorical field. If using hashes for all HC detectors, we need two get requests to ensure that a model checkpoint exists. One uses the document Id without a hash, while one uses the document Id with a hash. The dual get requests are ineffective. If limiting hashes to a HC detector with multiple categorical fields, there is no backward compatibility issue. However, the code will be branchy. One may wonder if backward compatibility can be ignored; indeed, the old checkpoints will be gone after a transition period during upgrading. During the transition period, HC detectors can experience unnecessary cold starts as if the detectors were just started. Checkpoint index size can double if every model has two model documents. The transition period can be as long as 3 days since our checkpoint retention period is 3 days. There is no perfect solution. We prefer limiting hashes to an HC detector with multiple categorical fields as its customer impact is none.

Testing done:
1. Manually tested the model id of multi-category entity works, and the single-category entity does not break.
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
