### PR TITLE
Make profile and stats API compatible with multi-category field.

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -74,7 +74,6 @@ import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParseException;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHits;
@@ -250,7 +249,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 onGetDetectorForPrepare(listener, profilesToCollect);
             }
         }, exception -> {
-            if (exception instanceof IndexNotFoundException) {
+            if (ExceptionUtil.isIndexNotAvailable(exception)) {
                 logger.info(exception.getMessage());
                 onGetDetectorForPrepare(listener, profilesToCollect);
             } else {
@@ -364,7 +363,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 listener.onResponse(profileBuilder.build());
             }
         }, exception -> {
-            if (exception instanceof IndexNotFoundException) {
+            if (ExceptionUtil.isIndexNotAvailable(exception)) {
                 // detector state index is not created yet
                 listener.onResponse(new DetectorProfile.Builder().build());
             } else {
@@ -482,7 +481,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 listener.onResponse(profileBuilder.build());
             }
         }, exception -> {
-            if (exception instanceof IndexNotFoundException) {
+            if (ExceptionUtil.isIndexNotAvailable(exception)) {
                 // anomaly result index is not created yet
                 processInitResponse(detector, profilesToCollect, totalUpdates, false, profileBuilder, listener);
             } else {
@@ -525,7 +524,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
             Exception causeException = (Exception) cause;
             if (ExceptionUtil
                 .isException(causeException, ResourceNotFoundException.class, ExceptionUtil.RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE)
-                || (causeException instanceof IndexNotFoundException
+                || (ExceptionUtil.isIndexNotAvailable(causeException)
                     && causeException.getMessage().contains(CommonName.CHECKPOINT_INDEX_NAME))) {
                 // cannot find checkpoint
                 // We don't want to show the estimated time remaining to initialize

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -137,6 +137,12 @@ public class EntityProfileRunner extends AbstractProfileRunner {
 
     /**
      * Verify if the input entity exists or not in case of typos.
+     *
+     * If a user deletes the entity after job start, then we will not be able to
+     * get this entity in the index. For this case, we will not return a profile
+     * for this entity even if it's running on some data node. the entity's model
+     * will be deleted by another entity or by maintenance due to long inactivity.
+     *
      * @param entity Entity accessor
      * @param categoryFields category fields defined for a detector
      * @param detectorId Detector Id

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -135,6 +135,15 @@ public class EntityProfileRunner extends AbstractProfileRunner {
         }, listener::onFailure));
     }
 
+    /**
+     * Verify if the input entity exists or not in case of typos.
+     * @param entity Entity accessor
+     * @param categoryFields category fields defined for a detector
+     * @param detectorId Detector Id
+     * @param profilesToCollect Profile to collect from the input
+     * @param detector Detector config accessor
+     * @param listener Callback to send responses.
+     */
     private void validateEntity(
         Entity entity,
         List<String> categoryFields,

--- a/src/main/java/org/opensearch/ad/ml/ModelState.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelState.java
@@ -33,19 +33,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.opensearch.ad.ExpiringState;
+import org.opensearch.ad.constant.CommonName;
 
 /**
  * A ML model and states such as usage.
  */
 public class ModelState<T> implements ExpiringState {
 
-    public static String MODEL_ID_KEY = "model_id";
-    public static String DETECTOR_ID_KEY = "detector_id";
     public static String MODEL_TYPE_KEY = "model_type";
     public static String LAST_USED_TIME_KEY = "last_used_time";
     public static String LAST_CHECKPOINT_TIME_KEY = "last_checkpoint_time";
-    public static String PRIORITY = "priority";
-
+    public static String PRIORITY_KEY = "priority";
     private T model;
     private String modelId;
     private String detectorId;
@@ -196,12 +194,18 @@ public class ModelState<T> implements ExpiringState {
     public Map<String, Object> getModelStateAsMap() {
         return new HashMap<String, Object>() {
             {
-                put(MODEL_ID_KEY, modelId);
-                put(DETECTOR_ID_KEY, detectorId);
+                put(CommonName.MODEL_ID_KEY, modelId);
+                put(CommonName.DETECTOR_ID_KEY, detectorId);
                 put(MODEL_TYPE_KEY, modelType);
                 put(LAST_USED_TIME_KEY, lastUsedTime);
                 put(LAST_CHECKPOINT_TIME_KEY, lastCheckpointTime);
-                put(PRIORITY, priority);
+                put(PRIORITY_KEY, priority);
+                if (model != null && model instanceof EntityModel) {
+                    EntityModel summary = (EntityModel) model;
+                    if (summary.getEntity().isPresent()) {
+                        put(CommonName.ENTITY_KEY, summary.getEntity().get());
+                    }
+                }
             }
         };
     }

--- a/src/main/java/org/opensearch/ad/model/DetectorProfile.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorProfile.java
@@ -42,7 +42,7 @@ import org.opensearch.common.xcontent.XContentBuilder;
 public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
     private DetectorState state;
     private String error;
-    private ModelProfile[] modelProfile;
+    private ModelProfileOnNode[] modelProfile;
     private int shingleSize;
     private String coordinatingNode;
     private long totalSizeInBytes;
@@ -61,7 +61,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
 
         this.error = in.readOptionalString();
-        this.modelProfile = in.readOptionalArray(ModelProfile::new, ModelProfile[]::new);
+        this.modelProfile = in.readOptionalArray(ModelProfileOnNode::new, ModelProfileOnNode[]::new);
         this.shingleSize = in.readOptionalInt();
         this.coordinatingNode = in.readOptionalString();
         this.totalSizeInBytes = in.readOptionalLong();
@@ -78,7 +78,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
     public static class Builder {
         private DetectorState state = null;
         private String error = null;
-        private ModelProfile[] modelProfile = null;
+        private ModelProfileOnNode[] modelProfile = null;
         private int shingleSize = -1;
         private String coordinatingNode = null;
         private long totalSizeInBytes = -1;
@@ -99,7 +99,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             return this;
         }
 
-        public Builder modelProfile(ModelProfile[] modelProfile) {
+        public Builder modelProfile(ModelProfileOnNode[] modelProfile) {
             this.modelProfile = modelProfile;
             return this;
         }
@@ -196,7 +196,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
         if (modelProfile != null && modelProfile.length > 0) {
             xContentBuilder.startArray(CommonName.MODELS);
-            for (ModelProfile profile : modelProfile) {
+            for (ModelProfileOnNode profile : modelProfile) {
                 profile.toXContent(xContentBuilder, params);
             }
             xContentBuilder.endArray();
@@ -241,11 +241,11 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         this.error = error;
     }
 
-    public ModelProfile[] getModelProfile() {
+    public ModelProfileOnNode[] getModelProfile() {
         return modelProfile;
     }
 
-    public void setModelProfile(ModelProfile[] modelProfile) {
+    public void setModelProfile(ModelProfileOnNode[] modelProfile) {
         this.modelProfile = modelProfile;
     }
 

--- a/src/main/java/org/opensearch/ad/model/EntityProfile.java
+++ b/src/main/java/org/opensearch/ad/model/EntityProfile.java
@@ -44,34 +44,26 @@ import org.opensearch.common.xcontent.XContentBuilder;
  */
 public class EntityProfile implements Writeable, ToXContent, Mergeable {
     // field name in toXContent
-    public static final String CATEGORY_FIELD = "category_field";
-    public static final String ENTITY_VALUE = "value";
     public static final String IS_ACTIVE = "is_active";
     public static final String LAST_ACTIVE_TIMESTAMP = "last_active_timestamp";
     public static final String LAST_SAMPLE_TIMESTAMP = "last_sample_timestamp";
 
-    private final String categoryField;
-    private final String value;
     private Boolean isActive;
     private long lastActiveTimestampMs;
     private long lastSampleTimestampMs;
     private InitProgressProfile initProgress;
-    private ModelProfile modelProfile;
+    private ModelProfileOnNode modelProfile;
     private EntityState state;
 
     public EntityProfile(
-        String categoryField,
-        String value,
         Boolean isActive,
         long lastActiveTimeStamp,
         long lastSampleTimestamp,
         InitProgressProfile initProgress,
-        ModelProfile modelProfile,
+        ModelProfileOnNode modelProfile,
         EntityState state
     ) {
         super();
-        this.categoryField = categoryField;
-        this.value = value;
         this.isActive = isActive;
         this.lastActiveTimestampMs = lastActiveTimeStamp;
         this.lastSampleTimestampMs = lastSampleTimestamp;
@@ -81,19 +73,12 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
     }
 
     public static class Builder {
-        private final String categoryField;
-        private final String value;
         private Boolean isActive = null;
         private long lastActiveTimestampMs = -1L;
         private long lastSampleTimestampMs = -1L;
         private InitProgressProfile initProgress = null;
-        private ModelProfile modelProfile = null;
+        private ModelProfileOnNode modelProfile = null;
         private EntityState state = EntityState.UNKNOWN;
-
-        public Builder(String categoryField, String value) {
-            this.categoryField = categoryField;
-            this.value = value;
-        }
 
         public Builder isActive(Boolean isActive) {
             this.isActive = isActive;
@@ -115,7 +100,7 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
             return this;
         }
 
-        public Builder modelProfile(ModelProfile modelProfile) {
+        public Builder modelProfile(ModelProfileOnNode modelProfile) {
             this.modelProfile = modelProfile;
             return this;
         }
@@ -126,22 +111,11 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
         }
 
         public EntityProfile build() {
-            return new EntityProfile(
-                categoryField,
-                value,
-                isActive,
-                lastActiveTimestampMs,
-                lastSampleTimestampMs,
-                initProgress,
-                modelProfile,
-                state
-            );
+            return new EntityProfile(isActive, lastActiveTimestampMs, lastSampleTimestampMs, initProgress, modelProfile, state);
         }
     }
 
     public EntityProfile(StreamInput in) throws IOException {
-        this.categoryField = in.readString();
-        this.value = in.readString();
         this.isActive = in.readOptionalBoolean();
         this.lastActiveTimestampMs = in.readLong();
         this.lastSampleTimestampMs = in.readLong();
@@ -149,17 +123,9 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
             this.initProgress = new InitProgressProfile(in);
         }
         if (in.readBoolean()) {
-            this.modelProfile = new ModelProfile(in);
+            this.modelProfile = new ModelProfileOnNode(in);
         }
         this.state = in.readEnum(EntityState.class);
-    }
-
-    public String getCategoryField() {
-        return categoryField;
-    }
-
-    public String getValue() {
-        return value;
     }
 
     public Optional<Boolean> getActive() {
@@ -192,7 +158,7 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
         return initProgress;
     }
 
-    public ModelProfile getModelProfile() {
+    public ModelProfileOnNode getModelProfile() {
         return modelProfile;
     }
 
@@ -207,8 +173,6 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(CATEGORY_FIELD, categoryField);
-        builder.field(ENTITY_VALUE, value);
         if (isActive != null) {
             builder.field(IS_ACTIVE, isActive);
         }
@@ -233,8 +197,6 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(categoryField);
-        out.writeString(value);
         out.writeOptionalBoolean(isActive);
         out.writeLong(lastActiveTimestampMs);
         out.writeLong(lastSampleTimestampMs);
@@ -256,8 +218,6 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
     @Override
     public String toString() {
         ToStringBuilder builder = new ToStringBuilder(this);
-        builder.append(CATEGORY_FIELD, categoryField);
-        builder.append(ENTITY_VALUE, value);
         if (isActive != null) {
             builder.append(IS_ACTIVE, isActive);
         }
@@ -290,8 +250,6 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
         if (obj instanceof EntityProfile) {
             EntityProfile other = (EntityProfile) obj;
             EqualsBuilder equalsBuilder = new EqualsBuilder();
-            equalsBuilder.append(categoryField, other.categoryField);
-            equalsBuilder.append(value, other.value);
             equalsBuilder.append(isActive, other.isActive);
             equalsBuilder.append(lastActiveTimestampMs, other.lastActiveTimestampMs);
             equalsBuilder.append(lastSampleTimestampMs, other.lastSampleTimestampMs);
@@ -307,8 +265,6 @@ public class EntityProfile implements Writeable, ToXContent, Mergeable {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-            .append(categoryField)
-            .append(value)
             .append(isActive)
             .append(lastActiveTimestampMs)
             .append(lastSampleTimestampMs)

--- a/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
+++ b/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.ad.model;
+
+import java.io.IOException;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+public class ModelProfileOnNode implements Writeable, ToXContent {
+    // field name in toXContent
+    public static final String NODE_ID = "node_id";
+
+    private final String nodeId;
+    private final ModelProfile modelProfile;
+
+    public ModelProfileOnNode(String nodeId, ModelProfile modelProfile) {
+        this.nodeId = nodeId;
+        this.modelProfile = modelProfile;
+    }
+
+    public ModelProfileOnNode(StreamInput in) throws IOException {
+        this.nodeId = in.readString();
+        this.modelProfile = new ModelProfile(in);
+    }
+
+    public String getModelId() {
+        return modelProfile.getModelId();
+    }
+
+    public long getModelSize() {
+        return modelProfile.getModelSizeInBytes();
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        modelProfile.toXContent(builder, params);
+        builder.field(NODE_ID, nodeId);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        modelProfile.writeTo(out);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        if (obj instanceof ModelProfileOnNode) {
+            ModelProfileOnNode other = (ModelProfileOnNode) obj;
+            EqualsBuilder equalsBuilder = new EqualsBuilder();
+            equalsBuilder.append(modelProfile, other.modelProfile);
+            equalsBuilder.append(nodeId, other.nodeId);
+
+            return equalsBuilder.isEquals();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(modelProfile).append(nodeId).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        ToStringBuilder builder = new ToStringBuilder(this);
+        builder.append(CommonName.MODEL, modelProfile);
+        builder.append(NODE_ID, nodeId);
+        return builder.toString();
+    }
+}

--- a/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
+++ b/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
@@ -9,21 +9,6 @@
  * GitHub history for details.
  */
 
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package org.opensearch.ad.model;
 
 import java.io.IOException;

--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -161,9 +161,9 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
              * GET _opendistro/_anomaly_detection/detectors/<detectorId>/_profile/init_progress
              * {
              *     "entity": [{
-                      "name": "clientip",
-                      "value": "13.24.0.0"
-                   }]
+             *         "name": "clientip",
+             *         "value": "13.24.0.0"
+             *      }]
              * }
              */
             Optional<Entity> entity = Entity.fromJsonObject(request.contentParser());

--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -27,22 +27,25 @@
 package org.opensearch.ad.rest;
 
 import static org.opensearch.ad.util.RestHandlerUtils.DETECTOR_ID;
-import static org.opensearch.ad.util.RestHandlerUtils.ENTITY;
 import static org.opensearch.ad.util.RestHandlerUtils.PROFILE;
 import static org.opensearch.ad.util.RestHandlerUtils.TYPE;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.GetAnomalyDetectorAction;
 import org.opensearch.ad.transport.GetAnomalyDetectorRequest;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestActions;
@@ -72,7 +75,7 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
         }
         String detectorId = request.param(DETECTOR_ID);
         String typesStr = request.param(TYPE);
-        String entityValue = request.param(ENTITY);
+
         String rawPath = request.rawPath();
         boolean returnJob = request.paramAsBoolean("job", false);
         boolean returnTask = request.paramAsBoolean("task", false);
@@ -85,7 +88,7 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
             typesStr,
             rawPath,
             all,
-            entityValue
+            buildEntity(request, detectorId)
         );
 
         return channel -> client
@@ -94,7 +97,18 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return ImmutableList.of();
+        return ImmutableList
+            .of(
+                // Opensearch-only API. Considering users may provide entity in the search body, support POST as well.
+                new Route(
+                    RestRequest.Method.POST,
+                    String.format(Locale.ROOT, "%s/{%s}/%s", AnomalyDetectorPlugin.AD_BASE_DETECTORS_URI, DETECTOR_ID, PROFILE)
+                ),
+                new Route(
+                    RestRequest.Method.POST,
+                    String.format(Locale.ROOT, "%s/{%s}/%s/{%s}", AnomalyDetectorPlugin.AD_BASE_DETECTORS_URI, DETECTOR_ID, PROFILE, TYPE)
+                )
+            );
     }
 
     @Override
@@ -128,5 +142,36 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
                         )
                 )
             );
+    }
+
+    private Entity buildEntity(RestRequest request, String detectorId) throws IOException {
+        if (Strings.isEmpty(detectorId)) {
+            throw new IllegalStateException(CommonErrorMessages.AD_ID_MISSING_MSG);
+        }
+
+        String entityName = request.param(CommonName.CATEGORICAL_FIELD);
+        String entityValue = request.param(CommonName.ENTITY_KEY);
+
+        if (entityName != null && entityValue != null) {
+            // single-stream profile request:
+            // GET _opendistro/_anomaly_detection/detectors/<detectorId>/_profile/init_progress?category_field=<field-name>&entity=<value>
+            return Entity.createSingleAttributeEntity(detectorId, entityName, entityValue);
+        } else if (request.hasContent()) {
+            /* HCAD profile request:
+             * GET _opendistro/_anomaly_detection/detectors/<detectorId>/_profile/init_progress
+             * {
+             *     "entity": [{
+                      "name": "clientip",
+                      "value": "13.24.0.0"
+                   }]
+             * }
+             */
+            Optional<Entity> entity = Entity.fromJsonObject(request.contentParser());
+            if (entity.isPresent()) {
+                return entity.get();
+            }
+        }
+        // not a valid profile request with correct entity information
+        return null;
     }
 }

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
@@ -26,8 +26,6 @@
 
 package org.opensearch.ad.stats.suppliers;
 
-import static org.opensearch.ad.ml.ModelState.DETECTOR_ID_KEY;
-import static org.opensearch.ad.ml.ModelState.MODEL_ID_KEY;
 import static org.opensearch.ad.ml.ModelState.MODEL_TYPE_KEY;
 
 import java.util.ArrayList;
@@ -41,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.opensearch.ad.caching.CacheProvider;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.ml.ModelManager;
 
 /**
@@ -53,7 +52,9 @@ public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>>
     /**
      * Set that contains the model stats that should be exposed.
      */
-    public static Set<String> MODEL_STATE_STAT_KEYS = new HashSet<>(Arrays.asList(MODEL_ID_KEY, DETECTOR_ID_KEY, MODEL_TYPE_KEY));
+    public static Set<String> MODEL_STATE_STAT_KEYS = new HashSet<>(
+        Arrays.asList(CommonName.MODEL_ID_KEY, CommonName.DETECTOR_ID_KEY, MODEL_TYPE_KEY, CommonName.ENTITY_KEY)
+    );
 
     /**
      * Constructor

--- a/src/main/java/org/opensearch/ad/transport/EntityProfileRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityProfileRequest.java
@@ -35,7 +35,8 @@ import java.util.Set;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
-import org.opensearch.ad.constant.CommonMessageAttributes;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
@@ -47,13 +48,13 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
     public static final String ENTITY = "entity";
     public static final String PROFILES = "profiles";
     private String adID;
-    private String entityValue;
+    private Entity entityValue;
     private Set<EntityProfileName> profilesToCollect;
 
     public EntityProfileRequest(StreamInput in) throws IOException {
         super(in);
         adID = in.readString();
-        entityValue = in.readString();
+        entityValue = new Entity(in);
         int size = in.readVInt();
         profilesToCollect = new HashSet<EntityProfileName>();
         if (size != 0) {
@@ -63,7 +64,7 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
         }
     }
 
-    public EntityProfileRequest(String adID, String entityValue, Set<EntityProfileName> profilesToCollect) {
+    public EntityProfileRequest(String adID, Entity entityValue, Set<EntityProfileName> profilesToCollect) {
         super();
         this.adID = adID;
         this.entityValue = entityValue;
@@ -74,7 +75,7 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
         return adID;
     }
 
-    public String getEntityValue() {
+    public Entity getEntityValue() {
         return entityValue;
     }
 
@@ -86,7 +87,7 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(adID);
-        out.writeString(entityValue);
+        entityValue.writeTo(out);
         out.writeVInt(profilesToCollect.size());
         for (EntityProfileName profile : profilesToCollect) {
             out.writeEnum(profile);
@@ -99,7 +100,7 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
         if (Strings.isEmpty(adID)) {
             validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
         }
-        if (Strings.isEmpty(entityValue)) {
+        if (entityValue == null) {
             validationException = addValidationError("Entity value is missing", validationException);
         }
         if (profilesToCollect == null || profilesToCollect.isEmpty()) {
@@ -111,7 +112,7 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(CommonMessageAttributes.ID_JSON_KEY, adID);
+        builder.field(CommonName.ID_JSON_KEY, adID);
         builder.field(ENTITY, entityValue);
         builder.field(PROFILES, profilesToCollect);
         builder.endObject();

--- a/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
@@ -41,16 +41,16 @@ import test.org.opensearch.ad.util.JsonDeserializer;
 
 public class EntityProfileTests extends AbstractADTest {
     public void testMerge() {
-        EntityProfile profile1 = new EntityProfile(null, null, null, -1, -1, null, null, EntityState.INIT);
+        EntityProfile profile1 = new EntityProfile(null, -1, -1, null, null, EntityState.INIT);
 
-        EntityProfile profile2 = new EntityProfile(null, null, null, -1, -1, null, null, EntityState.UNKNOWN);
+        EntityProfile profile2 = new EntityProfile(null, -1, -1, null, null, EntityState.UNKNOWN);
 
         profile1.merge(profile2);
         assertEquals(profile1.getState(), EntityState.INIT);
     }
 
     public void testToXContent() throws IOException, JsonPathNotFoundException {
-        EntityProfile profile1 = new EntityProfile(null, null, null, -1, -1, null, null, EntityState.INIT);
+        EntityProfile profile1 = new EntityProfile(null, -1, -1, null, null, EntityState.INIT);
 
         XContentBuilder builder = jsonBuilder();
         profile1.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -58,7 +58,7 @@ public class EntityProfileTests extends AbstractADTest {
 
         assertEquals("INIT", JsonDeserializer.getTextValue(json, CommonName.STATE));
 
-        EntityProfile profile2 = new EntityProfile(null, null, null, -1, -1, null, null, EntityState.UNKNOWN);
+        EntityProfile profile2 = new EntityProfile(null, -1, -1, null, null, EntityState.UNKNOWN);
 
         builder = jsonBuilder();
         profile2.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
+++ b/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
@@ -56,6 +56,7 @@ import org.opensearch.ad.util.IndexUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
 import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
 
 import com.amazon.randomcutforest.RandomCutForest;
 
@@ -96,8 +97,8 @@ public class ADStatsTests extends OpenSearchTestCase {
 
         when(modelManager.getAllModels()).thenReturn(modelsInformation);
 
-        ModelState<EntityModel> entityModel1 = MLUtil.randomNonEmptyModelState();
-        ModelState<EntityModel> entityModel2 = MLUtil.randomNonEmptyModelState();
+        ModelState<EntityModel> entityModel1 = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
+        ModelState<EntityModel> entityModel2 = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
 
         List<ModelState<?>> entityModelsInformation = new ArrayList<>(Arrays.asList(entityModel1, entityModel2));
         EntityCache cache = mock(EntityCache.class);

--- a/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
+++ b/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
@@ -51,6 +51,7 @@ import org.opensearch.ad.ml.ModelState;
 import org.opensearch.test.OpenSearchTestCase;
 
 import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
 
 import com.amazon.randomcutforest.RandomCutForest;
 
@@ -87,8 +88,8 @@ public class ModelsOnNodeSupplierTests extends OpenSearchTestCase {
 
         when(modelManager.getAllModels()).thenReturn(expectedResults);
 
-        ModelState<EntityModel> entityModel1 = MLUtil.randomNonEmptyModelState();
-        ModelState<EntityModel> entityModel2 = MLUtil.randomNonEmptyModelState();
+        ModelState<EntityModel> entityModel1 = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
+        ModelState<EntityModel> entityModel2 = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
 
         entityModelsInformation = new ArrayList<>(Arrays.asList(entityModel1, entityModel2));
         EntityCache cache = mock(EntityCache.class);

--- a/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
@@ -36,7 +36,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,9 +55,10 @@ import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.constant.CommonName;
-import org.opensearch.ad.ml.ModelManager;
+import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
 import org.opensearch.ad.model.ModelProfile;
+import org.opensearch.ad.model.ModelProfileOnNode;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -88,7 +91,6 @@ public class EntityProfileTests extends AbstractADTest {
     private ActionFilters actionFilters;
     private TransportService transportService;
     private Settings settings;
-    private ModelManager modelManager;
     private ClusterService clusterService;
     private CacheProvider cacheProvider;
     private EntityProfileTransportAction action;
@@ -102,6 +104,8 @@ public class EntityProfileTests extends AbstractADTest {
     private long modelSize = 712480L;
     private boolean isActive = Boolean.TRUE;
     private TransportInterceptor normalTransportInterceptor, failureTransportInterceptor;
+    private String categoryName = "field";
+    private Entity entity;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -140,9 +144,7 @@ public class EntityProfileTests extends AbstractADTest {
         );
         settings = Settings.EMPTY;
 
-        modelManager = mock(ModelManager.class);
         modelId = "yecrdnUBqurvo9uKU_d8_entity_app_0";
-        when(modelManager.getEntityModelId(anyString(), anyString())).thenReturn(modelId);
 
         clusterService = mock(ClusterService.class);
 
@@ -152,23 +154,19 @@ public class EntityProfileTests extends AbstractADTest {
         when(cache.getTotalUpdates(anyString(), anyString())).thenReturn(updates);
         when(cache.isActive(anyString(), anyString())).thenReturn(isActive);
         when(cache.getLastActiveMs(anyString(), anyString())).thenReturn(lastActiveTimestamp);
-        when(cache.getModelSize(anyString(), anyString())).thenReturn(modelSize);
+        Map<String, Long> modelSizeMap = new HashMap<>();
+        modelSizeMap.put(modelId, modelSize);
+        when(cache.getModelSize(anyString())).thenReturn(modelSizeMap);
         when(cacheProvider.get()).thenReturn(cache);
 
-        action = new EntityProfileTransportAction(
-            actionFilters,
-            transportService,
-            settings,
-            modelManager,
-            hashRing,
-            clusterService,
-            cacheProvider
-        );
+        action = new EntityProfileTransportAction(actionFilters, transportService, settings, hashRing, clusterService, cacheProvider);
 
         future = new PlainActionFuture<>();
         transportAddress1 = new TransportAddress(new InetSocketAddress(InetAddress.getByName("1.2.3.4"), 9300));
 
-        request = new EntityProfileRequest(detectorId, entityValue, state);
+        entity = Entity.createSingleAttributeEntity(detectorId, categoryName, entityValue);
+
+        request = new EntityProfileRequest(detectorId, entity, state);
 
         normalTransportInterceptor = new TransportInterceptor() {
             @Override
@@ -275,7 +273,6 @@ public class EntityProfileTests extends AbstractADTest {
             new ActionFilters(Collections.emptySet()),
             node.transportService,
             Settings.EMPTY,
-            modelManager,
             hashRing,
             node.clusterService,
             cacheProvider
@@ -304,21 +301,16 @@ public class EntityProfileTests extends AbstractADTest {
         when(hashRing.getOwningNode(anyString())).thenReturn(Optional.of(localNode));
         when(clusterService.localNode()).thenReturn(localNode);
 
-        request = new EntityProfileRequest(detectorId, entityValue, all);
+        request = new EntityProfileRequest(detectorId, entity, all);
         action.doExecute(task, request, future);
 
-        EntityProfileResponse expectedResponse = new EntityProfileResponse(
-            isActive,
-            lastActiveTimestamp,
-            updates,
-            new ModelProfile(modelId, modelSize, nodeId)
-        );
+        EntityProfileResponse expectedResponse = new EntityProfileResponse(isActive, lastActiveTimestamp, updates, null);
         EntityProfileResponse response = future.actionGet(20_000);
         assertEquals(expectedResponse, response);
     }
 
     public void testGetRemoteUpdateResponse() {
-        setupTestNodes(Settings.EMPTY, normalTransportInterceptor);
+        setupTestNodes(normalTransportInterceptor);
         try {
             TransportService realTransportService = testNodes[0].transportService;
             clusterService = testNodes[0].clusterService;
@@ -327,7 +319,6 @@ public class EntityProfileTests extends AbstractADTest {
                 actionFilters,
                 realTransportService,
                 settings,
-                modelManager,
                 hashRing,
                 clusterService,
                 cacheProvider
@@ -348,7 +339,7 @@ public class EntityProfileTests extends AbstractADTest {
     }
 
     public void testGetRemoteFailureResponse() {
-        setupTestNodes(Settings.EMPTY, failureTransportInterceptor);
+        setupTestNodes(failureTransportInterceptor);
         try {
             TransportService realTransportService = testNodes[0].transportService;
             clusterService = testNodes[0].clusterService;
@@ -357,7 +348,6 @@ public class EntityProfileTests extends AbstractADTest {
                 actionFilters,
                 realTransportService,
                 settings,
-                modelManager,
                 hashRing,
                 clusterService,
                 cacheProvider
@@ -378,17 +368,17 @@ public class EntityProfileTests extends AbstractADTest {
         long lastActiveTimestamp = 10L;
         EntityProfileResponse.Builder builder = new EntityProfileResponse.Builder();
         builder.setLastActiveMs(lastActiveTimestamp).build();
-        builder.setModelProfile(new ModelProfile(modelId, modelSize, nodeId));
+        builder.setModelProfile(new ModelProfileOnNode(nodeId, new ModelProfile(modelId, entity, modelSize)));
         EntityProfileResponse response = builder.build();
         String json = TestHelpers.xContentBuilderToString(response.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         assertEquals(lastActiveTimestamp, JsonDeserializer.getLongValue(json, EntityProfileResponse.LAST_ACTIVE_TS));
-        assertEquals(modelSize, JsonDeserializer.getChildNode(json, CommonName.MODEL, ModelProfile.MODEL_SIZE_IN_BYTES).getAsLong());
+        assertEquals(modelSize, JsonDeserializer.getChildNode(json, CommonName.MODEL, CommonName.MODEL_SIZE_IN_BYTES).getAsLong());
     }
 
     public void testSerialzationResponse() throws IOException {
         EntityProfileResponse.Builder builder = new EntityProfileResponse.Builder();
         builder.setLastActiveMs(lastActiveTimestamp).build();
-        ModelProfile model = new ModelProfile(modelId, modelSize, nodeId);
+        ModelProfileOnNode model = new ModelProfileOnNode(nodeId, new ModelProfile(modelId, entity, modelSize));
         builder.setModelProfile(model);
         EntityProfileResponse response = builder.build();
 
@@ -404,7 +394,7 @@ public class EntityProfileTests extends AbstractADTest {
     public void testResponseHashCodeEquals() {
         EntityProfileResponse.Builder builder = new EntityProfileResponse.Builder();
         builder.setLastActiveMs(lastActiveTimestamp).build();
-        ModelProfile model = new ModelProfile(modelId, modelSize, nodeId);
+        ModelProfileOnNode model = new ModelProfileOnNode(nodeId, new ModelProfile(modelId, entity, modelSize));
         builder.setModelProfile(model);
         EntityProfileResponse response = builder.build();
 

--- a/src/test/java/org/opensearch/search/aggregations/metrics/CardinalityProfileTests.java
+++ b/src/test/java/org/opensearch/search/aggregations/metrics/CardinalityProfileTests.java
@@ -197,7 +197,14 @@ public class CardinalityProfileTests extends AbstractProfileRunnerTests {
 
             ActionListener<ProfileResponse> listener = (ActionListener<ProfileResponse>) args[2];
 
-            ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(discoveryNode1, new HashMap<>(), shingleSize, 0, 0);
+            ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(
+                discoveryNode1,
+                new HashMap<>(),
+                shingleSize,
+                0,
+                0,
+                new ArrayList<>()
+            );
             List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1);
             listener.onResponse(new ProfileResponse(new ClusterName(clusterName), profileNodeResponses, Collections.emptyList()));
 

--- a/src/test/java/test/org/opensearch/ad/util/RandomModelStateConfig.java
+++ b/src/test/java/test/org/opensearch/ad/util/RandomModelStateConfig.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package test.org.opensearch.ad.util;
+
+import java.time.Clock;
+
+public class RandomModelStateConfig {
+    private final Boolean fullModel;
+    private final Float priority;
+    private final String detectorId;
+    private final Integer sampleSize;
+    private final Clock clock;
+
+    private RandomModelStateConfig(Builder builder) {
+        this.fullModel = builder.fullModel;
+        this.priority = builder.priority;
+        this.detectorId = builder.detectorId;
+        this.sampleSize = builder.sampleSize;
+        this.clock = builder.clock;
+    }
+
+    public Boolean getFullModel() {
+        return fullModel;
+    }
+
+    public Float getPriority() {
+        return priority;
+    }
+
+    public String getDetectorId() {
+        return detectorId;
+    }
+
+    public Integer getSampleSize() {
+        return sampleSize;
+    }
+
+    public Clock getClock() {
+        return clock;
+    }
+
+    public static class Builder {
+        private Boolean fullModel = null;
+        private Float priority = null;
+        private String detectorId = null;
+        private Integer sampleSize = null;
+        private Clock clock = null;
+
+        public Builder fullModel(boolean fullModel) {
+            this.fullModel = fullModel;
+            return this;
+        }
+
+        public Builder priority(float priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        public Builder detectorId(String detectorId) {
+            this.detectorId = detectorId;
+            return this;
+        }
+
+        public Builder sampleSize(int sampleSize) {
+            this.sampleSize = sampleSize;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        public RandomModelStateConfig build() {
+            RandomModelStateConfig config = new RandomModelStateConfig(this);
+            return config;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Previously, our profile API only took one entity key and value pair in the command as parameters. Using parameters won't work when moving to multi-category fields. This PR allows users to put the entity information on the request body in JSON format.

Also, we use the GET method to call profile API. As mentioned earlier, we added a request body with entity attributes. Some CLI tools require an API with a request body that uses the POST method. So we also allow a profile API with the POST method.

What's more, we didn't show entity attributes on model output as the model id carries entity values. A multi-category entity's model id is a hash instead of concrete entity attributes. So we added the entity attributes to the response output. Similar changes are also added for stats API.

Testing done:
1. manual testing using a local cluster.
 
Profile API:
```
Sample  request:
http://localhost:9200/_opendistro/_anomaly_detection/detectors/TSB5cnkBbTSBdroveJIW/_profile/models
{
	"entity": [{
			"name": "service",
			"value": "app_6"
		},
		{
			"name": "host",
			"value": "server_1"
		}
	]
}

Response:
{
	"model": {
		"model_id": "7sF5qXkBxjkVBFJhhe5K_entity_ZoNYVJsq5ry6e-SWXmAt1Q",
		"entity": [{
				"name": "host",
				"value": "server_1"
			},
			{
				"name": "service",
				"value": "app_6"
			}
		],
		"model_size_in_bytes": 712480,
		"node_id": "LSNdy0zzR_273CGX1EFR2A"
	}
}
```

Stats API:

```
Sample request:
localhost:9200/_opendistro/_anomaly_detection/stats

response:

{
	"anomaly_detectors_index_status": "yellow",
	"anomaly_detection_state_status": "yellow",
	"detector_count": 1,
	"anomaly_detection_job_index_status": "yellow",
	"models_checkpoint_index_status": "yellow",
	"anomaly_results_index_status": "yellow",
	"historical_single_entity_detector_count": 0,
	"nodes": {
		"LSNdy0zzR_273CGX1EFR2A": {
			"ad_execute_request_count": 30,
			"models": [{
					"detector_id": "7sF5qXkBxjkVBFJhhe5K",
					"model_type": "entity",
					"model_id": "7sF5qXkBxjkVBFJhhe5K_entity_412FoQwCykWTAhjVfDGQDg",
					"entity": [{
							"name": "host",
							"value": "server_1"
						},
						{
							"name": "service",
							"value": "app_2"
						}
					]
				},
				{
					"detector_id": "7sF5qXkBxjkVBFJhhe5K",
					"model_type": "entity",
					"model_id": "7sF5qXkBxjkVBFJhhe5K_entity_FuqXh0HBXlPhKepOc6JADQ",
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_6"
						}
					]
				}, …
				{
					"detector_id": "7sF5qXkBxjkVBFJhhe5K",
					"model_type": "entity",
					"model_id": "7sF5qXkBxjkVBFJhhe5K_entity_B4zrbSQ1-pvdBLx0FzQxvw",
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_3"
						}
					]
				}
			],
			"ad_canceled_batch_task_count": 0,
			"ad_hc_execute_request_count": 30,
			"ad_hc_execute_failure_count": 0,
			"ad_execute_failure_count": 0,
			"ad_batch_task_failure_count": 0,
			"ad_total_batch_task_execution_count": 0,
			"ad_executing_batch_task_count": 0
		}
	}
}
```


### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
