### PR TITLE
check if user has permission to read index when create/update/preview detector

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -51,6 +51,7 @@ import org.opensearch.ad.model.EntityAnomalyResult;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
+import org.opensearch.common.util.concurrent.ThreadContext;
 
 /**
  * Runner to trigger an anomaly detector.
@@ -77,8 +78,14 @@ public final class AnomalyDetectorRunner {
      * @param listener handle anomaly result
      * @throws IOException - if a user gives wrong query input when defining a detector
      */
-    public void executeDetector(AnomalyDetector detector, Instant startTime, Instant endTime, ActionListener<List<AnomalyResult>> listener)
-        throws IOException {
+    public void executeDetector(
+        AnomalyDetector detector,
+        Instant startTime,
+        Instant endTime,
+        ThreadContext.StoredContext context,
+        ActionListener<List<AnomalyResult>> listener
+    ) throws IOException {
+        context.restore();
         List<String> categoryField = detector.getCategoryField();
         if (categoryField != null && !categoryField.isEmpty()) {
             featureManager.getPreviewEntities(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(entities -> {

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.feature.FeatureManager;
@@ -143,6 +144,9 @@ public final class AnomalyDetectorRunner {
         // TODO return exception like IllegalArgumentException to explain data is not enough for preview
         // This also requires front-end change to handle error message correspondingly
         // We return empty list for now to avoid breaking front-end
+        if (e instanceof OpenSearchSecurityException) {
+            listener.onFailure(e);
+        }
         listener.onResponse(Collections.emptyList());
     }
 

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -104,7 +104,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                 detectorId,
                 filterByEnabled,
                 listener,
-                () -> previewExecute(request, listener),
+                () -> previewExecute(request, context, listener),
                 client,
                 clusterService,
                 xContentRegistry
@@ -115,7 +115,11 @@ public class PreviewAnomalyDetectorTransportAction extends
         }
     }
 
-    void previewExecute(PreviewAnomalyDetectorRequest request, ActionListener<PreviewAnomalyDetectorResponse> listener) {
+    void previewExecute(
+        PreviewAnomalyDetectorRequest request,
+        ThreadContext.StoredContext context,
+        ActionListener<PreviewAnomalyDetectorResponse> listener
+    ) {
         try {
             AnomalyDetector detector = request.getDetector();
             String detectorId = request.getDetectorId();
@@ -127,9 +131,10 @@ public class PreviewAnomalyDetectorTransportAction extends
                     listener.onFailure(new OpenSearchException(error, RestStatus.BAD_REQUEST));
                     return;
                 }
-                anomalyDetectorRunner.executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(listener, detector));
+                anomalyDetectorRunner
+                    .executeDetector(detector, startTime, endTime, context, getPreviewDetectorActionListener(listener, detector));
             } else {
-                previewAnomalyDetector(listener, detectorId, startTime, endTime);
+                previewAnomalyDetector(listener, detectorId, startTime, endTime, context);
             }
         } catch (Exception e) {
             logger.error(e);
@@ -171,11 +176,12 @@ public class PreviewAnomalyDetectorTransportAction extends
         ActionListener<PreviewAnomalyDetectorResponse> listener,
         String detectorId,
         Instant startTime,
-        Instant endTime
+        Instant endTime,
+        ThreadContext.StoredContext context
     ) {
         if (!StringUtils.isBlank(detectorId)) {
             GetRequest getRequest = new GetRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX).id(detectorId);
-            client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime));
+            client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime, context));
         } else {
             listener.onFailure(new OpenSearchException("Wrong input, no detector id", RestStatus.BAD_REQUEST));
         }
@@ -184,7 +190,8 @@ public class PreviewAnomalyDetectorTransportAction extends
     private ActionListener<GetResponse> onGetAnomalyDetectorResponse(
         ActionListener<PreviewAnomalyDetectorResponse> listener,
         Instant startTime,
-        Instant endTime
+        Instant endTime,
+        ThreadContext.StoredContext context
     ) {
         return ActionListener.wrap(new CheckedConsumer<GetResponse, Exception>() {
             @Override
@@ -204,7 +211,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                     AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
                     anomalyDetectorRunner
-                        .executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(listener, detector));
+                        .executeDetector(detector, startTime, endTime, context, getPreviewDetectorActionListener(listener, detector));
                 } catch (IOException e) {
                     listener.onFailure(e);
                 }

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -165,7 +165,7 @@ public class PreviewAnomalyDetectorTransportAction extends
             listener
                 .onFailure(
                     new OpenSearchException(
-                        "Unexpected error running anomaly detector " + detector.getDetectorId(),
+                        "Unexpected error running anomaly detector " + detector.getDetectorId() + ". " + exception.getMessage(),
                         RestStatus.INTERNAL_SERVER_ERROR
                     )
                 );

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -52,6 +52,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
     RestClient catClient;
     String dogUser = "dog";
     RestClient dogClient;
+    String elkUser = "elk";
+    RestClient elkClient;
 
     @Before
     public void setupSecureTests() throws IOException {
@@ -78,8 +80,13 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             .setSocketTimeout(60000)
             .build();
 
+        createUser(elkUser, elkUser, new ArrayList<>(Arrays.asList("odfe")));
+        elkClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), elkUser, elkUser)
+            .setSocketTimeout(60000)
+            .build();
+
         createRoleMapping("anomaly_read_access", new ArrayList<>(Arrays.asList(bobUser)));
-        createRoleMapping("anomaly_full_access", new ArrayList<>(Arrays.asList(aliceUser, catUser, dogUser)));
+        createRoleMapping("anomaly_full_access", new ArrayList<>(Arrays.asList(aliceUser, catUser, dogUser, elkUser)));
         createRoleMapping("index_all_access", new ArrayList<>(Arrays.asList(aliceUser, bobUser, catUser, dogUser)));
     }
 
@@ -89,10 +96,12 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         bobClient.close();
         catClient.close();
         dogClient.close();
+        elkClient.close();
         deleteUser(aliceUser);
         deleteUser(bobUser);
         deleteUser(catUser);
         deleteUser(dogUser);
+        deleteUser(elkUser);
     }
 
     public void testCreateAnomalyDetectorWithWriteAccess() throws IOException {
@@ -194,6 +203,16 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             );
     }
 
+    public void testCreateAnomalyDetectorWithNoReadPermissionOfIndex() throws IOException {
+        enableFilterBy();
+        // User alice has AD full access and index permission, so can create detector
+        AnomalyDetector anomalyDetector = createRandomAnomalyDetector(false, false, aliceClient);
+        // User elk has AD full access, but has no read permission of index
+        String indexName = anomalyDetector.getIndices().get(0);
+        Exception exception = expectThrows(IOException.class, () -> { createRandomAnomalyDetector(false, false, indexName, elkClient); });
+        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
+    }
+
     public void testPreviewAnomalyDetectorWithWriteAccess() throws IOException {
         // User Alice has AD full access, should be able to create/preview a detector
         AnomalyDetector aliceDetector = createRandomAnomalyDetector(false, false, aliceClient);
@@ -244,5 +263,23 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             .assertTrue(
                 exception.getMessage().contains("User does not have permissions to access detector: " + aliceDetector.getDetectorId())
             );
+    }
+
+    public void testPreviewAnomalyDetectorWithNoReadPermissionOfIndex() throws IOException {
+        // User Alice has AD full access, should be able to create a detector
+        AnomalyDetector aliceDetector = createRandomAnomalyDetector(false, false, aliceClient);
+        AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(
+            aliceDetector.getDetectorId(),
+            Instant.now().minusSeconds(60 * 10),
+            Instant.now(),
+            aliceDetector
+        );
+        enableFilterBy();
+        // User elk has no read permission of index
+        Exception exception = expectThrows(
+            Exception.class,
+            () -> { previewAnomalyDetector(aliceDetector.getDetectorId(), elkClient, input); }
+        );
+        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
     }
 }


### PR DESCRIPTION
### Description
If user has no permission to read index, we should block creating/updating detector with that index.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/36
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
