### PR TITLE
Fix empty range for cold start bug

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -382,6 +382,11 @@ public class EntityColdStarter {
                         maxTrainSamples
                     );
 
+                    if (sampleRanges.isEmpty()) {
+                        listener.onResponse(Optional.empty());
+                        return;
+                    }
+
                     ActionListener<List<Optional<double[]>>> getFeaturelistener = ActionListener.wrap(featureSamples -> {
                         ArrayList<double[]> continuousSampledFeatures = new ArrayList<>(maxTrainSamples);
 

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -444,6 +444,29 @@ public class TestHelpers {
         );
     }
 
+    public static AnomalyDetector randomAnomalyDetectorWithInterval(TimeConfiguration interval, boolean hcDetector, boolean featureEnabled)
+        throws IOException {
+        List<String> categoryField = hcDetector ? ImmutableList.of(randomAlphaOfLength(5)) : null;
+        return new AnomalyDetector(
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomAlphaOfLength(20),
+            randomAlphaOfLength(30),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+            ImmutableList.of(randomFeature(featureEnabled)),
+            randomQuery(),
+            interval,
+            randomIntervalTimeConfiguration(),
+            randomIntBetween(1, 2000),
+            null,
+            randomInt(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            categoryField,
+            randomUser()
+        );
+    }
+
     public static SearchSourceBuilder randomFeatureQuery() throws IOException {
         String query = "{\"query\":{\"match\":{\"user\":{\"query\":\"kimchy\",\"operator\":\"OR\",\"prefix_length\":0,"
             + "\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\","


### PR DESCRIPTION
### Description
While collecting training data, we continue searching even if no data range has data.  This bug can cause "No [ranges] specified for the [date_range] aggregation" exception printed out.  This PR fixed that by returning empty training data instead of logging exceptions.

Testing done:
1. testing on a cluster with sparse data.  Verified we don't log exceptions anymore.
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
