### PR TITLE
Refactor ModelManager.

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -967,6 +967,7 @@ public class ModelManager implements DetectorModelSize {
                 modelState.setModel(entityModel);
             }
 
+            // trainModelFromExistingSamples may be able to make models not null
             if (entityModel.getRcf() == null || entityModel.getThreshold() == null) {
                 entityColdStarter.trainModelFromExistingSamples(modelState);
             }

--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -61,6 +61,7 @@ import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.rcf.CombinedRcfResult;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.Entity;
 
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.returntypes.DiVector;
@@ -149,7 +150,7 @@ public class ModelManager implements DetectorModelSize {
      * @param minPreviewSize minimum number of data points for preview
      * @param modelTtl time to live for hosted models
      * @param checkpointInterval interval between checkpoints
-     * @param entityColdStarter Used train models on input data
+     * @param entityColdStarter HCAD cold start utility
      * @param modelPartitioner Used to partition RCF models
      * @param featureManager Used to create features for models
      * @param memoryTracker AD memory usage tracker
@@ -178,7 +179,6 @@ public class ModelManager implements DetectorModelSize {
         FeatureManager featureManager,
         MemoryTracker memoryTracker
     ) {
-
         this.rcfSerde = rcfSerde;
         this.checkpointDao = checkpointDao;
         this.gson = gson;
@@ -944,102 +944,121 @@ public class ModelManager implements DetectorModelSize {
 
     /**
      * Compute anomaly result for the given data point
-     * @param detectorId Detector Id
      * @param datapoint Data point
-     * @param entityName entity's name like "server_1"
      * @param modelState the state associated with the entity
      * @param modelId the model Id
+     * @param detector Detector accessor
+     * @param entity entity accessor
+     *
      * @return anomaly result, confidence, and the corresponding RCF score.
      */
     public ThresholdingResult getAnomalyResultForEntity(
-        String detectorId,
         double[] datapoint,
-        String entityName,
         ModelState<EntityModel> modelState,
-        String modelId
+        String modelId,
+        AnomalyDetector detector,
+        Entity entity
     ) {
-        ThresholdingResult result = null;
-
         if (modelState != null) {
-            EntityModel model = modelState.getModel();
-            Queue<double[]> samples = model.getSamples();
-            samples.add(datapoint);
-            if (samples.size() > this.rcfNumMinSamples) {
-                samples.remove();
+            EntityModel entityModel = modelState.getModel();
+
+            if (entityModel == null) {
+                entityModel = new EntityModel(entity, new ArrayDeque<>(), null, null);
+                modelState.setModel(entityModel);
             }
 
-            result = maybeTrainBeforeScore(modelState, entityName);
-        } else {
-            result = new ThresholdingResult(0, 0, 0);
-        }
+            if (entityModel.getRcf() == null || entityModel.getThreshold() == null) {
+                entityColdStarter.trainModelFromExistingSamples(modelState);
+            }
 
-        return result;
+            if (entityModel.getRcf() != null && entityModel.getThreshold() != null) {
+                return score(datapoint, modelId, modelState);
+            } else {
+                entityModel.addSample(datapoint);
+                return new ThresholdingResult(0, 0, 0);
+            }
+        } else {
+            return new ThresholdingResult(0, 0, 0);
+        }
     }
 
-    private ThresholdingResult score(Queue<double[]> samples, String modelId, ModelState<EntityModel> modelState) {
+    public ThresholdingResult score(double[] feature, String modelId, ModelState<EntityModel> modelState) {
         EntityModel model = modelState.getModel();
+        if (model == null) {
+            return new ThresholdingResult(0, 0, 0);
+        }
         RandomCutForest rcf = model.getRcf();
         ThresholdingModel threshold = model.getThreshold();
-
-        double lastRcfScore = 0;
-        while (samples.peek() != null) {
-            double[] feature = samples.poll();
-            lastRcfScore = rcf.getAnomalyScore(feature);
-            rcf.update(feature);
-            threshold.update(lastRcfScore);
+        if (rcf == null || threshold == null) {
+            return new ThresholdingResult(0, 0, 0);
         }
 
-        double anomalyGrade = threshold.grade(lastRcfScore);
+        // clear feature not scored yet
+        Queue<double[]> samples = model.getSamples();
+        while (samples != null && samples.peek() != null) {
+            double[] recordedFeature = samples.poll();
+            double rcfScore = rcf.getAnomalyScore(recordedFeature);
+            rcf.update(recordedFeature);
+            threshold.update(rcfScore);
+        }
+
+        double rcfScore = rcf.getAnomalyScore(feature);
+        rcf.update(feature);
+        threshold.update(rcfScore);
+
+        double anomalyGrade = threshold.grade(rcfScore);
         double anomalyConfidence = computeRcfConfidence(rcf) * threshold.confidence();
-        ThresholdingResult result = new ThresholdingResult(anomalyGrade, anomalyConfidence, lastRcfScore);
+        ThresholdingResult result = new ThresholdingResult(anomalyGrade, anomalyConfidence, rcfScore);
 
         modelState.setLastUsedTime(clock.instant());
         return result;
     }
 
     /**
-     * Create model Id out of detector Id and entity name
-     * @param detectorId Detector Id
-     * @param entityValue Entity's value
-     * @return The model Id
-     */
-    public String getEntityModelId(String detectorId, String entityValue) {
-        return detectorId + "_entity_" + entityValue;
-    }
-
-    /**
-     * Instantiate an entity state out of checkpoint.  Running cold start if the
-     * model is empty. Update models using recent samples if applicable.
+     * Instantiate an entity state out of checkpoint.
      * @param checkpoint Checkpoint loaded from index
+     * @param entity objects to access Entity attributes
      * @param modelId Model Id
-     * @param entityName Entity's name
-     * @param modelState entity state to instantiate
+     * @param detectorId Detector Id
+     *
+     * @return updated model state
+     *
      */
-    public void processEntityCheckpoint(
+    public ModelState<EntityModel> processEntityCheckpoint(
         Optional<Entry<EntityModel, Instant>> checkpoint,
+        Entity entity,
         String modelId,
-        String entityName,
-        ModelState<EntityModel> modelState
+        String detectorId
     ) {
+        // entity state to instantiate
+        ModelState<EntityModel> modelState = new ModelState<>(
+            new EntityModel(entity, new ArrayDeque<>(), null, null),
+            modelId,
+            detectorId,
+            ModelType.ENTITY.getName(),
+            clock,
+            0
+        );
+
         if (checkpoint.isPresent()) {
             Entry<EntityModel, Instant> modelToTime = checkpoint.get();
             EntityModel restoredModel = modelToTime.getKey();
             combineSamples(modelState.getModel(), restoredModel);
             modelState.setModel(restoredModel);
             modelState.setLastCheckpointTime(modelToTime.getValue());
-        } else {
-            // the time controls whether we saves this state or not.
-            // if it is within one hour, we don't save.
-            // This branch means this is the first state in record
-            // (the checkpoint might have been deleted).
-            // we have to save.
-            modelState.setLastCheckpointTime(clock.instant().minus(checkpointInterval));
+        }
+        EntityModel model = modelState.getModel();
+        if (model == null) {
+            model = new EntityModel(null, new ArrayDeque<>(), null, null);
+            modelState.setModel(model);
         }
 
-        if (modelState.getModel() == null) {
-            modelState.setModel(new EntityModel(modelId, new ArrayDeque<>(), null, null));
+        if ((model.getRcf() == null || model.getThreshold() == null)
+            && model.getSamples() != null
+            && model.getSamples().size() >= rcfNumMinSamples) {
+            entityColdStarter.trainModelFromExistingSamples(modelState);
         }
-        maybeTrainBeforeScore(modelState, entityName);
+        return modelState;
     }
 
     private void combineSamples(EntityModel fromModel, EntityModel toModel) {
@@ -1047,29 +1066,5 @@ public class ModelManager implements DetectorModelSize {
         while (samples.peek() != null) {
             toModel.addSample(samples.poll());
         }
-    }
-
-    /**
-     * Infer whenever both models are not null and do cold start if one of the models is not there
-     * @param modelState Model State
-     * @param entityName The entity's name
-     * @return model inference result for the entity, return all 0 Thresholding
-     *  result if the models are not ready
-     */
-    private ThresholdingResult maybeTrainBeforeScore(ModelState<EntityModel> modelState, String entityName) {
-        EntityModel model = modelState.getModel();
-        Queue<double[]> samples = model.getSamples();
-        String modelId = model.getModelId();
-        String detectorId = modelState.getDetectorId();
-        ThresholdingResult result = null;
-        if (model.getRcf() == null || model.getThreshold() == null) {
-            entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
-        }
-
-        // update models using recent samples
-        if (model.getRcf() != null && model.getThreshold() != null && result == null) {
-            return score(samples, modelId, modelState);
-        }
-        return new ThresholdingResult(0, 0, 0);
     }
 }


### PR DESCRIPTION
### Description
First, we move maybeTrainBeforeScore to EntityColdStarter for code reuse in the entity cold start queue.
Second, we add logic to deal with null models and don’t assume the callers will ensure that.
Third, we make processEntityCheckpoint a pure function that does not change input parameters.

Testing done:
* Verified after refactoring, the basic workflow of HCAD still works.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/85
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
