### PR TITLE
Reuse the error message of the multi-category limit surpassed error

### DIFF
--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -39,7 +39,7 @@ public class CommonErrorMessages {
     public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
     public static final String DISABLED_ERR_MSG = "AD plugin is disabled. To enable update plugins.anomaly_detection.enabled to true";
     // We need this invalid query tag to show proper error message on frontend
-    // refer to AD Kibana code: https://tinyurl.com/8b5n8hat
+    // refer to AD Dashboard code: https://tinyurl.com/8b5n8hat
     public static final String INVALID_SEARCH_QUERY_MSG = "Invalid search query.";
     public static final String ALL_FEATURES_DISABLED_ERR_MSG =
         "Having trouble querying data because all of your features have been disabled.";

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.constant;
 
+import java.util.Locale;
+
 public class CommonErrorMessages {
     public static final String AD_ID_MISSING_MSG = "AD ID is missing";
     public static final String MODEL_ID_MISSING_MSG = "Model ID is missing";
@@ -36,6 +38,8 @@ public class CommonErrorMessages {
     public static final String FEATURE_NOT_AVAILABLE_ERR_MSG = "No Feature in current detection window.";
     public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
     public static final String DISABLED_ERR_MSG = "AD plugin is disabled. To enable update plugins.anomaly_detection.enabled to true";
+    // We need this invalid query tag to show proper error message on frontend
+    // refer to AD Kibana code: https://tinyurl.com/8b5n8hat
     public static final String INVALID_SEARCH_QUERY_MSG = "Invalid search query.";
     public static final String ALL_FEATURES_DISABLED_ERR_MSG =
         "Having trouble querying data because all of your features have been disabled.";
@@ -49,4 +53,11 @@ public class CommonErrorMessages {
     public static String DETECTOR_IS_RUNNING = "Detector is already running";
     public static String DETECTOR_MISSING = "Detector is missing";
     public static String AD_TASK_ACTION_MISSING = "AD task action is missing";
+    public static final String BUG_RESPONSE = "We might have bugs.";
+
+    private static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT = "We can have only %d categorical field.";
+
+    public static String getTooManyCategoricalFieldErr(int limit) {
+        return String.format(Locale.ROOT, TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT, limit);
+    }
 }

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -26,7 +26,6 @@
 
 package org.opensearch.ad.model;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.CATEGORY_FIELD_LIMIT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.DEFAULT_MULTI_ENTITY_SHINGLE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -46,6 +45,7 @@ import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.constant.CommonValue;
+import org.opensearch.ad.settings.NumericSetting;
 import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -214,8 +214,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         if (shingleSize != null && shingleSize < 1) {
             throw new IllegalArgumentException("Shingle size must be a positive integer");
         }
-        if (categoryFields != null && categoryFields.size() > CATEGORY_FIELD_LIMIT) {
-            throw new IllegalArgumentException(CommonErrorMessages.CATEGORICAL_FIELD_NUMBER_SURPASSED + CATEGORY_FIELD_LIMIT);
+        int maxCategoryFields = NumericSetting.maxCategoricalFields();
+        if (categoryFields != null && categoryFields.size() > maxCategoryFields) {
+            throw new IllegalArgumentException(CommonErrorMessages.getTooManyCategoricalFieldErr(maxCategoryFields));
         }
         if (((IntervalTimeConfiguration) detectionInterval).getInterval() <= 0) {
             throw new IllegalArgumentException("Detection interval must be a positive integer");

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -195,10 +195,11 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         );
     }
 
-    public void testTwoCategoricalFields() throws IOException {
+    // we support upto 2 category fields now
+    public void testThreeCategoricalFields() throws IOException {
         expectThrows(
             IllegalArgumentException.class,
-            () -> TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList("a", "b"))
+            () -> TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList("a", "b", "c"))
         );
     }
 


### PR DESCRIPTION
### Description
We have a limit of the number of categorical fields and report an error if the limit is breached. This PR moves the message to CommonErrorMessage and reuses it in multiple places.

Testing done:
* Verified the basic workflow of HCAD works
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/87
 
### Check List
- [ Y ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
