### PR TITLE
Bump to version 1.0.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: 'main' # TODO: update to the right branch name once it's ready. e.g. 1.x
+          ref: 'v1.0.0.0-rc1' # TODO: update to the right branch name once it's ready. e.g. 1.x
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
         with:
-          ref: 'main' # TODO: update to the right branch name once it's ready. e.g. 1.x
+          ref: '1.0.0.0-rc1' # TODO: update to the right branch name once it's ready. e.g. 1.x
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
@@ -59,11 +59,11 @@ jobs:
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd
@@ -75,11 +75,11 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0
+          ./gradlew build -Dopensearch.version=1.0.0-rc1
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1
 
       - name: Multi Nodes Integration Testing
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
           ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils
@@ -47,7 +47,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
@@ -59,11 +59,11 @@ jobs:
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd
@@ -75,11 +75,11 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0-rc1
+          ./gradlew build -Dopensearch.version=1.0.0
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
 
       - name: Multi Nodes Integration Testing
         run: |
@@ -91,8 +91,8 @@ jobs:
           ## version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
           ## plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
           ## TODO: remove these two hard code versions below after GA release
-          version=1.0.0-rc1
-          plugin_version=1.0.0.0-rc1
+          version=1.0.0
+          plugin_version=1.0.0.0
           echo $version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
           ref: '1.0'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0-rc1")
         common_utils_version = '1.0.0.0'
         job_scheduler_version = '1.0.0.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0-rc1")
-        common_utils_version = '1.0.0.0-rc1'
-        job_scheduler_version = '1.0.0.0-rc1'
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        common_utils_version = '1.0.0.0'
+        job_scheduler_version = '1.0.0.0'
     }
 
     repositories {
@@ -66,7 +66,7 @@ ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
-version = "${opensearchVersion}.0-rc1"
+version = "${opensearchVersion}.0"
 
 apply plugin: 'java'
 apply plugin: 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ buildscript {
     ext {
         opensearch_group = "org.opensearch"
         opensearch_version = System.getProperty("opensearch.version", "1.0.0-rc1")
-        common_utils_version = '1.0.0.0'
-        job_scheduler_version = '1.0.0.0'
+        common_utils_version = '1.0.0.0-rc1'
+        job_scheduler_version = '1.0.0.0-rc1'
     }
 
     repositories {


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Bump to version `1.0.0.0` by removing the `rc1` version qualifier from the plugin & necessary dependencies.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
