### PR TITLE
Bump plugin version to 1.0.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,7 +94,6 @@ jobs:
           version=1.0.0-rc1
           plugin_version=1.0.0.0
           echo $version
-          ls build/distributions/
           cd ..
           if docker pull opensearchstaging/opensearch:$version
           then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: 'main' # TODO: update to the right branch name once it's ready. e.g. 1.x
+          ref: 'v1.0.0.0-rc1' # TODO: update to the right branch name once it's ready. e.g. 1.x
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
         with:
-          ref: 'main' # TODO: update to the right branch name once it's ready. e.g. 1.x
+          ref: '1.0.0.0-rc1' # TODO: update to the right branch name once it's ready. e.g. 1.x
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: 1.0.0-rc1
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,6 +94,7 @@ jobs:
           version=1.0.0-rc1
           plugin_version=1.0.0.0
           echo $version
+          ls build/distributions/
           cd ..
           if docker pull opensearchstaging/opensearch:$version
           then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
           ## plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
           ## TODO: remove these two hard code versions below after GA release
           version=1.0.0-rc1
-          plugin_version=1.0.0.0-rc1
+          plugin_version=1.0.0.0
           echo $version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
           ## plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
           ## TODO: remove these two hard code versions below after GA release
           version=1.0.0-rc1
-          plugin_version=1.0.0.0
+          plugin_version=1.0.0.0-rc1
           echo $version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: 'v1.0.0.0-rc1' # TODO: update to the right branch name once it's ready. e.g. 1.x
+          ref: '1.0.0.0-rc1' # TODO: update to the right branch name once it's ready. e.g. 1.x
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
-version = "${opensearchVersion}.0-rc1"
+version = "${opensearchVersion}.0"
 
 apply plugin: 'java'
 apply plugin: 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
-version = "${opensearchVersion}.0"
+version = "${opensearchVersion}.0-rc1"
 
 apply plugin: 'java'
 apply plugin: 'idea'


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Bumps plugin version to `1.0.0.0`. Note that `rc1` versions of the dependencies are still being used here, since `integTest` is failing due to an issue related to OpenSearch's distribution downloader. Changes will need to be made to bump the versions to `1.0.0` once the upstream fix has been made. I've opened #109 to track this, which also includes a link to the upstream issue.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
