### PR TITLE
support HC task profiles in profile API;error handling

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -212,7 +212,6 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             false
                         );
                     if (profilesToCollect.contains(DetectorProfileName.ERROR)) {
-
                         adTaskManager.getLatestADTask(detectorId, ADTaskType.REALTIME_TASK_TYPES, adTask -> {
                             DetectorProfile.Builder profileBuilder = new DetectorProfile.Builder();
                             if (adTask.isPresent()) {
@@ -230,7 +229,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                                 // detector state for this detector does not exist
                                 listener.onResponse(profileBuilder.build());
                             }
-                        }, transportService, delegateListener);
+                        }, transportService, false, delegateListener);
                     }
 
                     // total number of listeners we need to define. Needed by MultiResponsesDelegateActionListener to decide

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -48,6 +48,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.AnomalyResult;
@@ -112,7 +113,6 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
     }
 
     public void profile(String detectorId, ActionListener<DetectorProfile> listener, Set<DetectorProfileName> profilesToCollect) {
-
         if (profilesToCollect.isEmpty()) {
             listener.onFailure(new InvalidParameterException(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
             return;
@@ -135,11 +135,6 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, xContentParser.nextToken(), xContentParser);
                     AnomalyDetector detector = AnomalyDetector.parse(xContentParser, detectorId);
-                    // TODO: remove isRealTimeDetector, change profile
-                    if (!detector.isRealTimeDetector() && profilesToCollect.contains(DetectorProfileName.AD_TASK)) {
-                        adTaskManager.getLatestADTaskProfile(detectorId, transportService, listener);
-                        return;
-                    }
                     prepareProfile(detector, listener, profilesToCollect);
                 } catch (Exception e) {
                     listener.onFailure(new RuntimeException(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG + detectorId, e));
@@ -190,6 +185,9 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             || profilesToCollect.contains(DetectorProfileName.STATE)) {
                             totalResponsesToWait++;
                         }
+                        if (profilesToCollect.contains(DetectorProfileName.AD_TASK)) {
+                            totalResponsesToWait++;
+                        }
                     } else {
                         if (profilesToCollect.contains(DetectorProfileName.STATE)
                             || profilesToCollect.contains(DetectorProfileName.INIT_PROGRESS)) {
@@ -199,6 +197,9 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             || profilesToCollect.contains(DetectorProfileName.SHINGLE_SIZE)
                             || profilesToCollect.contains(DetectorProfileName.TOTAL_SIZE_IN_BYTES)
                             || profilesToCollect.contains(DetectorProfileName.MODELS)) {
+                            totalResponsesToWait++;
+                        }
+                        if (profilesToCollect.contains(DetectorProfileName.AD_TASK)) {
                             totalResponsesToWait++;
                         }
                     }
@@ -211,8 +212,25 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             false
                         );
                     if (profilesToCollect.contains(DetectorProfileName.ERROR)) {
-                        GetRequest getStateRequest = new GetRequest(CommonName.DETECTION_STATE_INDEX, detectorId);
-                        client.get(getStateRequest, onGetDetectorState(delegateListener, detectorId, enabledTimeMs));
+
+                        adTaskManager.getLatestADTask(detectorId, ADTaskType.REALTIME_TASK_TYPES, adTask -> {
+                            DetectorProfile.Builder profileBuilder = new DetectorProfile.Builder();
+                            if (adTask.isPresent()) {
+                                long lastUpdateTimeMs = adTask.get().getLastUpdateTime().toEpochMilli();
+
+                                // if state index hasn't been updated, we should not use the error field
+                                // For example, before a detector is enabled, if the error message contains
+                                // the phrase "stopped due to blah", we should not show this when the detector
+                                // is enabled.
+                                if (lastUpdateTimeMs > enabledTimeMs && adTask.get().getError() != null) {
+                                    profileBuilder.error(adTask.get().getError());
+                                }
+                                delegateListener.onResponse(profileBuilder.build());
+                            } else {
+                                // detector state for this detector does not exist
+                                listener.onResponse(profileBuilder.build());
+                            }
+                        }, transportService, delegateListener);
                     }
 
                     // total number of listeners we need to define. Needed by MultiResponsesDelegateActionListener to decide
@@ -230,6 +248,9 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             || profilesToCollect.contains(DetectorProfileName.STATE)) {
                             profileModels(detector, profilesToCollect, job, true, delegateListener);
                         }
+                        if (profilesToCollect.contains(DetectorProfileName.AD_TASK)) {
+                            adTaskManager.getLatestHistoricalTaskProfile(detectorId, transportService, null, delegateListener);
+                        }
                     } else {
                         if (profilesToCollect.contains(DetectorProfileName.STATE)
                             || profilesToCollect.contains(DetectorProfileName.INIT_PROGRESS)) {
@@ -241,6 +262,9 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             || profilesToCollect.contains(DetectorProfileName.MODELS)) {
                             profileModels(detector, profilesToCollect, job, false, delegateListener);
                         }
+                        if (profilesToCollect.contains(DetectorProfileName.AD_TASK)) {
+                            adTaskManager.getLatestHistoricalTaskProfile(detectorId, transportService, null, delegateListener);
+                        }
                     }
 
                 } catch (Exception e) {
@@ -248,12 +272,12 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                     listener.onFailure(e);
                 }
             } else {
-                onGetDetectorForPrepare(listener, profilesToCollect);
+                onGetDetectorForPrepare(detectorId, listener, profilesToCollect);
             }
         }, exception -> {
             if (exception instanceof IndexNotFoundException) {
                 logger.info(exception.getMessage());
-                onGetDetectorForPrepare(listener, profilesToCollect);
+                onGetDetectorForPrepare(detectorId, listener, profilesToCollect);
             } else {
                 logger.error(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG + detectorId);
                 listener.onFailure(exception);
@@ -286,12 +310,16 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
         }
     }
 
-    private void onGetDetectorForPrepare(ActionListener<DetectorProfile> listener, Set<DetectorProfileName> profiles) {
+    private void onGetDetectorForPrepare(String detectorId, ActionListener<DetectorProfile> listener, Set<DetectorProfileName> profiles) {
         DetectorProfile.Builder profileBuilder = new DetectorProfile.Builder();
         if (profiles.contains(DetectorProfileName.STATE)) {
             profileBuilder.state(DetectorState.DISABLED);
         }
-        listener.onResponse(profileBuilder.build());
+        if (profiles.contains(DetectorProfileName.AD_TASK)) {
+            adTaskManager.getLatestHistoricalTaskProfile(detectorId, transportService, profileBuilder.build(), listener);
+        } else {
+            listener.onResponse(profileBuilder.build());
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -212,7 +212,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             false
                         );
                     if (profilesToCollect.contains(DetectorProfileName.ERROR)) {
-                        adTaskManager.getLatestADTask(detectorId, ADTaskType.REALTIME_TASK_TYPES, adTask -> {
+                        adTaskManager.getAndExecuteOnLatestADTask(detectorId, ADTaskType.REALTIME_TASK_TYPES, adTask -> {
                             DetectorProfile.Builder profileBuilder = new DetectorProfile.Builder();
                             if (adTask.isPresent()) {
                                 long lastUpdateTimeMs = adTask.get().getLastUpdateTime().toEpochMilli();

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -57,4 +57,5 @@ public class CommonErrorMessages {
     public static String INVALID_DETECTION_INTERVAL = "Detection interval must be a positive integer";
     public static String EXCEED_HISTORICAL_ANALYSIS_LIMIT = "Exceed max historical analysis limit per node";
     public static String NO_ELIGIBLE_NODE_TO_RUN_DETECTOR = "No eligible node to run detector ";
+    public static String EMPTY_STALE_RUNNING_ENTITIES = "Empty stale running entities";
 }

--- a/src/main/java/org/opensearch/ad/constant/CommonName.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonName.java
@@ -79,6 +79,7 @@ public class CommonName {
     public static final String ENTITY_INFO = "entity_info";
     public static final String TOTAL_UPDATES = "total_updates";
     public static final String AD_TASK = "ad_task";
+    public static final String HISTORICAL_ANALYSIS = "historical_analysis";
     public static final String AD_TASK_REMOTE = "ad_task_remote";
     public static final String CANCEL_TASK = "cancel_task";
 

--- a/src/main/java/org/opensearch/ad/model/ADTaskAction.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskAction.java
@@ -38,5 +38,5 @@ public enum ADTaskAction {
     // Push back entity to pending entities queue and run next entity.
     PUSH_BACK_ENTITY,
     // Clean stale entities in running entity queue, for example the work node crashed and fail to remove entity
-    CLEAN_RUNNING_ENTITY
+    CLEAN_STALE_RUNNING_ENTITIES
 }

--- a/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
@@ -29,6 +29,9 @@ package org.opensearch.ad.model;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.opensearch.ad.annotation.Generated;
 import org.opensearch.common.io.stream.StreamInput;
@@ -43,7 +46,7 @@ import com.google.common.base.Objects;
 /**
  * One anomaly detection task means one detector starts to run until stopped.
  */
-public class ADTaskProfile implements ToXContentObject, Writeable {
+public class ADTaskProfile implements ToXContentObject, Writeable, Writeable.Writer, Writeable.Reader {
 
     public static final String AD_TASK_FIELD = "ad_task";
     public static final String SHINGLE_SIZE_FIELD = "shingle_size";
@@ -52,6 +55,13 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
     public static final String THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD = "threshold_model_training_data_size";
     public static final String MODEL_SIZE_IN_BYTES = "model_size_in_bytes";
     public static final String NODE_ID_FIELD = "node_id";
+    public static final String ENTITY_FIELD = "entity";
+    public static final String TASK_ID_FIELD = "task_id";
+    public static final String AD_TASK_TYPE_FIELD = "task_type";
+    public static final String TOTAL_ENTITIES_COUNT_FIELD = "total_entities_count";
+    public static final String PENDING_ENTITIES_COUNT_FIELD = "pending_entities_count";
+    public static final String RUNNING_ENTITIES_COUNT_FIELD = "running_entities_count";
+    public static final String RUNNING_ENTITIES_FIELD = "running_entities";
 
     private ADTask adTask;
     private Integer shingleSize;
@@ -60,6 +70,13 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
     private Integer thresholdModelTrainingDataSize;
     private Long modelSizeInBytes;
     private String nodeId;
+    private List<Entity> entity;
+    private String taskId;
+    private String adTaskType;
+    private Integer totalEntitiesCount;
+    private Integer pendingEntitiesCount;
+    private Integer runningEntitiesCount;
+    private String[] runningEntities;
 
     public ADTaskProfile(
         Integer shingleSize,
@@ -70,6 +87,57 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         String nodeId
     ) {
         this(null, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdModelTrainingDataSize, modelSizeInBytes, nodeId);
+    }
+
+    public ADTaskProfile(
+        String nodeId,
+        Integer totalEntitiesCount,
+        Integer pendingEntitiesCount,
+        Integer runningEntitiesCount,
+        String[] runningEntities
+    ) {
+        this(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            nodeId,
+            null,
+            null,
+            totalEntitiesCount,
+            pendingEntitiesCount,
+            runningEntitiesCount,
+            runningEntities
+        );
+    }
+
+    public ADTaskProfile(
+        Integer shingleSize,
+        Long rcfTotalUpdates,
+        Boolean thresholdModelTrained,
+        Integer thresholdModelTrainingDataSize,
+        Long modelSizeInBytes,
+        String nodeId,
+        List<Entity> entity,
+        String taskId
+    ) {
+        this(
+            null,
+            shingleSize,
+            rcfTotalUpdates,
+            thresholdModelTrained,
+            thresholdModelTrainingDataSize,
+            modelSizeInBytes,
+            nodeId,
+            entity,
+            taskId,
+            null,
+            null,
+            null,
+            null
+        );
     }
 
     public ADTaskProfile(
@@ -90,6 +158,45 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         this.nodeId = nodeId;
     }
 
+    public ADTaskProfile(
+        ADTask adTask,
+        Integer shingleSize,
+        Long rcfTotalUpdates,
+        Boolean thresholdModelTrained,
+        Integer thresholdModelTrainingDataSize,
+        Long modelSizeInBytes,
+        String nodeId,
+        List<Entity> entity,
+        String taskId,
+        Integer totalEntitiesCount,
+        Integer pendingEntitiesCount,
+        Integer runningEntitiesCount,
+        String[] runningEntities
+    ) {
+        this.adTask = adTask;
+        this.shingleSize = shingleSize;
+        this.rcfTotalUpdates = rcfTotalUpdates;
+        this.thresholdModelTrained = thresholdModelTrained;
+        this.thresholdModelTrainingDataSize = thresholdModelTrainingDataSize;
+        this.modelSizeInBytes = modelSizeInBytes;
+        this.nodeId = nodeId;
+        this.entity = entity;
+        this.taskId = taskId;
+        this.totalEntitiesCount = totalEntitiesCount;
+        this.pendingEntitiesCount = pendingEntitiesCount;
+        this.runningEntitiesCount = runningEntitiesCount;
+        this.runningEntities = runningEntities;
+        if (entity != null && entity.size() > 0) {
+            setAdTaskType(ADTaskType.HISTORICAL_HC_ENTITY.name());
+        } else if (this.pendingEntitiesCount != null || runningEntities != null) {
+            setAdTaskType(ADTaskType.HISTORICAL_HC_DETECTOR.name());
+        }
+    }
+
+    public String getAdTaskType() {
+        return adTaskType;
+    }
+
     public ADTaskProfile(StreamInput input) throws IOException {
         if (input.readBoolean()) {
             this.adTask = new ADTask(input);
@@ -102,6 +209,17 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         this.thresholdModelTrainingDataSize = input.readOptionalInt();
         this.modelSizeInBytes = input.readOptionalLong();
         this.nodeId = input.readOptionalString();
+        if (input.readBoolean()) {
+            this.entity = input.readList(Entity::new);
+        } else {
+            this.entity = null;
+        }
+        this.taskId = input.readOptionalString();
+        this.adTaskType = input.readOptionalString();
+        totalEntitiesCount = input.readOptionalInt();
+        pendingEntitiesCount = input.readOptionalInt();
+        runningEntitiesCount = input.readOptionalInt();
+        runningEntities = input.readOptionalStringArray();
     }
 
     @Override
@@ -119,6 +237,18 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         out.writeOptionalInt(thresholdModelTrainingDataSize);
         out.writeOptionalLong(modelSizeInBytes);
         out.writeOptionalString(nodeId);
+        if (entity != null) {
+            out.writeBoolean(true);
+            out.writeList(entity);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalString(taskId);
+        out.writeOptionalString(adTaskType);
+        out.writeOptionalInt(totalEntitiesCount);
+        out.writeOptionalInt(pendingEntitiesCount);
+        out.writeOptionalInt(runningEntitiesCount);
+        out.writeOptionalStringArray(runningEntities);
     }
 
     @Override
@@ -145,6 +275,24 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         if (nodeId != null) {
             xContentBuilder.field(NODE_ID_FIELD, nodeId);
         }
+        if (entity != null && entity.size() > 0) {
+            xContentBuilder.field(ENTITY_FIELD, entity.toArray());
+        }
+        if (adTaskType != null) {
+            xContentBuilder.field(AD_TASK_TYPE_FIELD, adTaskType);
+        }
+        if (totalEntitiesCount != null) {
+            xContentBuilder.field(TOTAL_ENTITIES_COUNT_FIELD, totalEntitiesCount);
+        }
+        if (pendingEntitiesCount != null) {
+            xContentBuilder.field(PENDING_ENTITIES_COUNT_FIELD, pendingEntitiesCount);
+        }
+        if (runningEntitiesCount != null) {
+            xContentBuilder.field(RUNNING_ENTITIES_COUNT_FIELD, runningEntitiesCount);
+        }
+        if (runningEntities != null) {
+            xContentBuilder.field(RUNNING_ENTITIES_FIELD, runningEntities);
+        }
         return xContentBuilder.endObject();
     }
 
@@ -156,6 +304,12 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         Integer thresholdNodelTrainingDataSize = null;
         Long modelSizeInBytes = null;
         String nodeId = null;
+        List<Entity> entity = null;
+        String taskId = null;
+        Integer totalEntitiesCount = null;
+        Integer pendingEntitiesCount = null;
+        Integer runningEntitiesCount = null;
+        List<String> runningEntities = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -184,6 +338,32 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
                 case NODE_ID_FIELD:
                     nodeId = parser.text();
                     break;
+                case ENTITY_FIELD:
+                    entity = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        entity.add(Entity.parse(parser));
+                    }
+                    break;
+                case TASK_ID_FIELD:
+                    taskId = parser.text();
+                    break;
+                case TOTAL_ENTITIES_COUNT_FIELD:
+                    totalEntitiesCount = parser.intValue();
+                    break;
+                case PENDING_ENTITIES_COUNT_FIELD:
+                    pendingEntitiesCount = parser.intValue();
+                    break;
+                case RUNNING_ENTITIES_COUNT_FIELD:
+                    runningEntitiesCount = parser.intValue();
+                    break;
+                case RUNNING_ENTITIES_FIELD:
+                    runningEntities = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        runningEntities.add(parser.text());
+                    }
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -196,7 +376,13 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
             thresholdModelTrained,
             thresholdNodelTrainingDataSize,
             modelSizeInBytes,
-            nodeId
+            nodeId,
+            entity,
+            taskId,
+            totalEntitiesCount,
+            pendingEntitiesCount,
+            runningEntitiesCount,
+            runningEntities == null ? null : runningEntities.toArray(new String[0])
         );
     }
 
@@ -288,6 +474,38 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         this.modelSizeInBytes = modelSizeInBytes;
     }
 
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public void setAdTaskType(String adTaskType) {
+        this.adTaskType = adTaskType;
+    }
+
+    public List<Entity> getEntity() {
+        return entity;
+    }
+
+    public Integer getTotalEntitiesCount() {
+        return totalEntitiesCount;
+    }
+
+    public Integer getPendingEntitiesCount() {
+        return pendingEntitiesCount;
+    }
+
+    public Integer getRunningEntitiesCount() {
+        return runningEntitiesCount;
+    }
+
+    public String[] getRunningEntities() {
+        return runningEntities;
+    }
+
     @Override
     public String toString() {
         return "ADTaskProfile{"
@@ -299,13 +517,41 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
             + rcfTotalUpdates
             + ", thresholdModelTrained="
             + thresholdModelTrained
-            + ", thresholdNodelTrainingDataSize="
+            + ", thresholdModelTrainingDataSize="
             + thresholdModelTrainingDataSize
             + ", modelSizeInBytes="
             + modelSizeInBytes
             + ", nodeId='"
             + nodeId
             + '\''
+            + ", entity="
+            + entity
+            + ", taskId='"
+            + taskId
+            + '\''
+            + ", adTaskType='"
+            + adTaskType
+            + '\''
+            + ", totalEntitiesCount="
+            + totalEntitiesCount
+            + ", pendingEntitiesCount="
+            + pendingEntitiesCount
+            + ", runningEntitiesCount="
+            + runningEntitiesCount
+            + ", runningEntities="
+            + Arrays.toString(runningEntities)
             + '}';
+    }
+
+    @Override
+    public Object read(StreamInput in) throws IOException {
+        return new ADTaskProfile(in);
+    }
+
+    @Override
+    public void write(StreamOutput out, Object value) throws IOException {
+        if (value instanceof ADTaskProfile) {
+            ((ADTaskProfile) value).writeTo(out);
+        }
     }
 }

--- a/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
@@ -552,6 +552,8 @@ public class ADTaskProfile implements ToXContentObject, Writeable, Writeable.Wri
     public void write(StreamOutput out, Object value) throws IOException {
         if (value instanceof ADTaskProfile) {
             ((ADTaskProfile) value).writeTo(out);
+        } else {
+            throw new IllegalArgumentException("Can only write ADTaskProfile");
         }
     }
 }

--- a/src/main/java/org/opensearch/ad/model/ADTaskState.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskState.java
@@ -26,6 +26,10 @@
 
 package org.opensearch.ad.model;
 
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
 /**
  * AD task states.
  * <ul>
@@ -66,5 +70,8 @@ public enum ADTaskState {
     RUNNING,
     FAILED,
     STOPPED,
-    FINISHED
+    FINISHED;
+
+    public static List<String> NOT_ENDED_STATES = ImmutableList
+        .of(ADTaskState.CREATED.name(), ADTaskState.INIT.name(), ADTaskState.RUNNING.name());
 }

--- a/src/main/java/org/opensearch/ad/model/ADTaskType.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskType.java
@@ -43,4 +43,11 @@ public enum ADTaskType {
         .of(ADTaskType.HISTORICAL_HC_DETECTOR, ADTaskType.HISTORICAL_SINGLE_ENTITY, ADTaskType.HISTORICAL_HC_ENTITY);
     public static List<ADTaskType> REALTIME_TASK_TYPES = ImmutableList
         .of(ADTaskType.REALTIME_SINGLE_ENTITY, ADTaskType.REALTIME_HC_DETECTOR);
+    public static List<ADTaskType> ALL_DETECTOR_TASK_TYPES = ImmutableList
+        .of(
+            ADTaskType.REALTIME_SINGLE_ENTITY,
+            ADTaskType.REALTIME_HC_DETECTOR,
+            ADTaskType.HISTORICAL_SINGLE_ENTITY,
+            ADTaskType.HISTORICAL_HC_DETECTOR
+        );
 }

--- a/src/main/java/org/opensearch/ad/model/DetectorProfile.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorProfile.java
@@ -27,6 +27,7 @@
 package org.opensearch.ad.model;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -49,7 +50,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
     private InitProgressProfile initProgress;
     private Long totalEntities;
     private Long activeEntities;
-    private ADTaskProfile adTaskProfile;
+    private Map<String, ADTaskProfile> adTaskProfiles;
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
         return toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -69,7 +70,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             this.initProgress = new InitProgressProfile(in);
         }
         if (in.readBoolean()) {
-            this.adTaskProfile = new ADTaskProfile(in);
+            this.adTaskProfiles = in.readMap(StreamInput::readString, ADTaskProfile::new);
         }
     }
 
@@ -85,7 +86,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         private InitProgressProfile initProgress = null;
         private Long totalEntities;
         private Long activeEntities;
-        private ADTaskProfile adTaskProfile;
+        private Map<String, ADTaskProfile> adTaskProfiles;
 
         public Builder() {}
 
@@ -134,8 +135,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             return this;
         }
 
-        public Builder adTaskProfile(ADTaskProfile adTaskProfile) {
-            this.adTaskProfile = adTaskProfile;
+        public Builder adTaskProfiles(Map<String, ADTaskProfile> adTaskProfiles) {
+            this.adTaskProfiles = adTaskProfiles;
             return this;
         }
 
@@ -150,7 +151,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             profile.initProgress = initProgress;
             profile.totalEntities = totalEntities;
             profile.activeEntities = activeEntities;
-            profile.adTaskProfile = adTaskProfile;
+            profile.adTaskProfiles = adTaskProfiles;
 
             return profile;
         }
@@ -176,11 +177,10 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             out.writeBoolean(true);
             initProgress.writeTo(out);
         }
-        if (adTaskProfile == null) {
+        if (adTaskProfiles == null) {
             out.writeBoolean(false);
         } else {
-            out.writeBoolean(true);
-            adTaskProfile.writeTo(out);
+            out.writeMap(adTaskProfiles, StreamOutput::writeString, StreamOutput::writeGenericValue);
         }
     }
 
@@ -219,8 +219,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         if (activeEntities != null) {
             xContentBuilder.field(CommonName.ACTIVE_ENTITIES, activeEntities);
         }
-        if (adTaskProfile != null) {
-            xContentBuilder.field(CommonName.AD_TASK, adTaskProfile);
+        if (adTaskProfiles != null) {
+            xContentBuilder.field(CommonName.HISTORICAL_ANALYSIS, adTaskProfiles);
         }
         return xContentBuilder.endObject();
     }
@@ -297,12 +297,12 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         this.activeEntities = activeEntities;
     }
 
-    public ADTaskProfile getAdTaskProfile() {
-        return adTaskProfile;
+    public Map<String, ADTaskProfile> getAdTaskProfiles() {
+        return adTaskProfiles;
     }
 
-    public void setAdTaskProfile(ADTaskProfile adTaskProfile) {
-        this.adTaskProfile = adTaskProfile;
+    public void setAdTaskProfiles(Map<String, ADTaskProfile> adTaskProfiles) {
+        this.adTaskProfiles = adTaskProfiles;
     }
 
     @Override
@@ -338,8 +338,12 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         if (otherProfile.getActiveEntities() != null) {
             this.activeEntities = otherProfile.getActiveEntities();
         }
-        if (otherProfile.getAdTaskProfile() != null) {
-            this.adTaskProfile = otherProfile.getAdTaskProfile();
+        if (otherProfile.getAdTaskProfiles() != null) {
+            if (this.adTaskProfiles == null) {
+                this.adTaskProfiles = otherProfile.getAdTaskProfiles();
+            } else {
+                this.adTaskProfiles.putAll(otherProfile.getAdTaskProfiles());
+            }
         }
     }
 
@@ -382,8 +386,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             if (activeEntities != null) {
                 equalsBuilder.append(activeEntities, other.activeEntities);
             }
-            if (adTaskProfile != null) {
-                equalsBuilder.append(adTaskProfile, other.adTaskProfile);
+            if (adTaskProfiles != null) {
+                equalsBuilder.append(adTaskProfiles, other.adTaskProfiles);
             }
             return equalsBuilder.isEquals();
         }
@@ -402,7 +406,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             .append(initProgress)
             .append(totalEntities)
             .append(activeEntities)
-            .append(adTaskProfile)
+            .append(adTaskProfiles)
             .toHashCode();
     }
 
@@ -437,8 +441,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         if (activeEntities != null) {
             toStringBuilder.append(CommonName.ACTIVE_ENTITIES, activeEntities);
         }
-        if (adTaskProfile != null) {
-            toStringBuilder.append(CommonName.AD_TASK, adTaskProfile);
+        if (adTaskProfiles != null) {
+            toStringBuilder.append(CommonName.AD_TASK, adTaskProfiles);
         }
         return toStringBuilder.toString();
     }

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -250,7 +250,7 @@ public class IndexAnomalyDetectorActionHandler {
             if (existingDetector.isRealTimeDetector()) {
                 validateDetector(existingDetector);
             } else {
-                adTaskManager.getAndExecuteOnLatestADTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, (adTask) -> {
+                adTaskManager.getAndExecuteOnLatestDetectorLevelTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, (adTask) -> {
                     if (adTask.isPresent() && !adTaskManager.isADTaskEnded(adTask.get())) {
                         // can't update detector if there is AD task running
                         listener.onFailure(new OpenSearchStatusException("Detector is running", RestStatus.INTERNAL_SERVER_ERROR));

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -258,7 +258,7 @@ public class IndexAnomalyDetectorActionHandler {
                         // TODO: change to validateDetector method when we support HC historical detector
                         searchAdInputIndices(detectorId);
                     }
-                }, transportService, listener);
+                }, transportService, true, listener);
             }
         } catch (IOException e) {
             String message = "Failed to parse anomaly detector " + detectorId;

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -250,7 +250,7 @@ public class IndexAnomalyDetectorActionHandler {
             if (existingDetector.isRealTimeDetector()) {
                 validateDetector(existingDetector);
             } else {
-                adTaskManager.getLatestADTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, (adTask) -> {
+                adTaskManager.getAndExecuteOnLatestADTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, (adTask) -> {
                     if (adTask.isPresent() && !adTaskManager.isADTaskEnded(adTask.get())) {
                         // can't update detector if there is AD task running
                         listener.onFailure(new OpenSearchStatusException("Detector is running", RestStatus.INTERNAL_SERVER_ERROR));

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -30,6 +30,7 @@ import static org.opensearch.action.DocWriteResponse.Result.CREATED;
 import static org.opensearch.action.DocWriteResponse.Result.UPDATED;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.util.ExceptionUtil.getShardsFailure;
+import static org.opensearch.ad.util.RestHandlerUtils.createXContentParserFromRegistry;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
@@ -93,7 +94,7 @@ public class IndexAnomalyDetectorJobActionHandler {
      * @param primaryTerm             primary term of last modification
      * @param requestTimeout          request time out configuration
      * @param xContentRegistry        Registry which is used for XContentParser
-     * @param adTaskManager AD task manager
+     * @param adTaskManager           AD task manager
      */
     public IndexAnomalyDetectorJobActionHandler(
         Client client,
@@ -185,9 +186,7 @@ public class IndexAnomalyDetectorJobActionHandler {
     private void onGetAnomalyDetectorJobForWrite(GetResponse response, AnomalyDetector detector, AnomalyDetectorJob job)
         throws IOException {
         if (response.isExists()) {
-            try (
-                XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())
-            ) {
+            try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                 AnomalyDetectorJob currentAdJob = AnomalyDetectorJob.parse(parser);
                 if (currentAdJob.isEnabled()) {
@@ -266,10 +265,7 @@ public class IndexAnomalyDetectorJobActionHandler {
 
         client.get(getRequest, ActionListener.wrap(response -> {
             if (response.isExists()) {
-                try (
-                    XContentParser parser = RestHandlerUtils
-                        .createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())
-                ) {
+                try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     AnomalyDetectorJob job = AnomalyDetectorJob.parse(parser);
                     if (!job.isEnabled()) {

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -901,6 +901,7 @@ public class ADBatchTaskRunner {
             try {
                 if (dataPoints.size() == 0) {
                     logger.debug("No data in current piece with end time: " + pieceEndTime);
+                    // Current piece end time is the next piece's start time
                     runNextPiece(adTask, pieceEndTime, dataStartTime, dataEndTime, interval, internalListener);
                 } else {
                     detectAnomaly(
@@ -1033,6 +1034,7 @@ public class ADBatchTaskRunner {
                 anomalyResults,
                 new ThreadedActionListener<>(logger, threadPool, AD_BATCH_TASK_THREAD_POOL_NAME, ActionListener.wrap(r -> {
                     try {
+                        // Current piece end time is the next piece's start time
                         runNextPiece(adTask, pieceEndTime, dataStartTime, dataEndTime, interval, internalListener);
                     } catch (Exception e) {
                         internalListener.onFailure(e);

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -426,7 +426,7 @@ public class ADBatchTaskRunner {
                 // If fail, move the entity into pending task queue
                 adTaskCacheManager.addPendingEntity(detectorId, entity);
             });
-            // This is to handle retry case
+            // This is to handle retry case. To retry entity, we need to get the old entity task created before.
             adTaskManager.getLatestADTask(detectorId, entity, ImmutableList.of(ADTaskType.HISTORICAL_HC_ENTITY), existingEntityTask -> {
                 if (existingEntityTask.isPresent()) { // retry failed entity caused by limit exceed exception
                     // TODO: if task failed due to limit exceed exception in half way, resume from the break point or just clear the

--- a/src/main/java/org/opensearch/ad/task/ADHCBatchTaskCache.java
+++ b/src/main/java/org/opensearch/ad/task/ADHCBatchTaskCache.java
@@ -18,8 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.util.concurrent.RateLimiter;
-
 /**
  * AD HC detector batch task cache which will mainly hold these for HC detector
  * 1. pending entities queue
@@ -63,15 +61,11 @@ public class ADHCBatchTaskCache {
     // Record how many times the task has retried. Key is task id.
     private Map<String, AtomicInteger> taskRetryTimes;
 
-    // Task rate limiters. Key is task id.
-    private Map<String, RateLimiter> rateLimiters;
-
     public ADHCBatchTaskCache() {
         this.pendingEntities = new ConcurrentLinkedQueue<>();
         this.runningEntities = new ConcurrentLinkedQueue<>();
         this.tempEntities = new ConcurrentLinkedQueue<>();
         this.taskRetryTimes = new ConcurrentHashMap<>();
-        this.rateLimiters = new ConcurrentHashMap<>();
         this.detectorTaskUpdating = false;
         this.topEntitiesInited = false;
     }
@@ -186,10 +180,6 @@ public class ADHCBatchTaskCache {
         return this.runningEntities.remove(entity);
     }
 
-    public RateLimiter getRateLimiter(String taskId) {
-        return this.rateLimiters.computeIfAbsent(taskId, id -> RateLimiter.create(1));
-    }
-
     /**
      * Clear pending/running/temp entities queues, task retry times and rate limiter cache.
      */
@@ -198,7 +188,6 @@ public class ADHCBatchTaskCache {
         this.runningEntities.clear();
         this.tempEntities.clear();
         this.taskRetryTimes.clear();
-        this.rateLimiters.clear();
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -60,7 +60,6 @@ import org.opensearch.common.util.set.Sets;
 
 import com.amazon.randomcutforest.RandomCutForest;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.RateLimiter;
 
 public class ADTaskCacheManager {
     private final Logger logger = LogManager.getLogger(ADTaskCacheManager.class);
@@ -712,18 +711,6 @@ public class ADTaskCacheManager {
      */
     public boolean hasEntity(String detectorId) {
         return hcTaskCaches.containsKey(detectorId) && hcTaskCaches.get(detectorId).hasEntity();
-    }
-
-    /**
-     * Get rate limiter of AD task.
-     *
-     * @param detectorId detector id
-     * @param taskId AD task id
-     * @return rate limiter
-     */
-    public RateLimiter getRateLimiter(String detectorId, String taskId) {
-        ADHCBatchTaskCache hcTaskCache = getHCTaskCache(detectorId);
-        return hcTaskCache.getRateLimiter(taskId);
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileNodeResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileNodeResponse.java
@@ -27,6 +27,7 @@
 package org.opensearch.ad.transport;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.ad.model.ADTaskProfile;
@@ -36,32 +37,32 @@ import org.opensearch.common.io.stream.StreamOutput;
 
 public class ADTaskProfileNodeResponse extends BaseNodeResponse {
 
-    private ADTaskProfile adTaskProfile;
+    private List<ADTaskProfile> adTaskProfiles;
 
-    public ADTaskProfileNodeResponse(DiscoveryNode node, ADTaskProfile adTaskProfile) {
+    public ADTaskProfileNodeResponse(DiscoveryNode node, List<ADTaskProfile> adTaskProfile) {
         super(node);
-        this.adTaskProfile = adTaskProfile;
+        this.adTaskProfiles = adTaskProfile;
     }
 
     public ADTaskProfileNodeResponse(StreamInput in) throws IOException {
         super(in);
         if (in.readBoolean()) {
-            this.adTaskProfile = new ADTaskProfile(in);
+            this.adTaskProfiles = in.readList(ADTaskProfile::new);
         } else {
-            this.adTaskProfile = null;
+            this.adTaskProfiles = null;
         }
     }
 
-    public ADTaskProfile getAdTaskProfile() {
-        return adTaskProfile;
+    public List<ADTaskProfile> getAdTaskProfiles() {
+        return adTaskProfiles;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (adTaskProfile != null) {
+        if (adTaskProfiles != null) {
             out.writeBoolean(true);
-            adTaskProfile.writeTo(out);
+            out.writeList(adTaskProfiles);
         } else {
             out.writeBoolean(false);
         }

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
@@ -88,7 +88,7 @@ public class ADTaskProfileTransportAction extends
 
     @Override
     protected ADTaskProfileNodeResponse nodeOperation(ADTaskProfileNodeRequest request) {
-        ADTaskProfile adTaskProfile = adTaskManager.getLocalADTaskProfileByDetectorId(request.getDetectorId());
+        List<ADTaskProfile> adTaskProfile = adTaskManager.getLocalADTaskProfilesByDetectorId(request.getDetectorId());
 
         return new ADTaskProfileNodeResponse(clusterService.localNode(), adTaskProfile);
     }

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -112,7 +112,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
                 // Check if there is realtime job or historical analysis task running. If none of these running, we
                 // can delete the detector.
                 () -> adTaskManager.getDetector(detectorId, detector -> getDetectorJob(detectorId, listener, () -> {
-                    adTaskManager.getLatestADTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, adTask -> {
+                    adTaskManager.getAndExecuteOnLatestADTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, adTask -> {
                         if (adTask.isPresent() && !adTaskManager.isADTaskEnded(adTask.get())) {
                             listener.onFailure(new OpenSearchStatusException("Detector is running", RestStatus.INTERNAL_SERVER_ERROR));
                         } else {

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -112,7 +112,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
                 // Check if there is realtime job or historical analysis task running. If none of these running, we
                 // can delete the detector.
                 () -> adTaskManager.getDetector(detectorId, detector -> getDetectorJob(detectorId, listener, () -> {
-                    adTaskManager.getAndExecuteOnLatestADTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, adTask -> {
+                    adTaskManager.getAndExecuteOnLatestDetectorLevelTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, adTask -> {
                         if (adTask.isPresent() && !adTaskManager.isADTaskEnded(adTask.get())) {
                             listener.onFailure(new OpenSearchStatusException("Detector is running", RestStatus.INTERNAL_SERVER_ERROR));
                         } else {

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -118,7 +118,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
                         } else {
                             adTaskManager.deleteADTasks(detectorId, () -> deleteAnomalyDetectorJobDoc(detectorId, listener), listener);
                         }
-                    }, transportService, listener);
+                    }, transportService, true, listener);
                 }), listener),
                 client,
                 clusterService,

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorResponse.java
@@ -50,7 +50,8 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
     private long seqNo;
     private AnomalyDetector detector;
     private AnomalyDetectorJob adJob;
-    private ADTask adTask;
+    private ADTask realtimeAdTask;
+    private ADTask historicalAdTask;
     private RestStatus restStatus;
     private DetectorProfile detectorProfile;
     private EntityProfile entityProfile;
@@ -84,10 +85,15 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
                 adJob = null;
             }
             returnTask = in.readBoolean();
-            if (returnTask) {
-                adTask = new ADTask(in);
+            if (in.readBoolean()) {
+                realtimeAdTask = new ADTask(in);
             } else {
-                adTask = null;
+                realtimeAdTask = null;
+            }
+            if (in.readBoolean()) {
+                historicalAdTask = new ADTask(in);
+            } else {
+                historicalAdTask = null;
             }
         }
     }
@@ -100,7 +106,8 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
         AnomalyDetector detector,
         AnomalyDetectorJob adJob,
         boolean returnJob,
-        ADTask adTask,
+        ADTask realtimeAdTask,
+        ADTask historicalAdTask,
         boolean returnTask,
         RestStatus restStatus,
         DetectorProfile detectorProfile,
@@ -122,9 +129,11 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
         }
         this.returnTask = returnTask;
         if (this.returnTask) {
-            this.adTask = adTask;
+            this.realtimeAdTask = realtimeAdTask;
+            this.historicalAdTask = historicalAdTask;
         } else {
-            this.adTask = null;
+            this.realtimeAdTask = null;
+            this.historicalAdTask = null;
         }
         this.detectorProfile = detectorProfile;
         this.entityProfile = entityProfile;
@@ -156,9 +165,16 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
             } else {
                 out.writeBoolean(false); // returnJob is false
             }
-            if (returnTask) {
+            out.writeBoolean(returnTask);
+            if (realtimeAdTask != null) {
                 out.writeBoolean(true);
-                adTask.writeTo(out);
+                realtimeAdTask.writeTo(out);
+            } else {
+                out.writeBoolean(false);
+            }
+            if (historicalAdTask != null) {
+                out.writeBoolean(true);
+                historicalAdTask.writeTo(out);
             } else {
                 out.writeBoolean(false);
             }
@@ -184,7 +200,8 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
                 builder.field(RestHandlerUtils.ANOMALY_DETECTOR_JOB, adJob);
             }
             if (returnTask) {
-                builder.field(RestHandlerUtils.ANOMALY_DETECTION_TASK, adTask);
+                builder.field(RestHandlerUtils.REALTIME_TASK, realtimeAdTask);
+                builder.field(RestHandlerUtils.HISTORICAL_ANALYSIS_TASK, historicalAdTask);
             }
             builder.endObject();
         }

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -222,7 +222,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                 }
             } else {
                 if (returnTask) {
-                    adTaskManager.getLatestADTasks(detectorID, null, ALL_DETECTOR_TASK_TYPES, (taskList) -> {
+                    adTaskManager.getAndExecuteOnLatestADTasks(detectorID, null, ALL_DETECTOR_TASK_TYPES, (taskList) -> {
                         Optional<ADTask> realtimeAdTask = Optional.empty();
                         Optional<ADTask> historicalAdTask = Optional.empty();
 

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -26,7 +26,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
+import static org.opensearch.ad.model.ADTaskType.ALL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
@@ -39,8 +39,10 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +58,7 @@ import org.opensearch.ad.AnomalyDetectorProfileRunner;
 import org.opensearch.ad.EntityProfileRunner;
 import org.opensearch.ad.Name;
 import org.opensearch.ad.model.ADTask;
+import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.DetectorProfile;
@@ -193,6 +196,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                                                     null,
                                                     false,
                                                     null,
+                                                    null,
                                                     false,
                                                     null,
                                                     null,
@@ -218,17 +222,29 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                 }
             } else {
                 if (returnTask) {
-                    adTaskManager
-                        .getLatestADTask(
-                            detectorID,
-                            // TODO: return both latest realtime and historical tasks, fix in next PR
-                            HISTORICAL_DETECTOR_TASK_TYPES,
-                            (adTask) -> getDetectorAndJob(detectorID, returnJob, returnTask, adTask, listener),
-                            transportService,
-                            listener
-                        );
+                    adTaskManager.getLatestADTasks(detectorID, null, ALL_DETECTOR_TASK_TYPES, (taskList) -> {
+                        Optional<ADTask> realtimeAdTask = Optional.empty();
+                        Optional<ADTask> historicalAdTask = Optional.empty();
+
+                        if (taskList != null && taskList.size() > 0) {
+                            Map<String, ADTask> adTasks = taskList
+                                .stream()
+                                .collect(Collectors.toMap(ADTask::getTaskType, Function.identity()));
+                            if (adTasks.containsKey(ADTaskType.REALTIME_HC_DETECTOR.name())) {
+                                realtimeAdTask = Optional.ofNullable(adTasks.get(ADTaskType.REALTIME_HC_DETECTOR.name()));
+                            } else if (adTasks.containsKey(ADTaskType.REALTIME_SINGLE_ENTITY.name())) {
+                                realtimeAdTask = Optional.ofNullable(adTasks.get(ADTaskType.REALTIME_SINGLE_ENTITY.name()));
+                            }
+                            if (adTasks.containsKey(ADTaskType.HISTORICAL_HC_DETECTOR.name())) {
+                                historicalAdTask = Optional.ofNullable(adTasks.get(ADTaskType.HISTORICAL_HC_DETECTOR.name()));
+                            } else if (adTasks.containsKey(ADTaskType.HISTORICAL_SINGLE_ENTITY.name())) {
+                                historicalAdTask = Optional.ofNullable(adTasks.get(ADTaskType.HISTORICAL_SINGLE_ENTITY.name()));
+                            }
+                        }
+                        getDetectorAndJob(detectorID, returnJob, returnTask, realtimeAdTask, historicalAdTask, listener);
+                    }, transportService, true, 2, listener);
                 } else {
-                    getDetectorAndJob(detectorID, returnJob, returnTask, Optional.empty(), listener);
+                    getDetectorAndJob(detectorID, returnJob, returnTask, Optional.empty(), Optional.empty(), listener);
                 }
             }
         } catch (Exception e) {
@@ -241,7 +257,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         String detectorID,
         boolean returnJob,
         boolean returnTask,
-        Optional<ADTask> adTask,
+        Optional<ADTask> realtimeAdTask,
+        Optional<ADTask> historicalAdTask,
         ActionListener<GetAnomalyDetectorResponse> listener
     ) {
         MultiGetRequest.Item adItem = new MultiGetRequest.Item(ANOMALY_DETECTORS_INDEX, detectorID);
@@ -250,14 +267,15 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
             MultiGetRequest.Item adJobItem = new MultiGetRequest.Item(ANOMALY_DETECTOR_JOB_INDEX, detectorID);
             multiGetRequest.add(adJobItem);
         }
-        client.multiGet(multiGetRequest, onMultiGetResponse(listener, returnJob, returnTask, adTask, detectorID));
+        client.multiGet(multiGetRequest, onMultiGetResponse(listener, returnJob, returnTask, realtimeAdTask, historicalAdTask, detectorID));
     }
 
     private ActionListener<MultiGetResponse> onMultiGetResponse(
         ActionListener<GetAnomalyDetectorResponse> listener,
         boolean returnJob,
         boolean returnTask,
-        Optional<ADTask> adTask,
+        Optional<ADTask> realtimeAdTask,
+        Optional<ADTask> historicalAdTask,
         String detectorId
     ) {
         return new ActionListener<MultiGetResponse>() {
@@ -327,7 +345,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                             detector,
                             adJob,
                             returnJob,
-                            adTask.orElse(null),
+                            realtimeAdTask.orElse(null),
+                            historicalAdTask.orElse(null),
                             returnTask,
                             RestStatus.OK,
                             null,
@@ -349,7 +368,9 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
             @Override
             public void accept(DetectorProfile profile) throws Exception {
                 listener
-                    .onResponse(new GetAnomalyDetectorResponse(0, null, 0, 0, null, null, false, null, false, null, profile, null, true));
+                    .onResponse(
+                        new GetAnomalyDetectorResponse(0, null, 0, 0, null, null, false, null, null, false, null, profile, null, true)
+                    );
             }
         }, exception -> { listener.onFailure(exception); });
     }

--- a/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
@@ -62,7 +62,8 @@ public final class RestHandlerUtils {
     public static final String DETECTOR_ID = "detectorID";
     public static final String ANOMALY_DETECTOR = "anomaly_detector";
     public static final String ANOMALY_DETECTOR_JOB = "anomaly_detector_job";
-    public static final String ANOMALY_DETECTION_TASK = "anomaly_detection_task";
+    public static final String REALTIME_TASK = "realtime_detection_task";
+    public static final String HISTORICAL_ANALYSIS_TASK = "historical_analysis_task";
     public static final String RUN = "_run";
     public static final String PREVIEW = "_preview";
     public static final String START_JOB = "_start";


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@dev-dsk-ylwu-2c-e500d1cf.us-west-2.amazon.com>

### Description
1. Profile API: return task profiles of HC historical analysis
2. Get detector API: return both realtime and historical tasks if user add task=true
3. Error handling: If task keeps running for a long time, get task profile to check if historical analysis still running. If not running, reset task state as stopped. This can handle coordinating node crash.
4. Error handling: clean stale running entities in coordinating node cache in case worker nodes crash or fail to send back entity task done message. This can handle worker node crash.
5. Change rate limiter to thread.schedule to avoid blocking thread.

This PR is only for reviewing the main logic. UT and IT will be in separate PR.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
