### PR TITLE
don't replace detector user when update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![AD Test](https://github.com/opensearch-project/anomaly-detection/workflows/Build%20and%20Test%20Anomaly%20detection/badge.svg)](https://github.com/opensearch-project/anomaly-detection/actions?query=workflow%3A%22Build+and+Test+Anomaly+detection%22+branch%3A%22main%22)
 [![codecov](https://codecov.io/gh/opensearch-project/anomaly-detection/branch/main/graph/badge.svg?flag=plugin)](https://codecov.io/gh/opensearch-project/anomaly-detection)
-[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://docs-beta.opensearch.org/monitoring-plugins/ad/index/)
+[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/monitoring-plugins/ad/index/)
 [![Forum](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/Use-this-category-for-all-questions-around-machine-learning-plugins)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
@@ -30,7 +30,7 @@ You can use this plugin with the same version of the [OpenSearch Alerting Plugin
   
 ## Documentation
 
-Please see [our documentation](https://docs-beta.opensearch.org/monitoring-plugins/ad/index/).
+Please see [our documentation](https://opensearch.org/docs/monitoring-plugins/ad/index/).
 
 
 ## Contributing

--- a/build.gradle
+++ b/build.gradle
@@ -449,7 +449,7 @@ afterEvaluate {
         url 'https://opensearch.org/downloads.html'
         summary '''
          Anomaly Detection plugin for OpenSearch.
-         Reference documentation can be found at https://docs-beta.opensearch.org/docs/ad/.
+         Reference documentation can be found at https://opensearch.org/docs/monitoring-plugins/ad/index/.
     '''.stripIndent().replace('\n', ' ').trim()
     }
 

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -102,7 +102,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
                 detectorId,
                 filterByEnabled,
                 listener,
-                () -> executeDetector(listener, detectorId, seqNo, primaryTerm, rawPath, requestTimeout, user),
+                (anomalyDetector) -> executeDetector(listener, detectorId, seqNo, primaryTerm, rawPath, requestTimeout, user),
                 client,
                 clusterService,
                 xContentRegistry

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -108,7 +108,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
                 detectorId,
                 filterByEnabled,
                 listener,
-                () -> adTaskManager
+                (anomalyDetector) -> adTaskManager
                     .getDetector(
                         detectorId,
                         // realtime detector

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -145,7 +145,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                 detectorID,
                 filterByEnabled,
                 listener,
-                () -> getExecute(request, listener),
+                (anomalyDetector) -> getExecute(request, listener),
                 client,
                 clusterService,
                 xContentRegistry

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -104,7 +104,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                 detectorId,
                 filterByEnabled,
                 listener,
-                () -> previewExecute(request, context, listener),
+                (anomalyDetector) -> previewExecute(request, context, listener),
                 client,
                 clusterService,
                 xContentRegistry

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -201,6 +201,19 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
         return (AnomalyDetector) getAnomalyDetector(detectorId, false, client)[0];
     }
 
+    public Response updateAnomalyDetector(String detectorId, AnomalyDetector newDetector, RestClient client) throws IOException {
+        BasicHeader header = new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        return TestHelpers
+            .makeRequest(
+                client,
+                "PUT",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId,
+                null,
+                toJsonString(newDetector),
+                ImmutableList.of(header)
+            );
+    }
+
     public AnomalyDetector getAnomalyDetector(String detectorId, BasicHeader header, RestClient client) throws IOException {
         return (AnomalyDetector) getAnomalyDetector(detectorId, header, false, false, client)[0];
     }

--- a/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
@@ -105,7 +105,7 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
                 detectorId,
                 filterByEnabled,
                 listener,
-                () -> executeDetector(listener, detectorId, seqNo, primaryTerm, rawPath, requestTimeout, user),
+                (anomalyDetector) -> executeDetector(listener, detectorId, seqNo, primaryTerm, rawPath, requestTimeout, user),
                 client,
                 clusterService,
                 xContentRegistry

--- a/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportActionTests.java
@@ -77,7 +77,6 @@ public class DeleteAnomalyDetectorTransportActionTests extends HistoricalDetecto
         String detectorId = createDetector(detector);
         DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest(detectorId);
         DeleteResponse deleteResponse = client().execute(DeleteAnomalyDetectorAction.INSTANCE, request).actionGet(10000);
-        System.out.println(deleteResponse);
         assertEquals("deleted", deleteResponse.getResult().getLowercase());
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
@@ -26,9 +26,12 @@
 
 package org.opensearch.ad.transport;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,25 +39,42 @@ import java.util.HashSet;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+
+import com.google.common.collect.ImmutableMap;
 
 public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTestCase {
     private IndexAnomalyDetectorTransportAction action;
@@ -64,7 +84,9 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
     private ClusterService clusterService;
     private ClusterSettings clusterSettings;
     private ADTaskManager adTaskManager;
+    private Client client = mock(Client.class);
 
+    @SuppressWarnings("unchecked")
     @Override
     @Before
     public void setUp() throws Exception {
@@ -75,6 +97,22 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        ClusterName clusterName = new ClusterName("test");
+        Settings indexSettings = Settings
+            .builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .build();
+        final Settings.Builder existingSettings = Settings.builder().put(indexSettings).put(IndexMetadata.SETTING_INDEX_UUID, "test2UUID");
+        IndexMetadata indexMetaData = IndexMetadata.builder(AnomalyDetector.ANOMALY_DETECTORS_INDEX).settings(existingSettings).build();
+        final ImmutableOpenMap<String, IndexMetadata> indices = ImmutableOpenMap
+            .<String, IndexMetadata>builder()
+            .fPut(AnomalyDetector.ANOMALY_DETECTORS_INDEX, indexMetaData)
+            .build();
+        ClusterState clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().indices(indices).build()).build();
+        when(clusterService.state()).thenReturn(clusterState);
 
         adTaskManager = mock(ADTaskManager.class);
         action = new IndexAnomalyDetectorTransportAction(
@@ -88,12 +126,51 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
             adTaskManager
         );
         task = mock(Task.class);
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        GetResponse getDetectorResponse = TestHelpers
+            .createGetResponse(detector, detector.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 2);
+
+            assertTrue(args[0] instanceof GetRequest);
+            assertTrue(args[1] instanceof ActionListener);
+
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+            listener.onResponse(getDetectorResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        SearchHits hits = new SearchHits(new SearchHit[] {}, null, Float.NaN);
+        SearchResponseSections searchSections = new SearchResponseSections(hits, null, null, false, false, null, 1);
+        SearchResponse searchResponse = new SearchResponse(
+            searchSections,
+            null,
+            1,
+            1,
+            0,
+            30,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 2);
+
+            assertTrue(args[0] instanceof SearchRequest);
+            assertTrue(args[1] instanceof ActionListener);
+
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+
         request = new IndexAnomalyDetectorRequest(
             "1234",
             4567,
             7890,
             WriteRequest.RefreshPolicy.IMMEDIATE,
-            mock(AnomalyDetector.class),
+            detector,
             RestRequest.Method.PUT,
             TimeValue.timeValueSeconds(60),
             1000,
@@ -125,7 +202,6 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
         ThreadContext threadContext = new ThreadContext(settings);
         threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        Client client = mock(Client.class);
         org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(client.threadPool()).thenReturn(mockThreadPool);
         when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
@@ -149,7 +225,6 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
         ThreadContext threadContext = new ThreadContext(settings);
         threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        Client client = mock(Client.class);
         org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(client.threadPool()).thenReturn(mockThreadPool);
         when(mockThreadPool.getThreadContext()).thenReturn(threadContext);


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
In current implementation, when user update detector,  we will replace detector user as current user. In some cases, it may cause detector creator lose access of detector. Check more details in #124 
Based on discussion with @skkosuri-amzn and PM, we plan to fix this issue quickly by blocking replacing detector user when update. User can't update detector user after creation.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/124
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
