### PR TITLE
add delete anomaly results API

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -70,6 +70,7 @@ import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.DetectorInternalState;
 import org.opensearch.ad.rest.RestAnomalyDetectorJobAction;
 import org.opensearch.ad.rest.RestDeleteAnomalyDetectorAction;
+import org.opensearch.ad.rest.RestDeleteAnomalyResultsAction;
 import org.opensearch.ad.rest.RestExecuteAnomalyDetectorAction;
 import org.opensearch.ad.rest.RestGetAnomalyDetectorAction;
 import org.opensearch.ad.rest.RestIndexAnomalyDetectorAction;
@@ -112,6 +113,8 @@ import org.opensearch.ad.transport.CronAction;
 import org.opensearch.ad.transport.CronTransportAction;
 import org.opensearch.ad.transport.DeleteAnomalyDetectorAction;
 import org.opensearch.ad.transport.DeleteAnomalyDetectorTransportAction;
+import org.opensearch.ad.transport.DeleteAnomalyResultsAction;
+import org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction;
 import org.opensearch.ad.transport.DeleteModelAction;
 import org.opensearch.ad.transport.DeleteModelTransportAction;
 import org.opensearch.ad.transport.EntityProfileAction;
@@ -277,6 +280,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         RestAnomalyDetectorJobAction anomalyDetectorJobAction = new RestAnomalyDetectorJobAction(settings, clusterService);
         RestSearchAnomalyDetectorInfoAction searchAnomalyDetectorInfoAction = new RestSearchAnomalyDetectorInfoAction();
         RestPreviewAnomalyDetectorAction previewAnomalyDetectorAction = new RestPreviewAnomalyDetectorAction();
+        RestDeleteAnomalyResultsAction deleteAnomalyResultsAction = new RestDeleteAnomalyResultsAction();
 
         return ImmutableList
             .of(
@@ -290,7 +294,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 anomalyDetectorJobAction,
                 statsAnomalyDetectorAction,
                 searchAnomalyDetectorInfoAction,
-                previewAnomalyDetectorAction
+                previewAnomalyDetectorAction,
+                deleteAnomalyResultsAction
             );
     }
 
@@ -740,7 +745,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(ADBatchTaskRemoteExecutionAction.INSTANCE, ADBatchTaskRemoteExecutionTransportAction.class),
                 new ActionHandler<>(ADTaskProfileAction.INSTANCE, ADTaskProfileTransportAction.class),
                 new ActionHandler<>(ADCancelTaskAction.INSTANCE, ADCancelTaskTransportAction.class),
-                new ActionHandler<>(ForwardADTaskAction.INSTANCE, ForwardADTaskTransportAction.class)
+                new ActionHandler<>(ForwardADTaskAction.INSTANCE, ForwardADTaskTransportAction.class),
+                new ActionHandler<>(DeleteAnomalyResultsAction.INSTANCE, DeleteAnomalyResultsTransportAction.class)
             );
     }
 

--- a/src/main/java/org/opensearch/ad/rest/RestDeleteAnomalyResultsAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestDeleteAnomalyResultsAction.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.rest;
+
+import static org.opensearch.ad.indices.AnomalyDetectionIndices.ALL_AD_RESULTS_INDEX_PATTERN;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.settings.EnabledSetting;
+import org.opensearch.ad.transport.DeleteAnomalyResultsAction;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This class consists of the REST handler to delete anomaly result with specific query.
+ * Currently AD dashboard plugin doesn't call this API. User can use this API to delete
+ * anomaly results to free up disk space.
+ */
+public class RestDeleteAnomalyResultsAction extends BaseRestHandler {
+
+    private static final String DELETE_AD_RESULTS_ACTION = "delete_anomaly_results";
+    private static final Logger logger = LogManager.getLogger(RestDeleteAnomalyResultsAction.class);
+
+    public RestDeleteAnomalyResultsAction() {}
+
+    @Override
+    public String getName() {
+        return DELETE_AD_RESULTS_ACTION;
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!EnabledSetting.isADPluginEnabled()) {
+            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+        }
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());
+        logger.debug("delete AD results with query: {} ", searchSourceBuilder);
+        DeleteByQueryRequest deleteRequest = new DeleteByQueryRequest(ALL_AD_RESULTS_INDEX_PATTERN)
+            .setQuery(searchSourceBuilder.query())
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN);
+        return channel -> client.execute(DeleteAnomalyResultsAction.INSTANCE, deleteRequest, ActionListener.wrap(r -> {
+            XContentBuilder contentBuilder = r.toXContent(channel.newBuilder().startObject(), ToXContent.EMPTY_PARAMS);
+            contentBuilder.endObject();
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, contentBuilder));
+        }, e -> {
+            try {
+                channel.sendResponse(new BytesRestResponse(channel, e));
+            } catch (IOException exception) {
+                logger.error("Failed to send back delete anomaly result exception result", exception);
+            }
+        }));
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.DELETE, AnomalyDetectorPlugin.AD_BASE_DETECTORS_URI + "/results"));
+    }
+}

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.ad.constant.CommonValue;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+
+public class DeleteAnomalyResultsAction extends ActionType<BulkByScrollResponse> {
+    // External Action which used for public facing RestAPIs.
+    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "results/delete";
+    public static final DeleteAnomalyResultsAction INSTANCE = new DeleteAnomalyResultsAction();
+
+    private DeleteAnomalyResultsAction() {
+        super(NAME, BulkByScrollResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.transport;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
+import static org.opensearch.ad.util.ParseUtils.getUserContext;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<DeleteByQueryRequest, BulkByScrollResponse> {
+
+    private final Client client;
+    private volatile Boolean filterEnabled;
+    private static final Logger logger = LogManager.getLogger(DeleteAnomalyResultsTransportAction.class);
+
+    @Inject
+    public DeleteAnomalyResultsTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Settings settings,
+        ClusterService clusterService,
+        Client client
+    ) {
+        super(DeleteAnomalyResultsAction.NAME, transportService, actionFilters, DeleteByQueryRequest::new);
+        this.client = client;
+        filterEnabled = FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterEnabled = it);
+    }
+
+    @Override
+    protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+        delete(request, listener);
+    }
+
+    public void delete(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+        User user = getUserContext(client);
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            validateRole(request, user, listener);
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void validateRole(DeleteByQueryRequest request, User user, ActionListener<BulkByScrollResponse> listener) {
+        if (user == null || !filterEnabled) {
+            // Case 1: user == null when 1. Security is disabled. 2. When user is super-admin
+            // Case 2: If Security is enabled and filter is disabled, proceed with search as
+            // user is already authenticated to hit this API.
+            client.execute(DeleteByQueryAction.INSTANCE, request, listener);
+        } else {
+            // Security is enabled and backend role filter is enabled
+            try {
+                addUserBackendRolesFilter(user, request.getSearchRequest().source());
+                client.execute(DeleteByQueryAction.INSTANCE, request, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
With historical analysis, user can generate much more anomaly result in a short time, especially for HC detector. AD plugin will roll over anomaly result index if its doc count reaches some limit, and will delete roll-over index after some period (30 days by default). So if user run historical analysis, it may generate too many AD results and speed up the rollover and AD result index cleanup. 

This PR adds delete anomaly result API. User can use this API to delete anomaly results with specific query like delete all anomaly results of one detector/task.

Sample request

```
DELETE _plugins/_anomaly_detection/detectors/results
{
  "query": {
    "bool": {
      "filter": [
        {
          "term": {
            "detector_id": {
              "value": "6tZminoBaXxjTubPk0k6"
            }
          }
        }
      ]
    }
  }
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
