### PR TITLE
maintain running historical task in hourly cron

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -526,7 +526,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             anomalyDetectionIndices,
             nodeFilter,
             hashRing,
-            adTaskCacheManager
+            adTaskCacheManager,
+            threadPool
         );
         AnomalyResultBulkIndexHandler anomalyResultBulkIndexHandler = new AnomalyResultBulkIndexHandler(
             client,
@@ -674,7 +675,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR,
                 AnomalyDetectorSettings.BATCH_TASK_PIECE_SIZE,
                 AnomalyDetectorSettings.MAX_TOP_ENTITIES_FOR_HISTORICAL_ANALYSIS,
-                AnomalyDetectorSettings.MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS
+                AnomalyDetectorSettings.MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS,
+                AnomalyDetectorSettings.MAX_CACHED_DELETED_TASKS
             );
         return unmodifiableList(Stream.concat(enabledSetting.stream(), systemSetting.stream()).collect(Collectors.toList()));
     }

--- a/src/main/java/org/opensearch/ad/cluster/HourlyCron.java
+++ b/src/main/java/org/opensearch/ad/cluster/HourlyCron.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.cluster;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
@@ -55,7 +56,10 @@ public class HourlyCron implements Runnable {
 
         // we also add the cancel query function here based on query text from the negative cache.
 
-        CronRequest modelDeleteRequest = new CronRequest(dataNodes);
+        // Length of detector id is 20. Here we create a random string as request id to get hash with
+        // HashRing, then we can control some maintaining task to just run on one data node. Read
+        // ADTaskManager#maintainRunningHistoricalTasks for more details.
+        CronRequest modelDeleteRequest = new CronRequest(RandomStringUtils.random(20), dataNodes);
         client.execute(CronAction.INSTANCE, modelDeleteRequest, ActionListener.wrap(response -> {
             if (response.hasFailures()) {
                 for (FailedNodeException failedNodeException : response.failures()) {

--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -210,6 +210,14 @@ public class ADTask implements ToXContentObject, Writeable {
         return ADTaskType.HISTORICAL_HC_ENTITY.name().equals(taskType);
     }
 
+    /**
+     * Get detector level task id. If a task has no parent task, the task is detector level task.
+     * @return detector level task id
+     */
+    public String getDetectorLevelTaskId() {
+        return getParentTaskId() != null ? getParentTaskId() : getTaskId();
+    }
+
     public static class Builder {
         private String taskId = null;
         private String taskType = null;

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -370,6 +370,17 @@ public final class AnomalyDetectorSettings {
             Setting.Property.Dynamic
         );
 
+    public static final Setting<Integer> MAX_CACHED_DELETED_TASKS = Setting
+        .intSetting(
+            "plugins.anomaly_detection.max_cached_deleted_tasks",
+            1000,
+            1,
+            10_000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic,
+            Setting.Property.Deprecated
+        );
+
     public static int THRESHOLD_MODEL_TRAINING_SIZE = 1000;
 
     // Maximum number of old AD tasks we can keep.

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -968,9 +968,10 @@ public class ADBatchTaskRunner {
                 String error = feature.getUnprocessedFeatures().isPresent()
                     ? "No full shingle in current detection window"
                     : "No data in current detection window";
+                String resultTaskId = adTask.getParentTaskId() != null ? adTask.getParentTaskId() : adTask.getTaskId();
                 AnomalyResult anomalyResult = new AnomalyResult(
                     adTask.getDetectorId(),
-                    taskId,
+                    resultTaskId,
                     Double.NaN,
                     Double.NaN,
                     Double.NaN,
@@ -980,7 +981,7 @@ public class ADBatchTaskRunner {
                     executeStartTime,
                     Instant.now(),
                     error,
-                    null,
+                    adTask.getEntity(),
                     adTask.getDetector().getUser(),
                     anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT)
                 );
@@ -1008,10 +1009,10 @@ public class ADBatchTaskRunner {
                         threshold.update(score);
                     }
                 }
-
+                String resultTaskId = adTask.getParentTaskId() != null ? adTask.getParentTaskId() : adTask.getTaskId();
                 AnomalyResult anomalyResult = new AnomalyResult(
                     adTask.getDetectorId(),
-                    taskId,
+                    resultTaskId,
                     score,
                     grade,
                     confidence,
@@ -1021,7 +1022,7 @@ public class ADBatchTaskRunner {
                     executeStartTime,
                     Instant.now(),
                     null,
-                    null,
+                    adTask.getEntity(),
                     adTask.getDetector().getUser(),
                     anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT)
                 );

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -968,10 +968,9 @@ public class ADBatchTaskRunner {
                 String error = feature.getUnprocessedFeatures().isPresent()
                     ? "No full shingle in current detection window"
                     : "No data in current detection window";
-                String resultTaskId = adTask.getParentTaskId() != null ? adTask.getParentTaskId() : adTask.getTaskId();
                 AnomalyResult anomalyResult = new AnomalyResult(
                     adTask.getDetectorId(),
-                    resultTaskId,
+                    adTask.getDetectorLevelTaskId(),
                     Double.NaN,
                     Double.NaN,
                     Double.NaN,
@@ -1009,10 +1008,9 @@ public class ADBatchTaskRunner {
                         threshold.update(score);
                     }
                 }
-                String resultTaskId = adTask.getParentTaskId() != null ? adTask.getParentTaskId() : adTask.getTaskId();
                 AnomalyResult anomalyResult = new AnomalyResult(
                     adTask.getDetectorId(),
-                    resultTaskId,
+                    adTask.getDetectorLevelTaskId(),
                     score,
                     grade,
                     confidence,

--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -30,6 +30,7 @@ import static org.opensearch.ad.MemoryTracker.Origin.HISTORICAL_SINGLE_ENTITY_DE
 import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
 import static org.opensearch.ad.constant.CommonErrorMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CACHED_DELETED_TASKS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_TREES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.THRESHOLD_MODEL_TRAINING_SIZE;
@@ -39,8 +40,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -65,6 +68,7 @@ public class ADTaskCacheManager {
     private final Logger logger = LogManager.getLogger(ADTaskCacheManager.class);
     private final Map<String, ADBatchTaskCache> taskCaches;
     private volatile Integer maxAdBatchTaskPerNode;
+    private volatile Integer maxCachedDeletedTask;
     private final MemoryTracker memoryTracker;
     private final int numberSize = 8;
     private final int taskRetryLimit = 3;
@@ -80,6 +84,8 @@ public class ADTaskCacheManager {
 
     // Use this field to cache all HC tasks. Key is detector id
     private Map<String, ADHCBatchTaskCache> hcTaskCaches;
+    // cache deleted detector level tasks
+    private Queue<String> deletedDetectorTasks;
 
     // This field is to cache all realtime tasks. Key is detector id
     private Map<String, ADRealtimeTaskCache> realtimeTaskCaches;
@@ -94,11 +100,14 @@ public class ADTaskCacheManager {
     public ADTaskCacheManager(Settings settings, ClusterService clusterService, MemoryTracker memoryTracker) {
         this.maxAdBatchTaskPerNode = MAX_BATCH_TASK_PER_NODE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_BATCH_TASK_PER_NODE, it -> maxAdBatchTaskPerNode = it);
+        this.maxCachedDeletedTask = MAX_CACHED_DELETED_TASKS.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_CACHED_DELETED_TASKS, it -> maxCachedDeletedTask = it);
         taskCaches = new ConcurrentHashMap<>();
         this.memoryTracker = memoryTracker;
         this.detectors = Sets.newConcurrentHashSet();
         this.hcTaskCaches = new ConcurrentHashMap<>();
         this.realtimeTaskCaches = new ConcurrentHashMap<>();
+        this.deletedDetectorTasks = new ConcurrentLinkedQueue<>();
     }
 
     /**
@@ -813,6 +822,16 @@ public class ADTaskCacheManager {
     }
 
     /**
+     * Add deleted task's id to deleted detector tasks queue.
+     * @param taskId task id
+     */
+    public void addDeletedDetectorTask(String taskId) {
+        if (deletedDetectorTasks.size() < maxCachedDeletedTask) {
+            deletedDetectorTasks.add(taskId);
+        }
+    }
+
+    /**
      * Remove detector's realtime task from cache.
      * @param detectorId detector id
      */
@@ -821,4 +840,21 @@ public class ADTaskCacheManager {
             realtimeTaskCaches.remove(detectorId);
         }
     }
+
+    /**
+     * Check if deleted task queue has items.
+     * @return true if has deleted detector task in cache
+     */
+    public boolean hasDeletedDetectorTask() {
+        return !deletedDetectorTasks.isEmpty();
+    }
+
+    /**
+     * Poll one deleted detector task.
+     * @return task id
+     */
+    public String pollDeletedDetectorTask() {
+        return this.deletedDetectorTasks.poll();
+    }
+
 }

--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -787,13 +787,15 @@ public class ADTaskCacheManager {
      * 2. If any field value changed, will consider the realtime task changed.
      * 3. If realtime task cache not found, will consider the realtime task changed
      *    and put new realtime task into cache.
+     *
+     * If realtime task changed, put new field value into cache.
      * @param detectorId detector id
      * @param newState new task state
      * @param newInitProgress new init progress
      * @param newError new error
      * @return true if realtime task changed comparing with realtime task cache.
      */
-    public boolean realtimeTaskChanged(String detectorId, String newState, Float newInitProgress, String newError) {
+    public boolean checkIfRealtimeTaskChangedAndUpdateCache(String detectorId, String newState, Float newInitProgress, String newError) {
         if (realtimeTaskCaches.containsKey(detectorId)) {
             ADRealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(detectorId);
             boolean stateChanged = false;
@@ -822,6 +824,14 @@ public class ADTaskCacheManager {
     }
 
     /**
+     * Get detector IDs from realtime task cache.
+     * @return array of detector id
+     */
+    public String[] getDetectorIdsInRealtimeTaskCache() {
+        return realtimeTaskCaches.keySet().toArray(new String[0]);
+    }
+
+    /**
      * Add deleted task's id to deleted detector tasks queue.
      * @param taskId task id
      */
@@ -839,6 +849,13 @@ public class ADTaskCacheManager {
         if (realtimeTaskCaches.containsKey(detectorId)) {
             realtimeTaskCaches.remove(detectorId);
         }
+    }
+
+    /**
+     * Clear realtime task cache.
+     */
+    public void clearRealtimeTaskCache() {
+        realtimeTaskCaches.clear();
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -27,9 +27,11 @@
 package org.opensearch.ad.task;
 
 import static org.opensearch.action.DocWriteResponse.Result.CREATED;
+import static org.opensearch.ad.AnomalyDetectorPlugin.AD_BATCH_TASK_THREAD_POOL_NAME;
 import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
 import static org.opensearch.ad.constant.CommonErrorMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
 import static org.opensearch.ad.constant.CommonErrorMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
+import static org.opensearch.ad.indices.AnomalyDetectionIndices.ALL_AD_RESULTS_INDEX_PATTERN;
 import static org.opensearch.ad.model.ADTask.DETECTOR_ID_FIELD;
 import static org.opensearch.ad.model.ADTask.ERROR_FIELD;
 import static org.opensearch.ad.model.ADTask.ESTIMATED_MINUTES_LEFT_FIELD;
@@ -43,10 +45,12 @@ import static org.opensearch.ad.model.ADTask.STATE_FIELD;
 import static org.opensearch.ad.model.ADTask.STOPPED_BY_FIELD;
 import static org.opensearch.ad.model.ADTask.TASK_PROGRESS_FIELD;
 import static org.opensearch.ad.model.ADTask.TASK_TYPE_FIELD;
+import static org.opensearch.ad.model.ADTaskState.NOT_ENDED_STATES;
 import static org.opensearch.ad.model.ADTaskType.ALL_HISTORICAL_TASK_TYPES;
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.ADTaskType.REALTIME_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.opensearch.ad.model.AnomalyResult.TASK_ID_FIELD;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
@@ -68,6 +72,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -127,6 +132,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -147,6 +153,7 @@ import org.opensearch.script.Script;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportService;
 
@@ -171,6 +178,8 @@ public class ADTaskManager {
     private volatile Integer maxOldAdTaskDocsPerDetector;
     private volatile Integer pieceIntervalSeconds;
     private volatile TransportRequestOptions transportRequestOptions;
+    private final ThreadPool threadPool;
+    private static int DEFAULT_MAINTAIN_INTERVAL_IN_SECONDS = 5;
 
     public ADTaskManager(
         Settings settings,
@@ -180,7 +189,8 @@ public class ADTaskManager {
         AnomalyDetectionIndices detectionIndices,
         DiscoveryNodeFilterer nodeFilter,
         HashRing hashRing,
-        ADTaskCacheManager adTaskCacheManager
+        ADTaskCacheManager adTaskCacheManager,
+        ThreadPool threadPool
     ) {
         this.client = client;
         this.xContentRegistry = xContentRegistry;
@@ -215,7 +225,7 @@ public class ADTaskManager {
                         .build();
                 }
             );
-
+        this.threadPool = threadPool;
     }
 
     /**
@@ -637,7 +647,11 @@ public class ADTaskManager {
     }
 
     /**
-     * Get latest AD tasks and execute consumer function
+     * Get latest AD tasks and execute consumer function.
+     * If resetTaskState is true, will collect latest task's profile data from all data nodes. If no data
+     * node running the latest task, will reset the task state as STOPPED; otherwise, check if there is
+     * any stale running entities(entity exists in coordinating node cache but no task running on worker
+     * node) and clean up.
      *
      * @param detectorId detector id
      * @param entityValue entity value
@@ -731,55 +745,63 @@ public class ADTaskManager {
 
         if (longRunningHistoricalTasks.size() > 0) {
             ADTask adTask = longRunningHistoricalTasks.get(0);
-            // If AD task is still running, but its last updated time not refreshed for 2 piece intervals, we will get
-            // task profile to check if it's really running. If task not running, reset state as STOPPED.
-            // For example, ES process crashes, then all tasks running on it will stay as running. We can reset the task
-            // state when get historical task with get detector API.
-            String taskId = adTask.getTaskId();
-            getADTaskProfile(adTask, ActionListener.wrap(taskProfiles -> {
-                if (!taskProfiles.containsKey(adTask.getTaskId())) {
-                    logger.debug("AD task not running. Reset task state as stopped, task id: {}", adTask.getTaskId());
-                    // If no node is running this task, reset it as STOPPED.
-                    resetTaskStateAsStopped(adTask, transportService, () -> function.accept(adTasks));
-                } else {
-                    // If still running, check if there is any stale running entities and clean them
-                    function.accept(adTasks);
-                    if (ADTaskType.HISTORICAL_HC_DETECTOR.name().equals(adTask.getTaskType())) {
-                        // Check if any running entity not run on worker node. If yes, we need to remove it
-                        // and poll next entity from pending entity queue and run it.
-                        ADTaskProfile detectorTaskProfile = taskProfiles.get(taskId);
-                        if (detectorTaskProfile.getRunningEntitiesCount() > 0) {
-                            List<String> runningTasksInCoordinatingNodeCache = Arrays.asList(detectorTaskProfile.getRunningEntities());
-                            List<String> runningTasksOnWorkerNode = taskProfiles
-                                .entrySet()
-                                .stream()
-                                .filter(entry -> !taskId.equals(entry.getKey()))
-                                .map(entry -> entry.getValue().getEntity().get(0).getValue())
-                                .collect(Collectors.toList());
-                            if (runningTasksInCoordinatingNodeCache.size() > runningTasksOnWorkerNode.size()) {
-                                runningTasksInCoordinatingNodeCache.removeAll(runningTasksOnWorkerNode);
-                                forwardStaleRunningEntitiesToCoordinatingNode(
-                                    adTask,
-                                    ADTaskAction.CLEAN_STALE_RUNNING_ENTITIES,
-                                    transportService,
-                                    runningTasksInCoordinatingNodeCache,
-                                    ActionListener
-                                        .wrap(
-                                            res -> logger.debug("Forwarded task to clean stale running entity, task id {}", taskId),
-                                            ex -> logger.error("Failed to forward clean stale running entity for task " + taskId, ex)
-                                        )
-                                );
-                            }
-                        }
-                    }
-                }
-            }, e -> {
-                logger.error("Failed to get AD task profile for task " + adTask.getTaskId(), e);
-                function.accept(adTasks);
-            }));
+            resetHistoricalDetectorTaskState(adTask, () -> function.accept(adTasks), transportService);
         } else {
             function.accept(adTasks);
         }
+    }
+
+    private void resetHistoricalDetectorTaskState(ADTask adTask, AnomalyDetectorFunction function, TransportService transportService) {
+        // If AD task is still running, but its last updated time not refreshed for 2 piece intervals, we will get
+        // task profile to check if it's really running. If task not running, reset state as STOPPED.
+        // For example, ES process crashes, then all tasks running on it will stay as running. We can reset the task
+        // state when get historical task with get detector API.
+        if (!lastUpdateTimeExpired(adTask)) {
+            function.execute();
+            return;
+        }
+        String taskId = adTask.getTaskId();
+        getADTaskProfile(adTask, ActionListener.wrap(taskProfiles -> {
+            if (!taskProfiles.containsKey(adTask.getTaskId())) {
+                logger.debug("AD task not running. Reset task state as stopped, task id: {}", adTask.getTaskId());
+                // If no node is running this task, reset it as STOPPED.
+                resetTaskStateAsStopped(adTask, transportService, () -> function.execute());
+            } else {
+                // If still running, check if there is any stale running entities and clean them
+                function.execute();
+                if (ADTaskType.HISTORICAL_HC_DETECTOR.name().equals(adTask.getTaskType())) {
+                    // Check if any running entity not run on worker node. If yes, we need to remove it
+                    // and poll next entity from pending entity queue and run it.
+                    ADTaskProfile detectorTaskProfile = taskProfiles.get(taskId);
+                    if (detectorTaskProfile.getRunningEntitiesCount() > 0) {
+                        List<String> runningTasksInCoordinatingNodeCache = Arrays.asList(detectorTaskProfile.getRunningEntities());
+                        List<String> runningTasksOnWorkerNode = taskProfiles
+                            .entrySet()
+                            .stream()
+                            .filter(entry -> !taskId.equals(entry.getKey()))
+                            .map(entry -> entry.getValue().getEntity().get(0).getValue())
+                            .collect(Collectors.toList());
+                        if (runningTasksInCoordinatingNodeCache.size() > runningTasksOnWorkerNode.size()) {
+                            runningTasksInCoordinatingNodeCache.removeAll(runningTasksOnWorkerNode);
+                            forwardStaleRunningEntitiesToCoordinatingNode(
+                                adTask,
+                                ADTaskAction.CLEAN_STALE_RUNNING_ENTITIES,
+                                transportService,
+                                runningTasksInCoordinatingNodeCache,
+                                ActionListener
+                                    .wrap(
+                                        res -> logger.debug("Forwarded task to clean stale running entity, task id {}", taskId),
+                                        ex -> logger.error("Failed to forward clean stale running entity for task " + taskId, ex)
+                                    )
+                            );
+                        }
+                    }
+                }
+            }
+        }, e -> {
+            logger.error("Failed to get AD task profile for task " + adTask.getTaskId(), e);
+            function.execute();
+        }));
     }
 
     private void stopHistoricalAnalysis(
@@ -856,7 +878,7 @@ public class ADTaskManager {
         BoolQueryBuilder query = new BoolQueryBuilder();
         query.filter(new TermQueryBuilder(PARENT_TASK_ID_FIELD, detectorTaskId));
         query.filter(new TermQueryBuilder(TASK_TYPE_FIELD, ADTaskType.HISTORICAL_HC_ENTITY.name()));
-        query.filter(new TermsQueryBuilder(STATE_FIELD, ADTaskState.NOT_ENDED_STATES));
+        query.filter(new TermsQueryBuilder(STATE_FIELD, NOT_ENDED_STATES));
         updateByQueryRequest.setQuery(query);
         updateByQueryRequest.setRefresh(true);
         String script = String.format(Locale.ROOT, "ctx._source.%s='%s';", STATE_FIELD, ADTaskState.STOPPED.name());
@@ -1260,7 +1282,6 @@ public class ADTaskManager {
                         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         ADTask adTask = ADTask.parse(parser, searchHit.getId());
                         logger.debug("Delete old task: {} of detector: {}", adTask.getTaskId(), adTask.getDetectorId());
-                        // TODO: add deleted task in cache to delete their AD results in hourly cron job
                         bulkRequest.add(new DeleteRequest(CommonName.DETECTION_STATE_INDEX).id(adTask.getTaskId()));
                     } catch (Exception e) {
                         listener.onFailure(e);
@@ -1268,7 +1289,19 @@ public class ADTaskManager {
                 }
                 client.execute(BulkAction.INSTANCE, bulkRequest, ActionListener.wrap(res -> {
                     logger.info("AD tasks deleted for detector {}", detectorId);
-                    // TODO: delete child tasks of HC detector task
+                    BulkItemResponse[] bulkItemResponses = res.getItems();
+                    if (bulkItemResponses != null && bulkItemResponses.length > 0) {
+                        for (BulkItemResponse bulkItemResponse : bulkItemResponses) {
+                            if (!bulkItemResponse.isFailed()) {
+                                logger.debug("Add detector task into cache. Task id: {}", bulkItemResponse.getId());
+                                // add deleted task in cache and delete its child tasks and AD results
+                                adTaskCacheManager.addDeletedDetectorTask(bulkItemResponse.getId());
+                            }
+                        }
+                    }
+                    // delete child tasks and AD results of this task
+                    cleanChildTasksAndADResultsOfDeletedTask();
+
                     function.execute();
                 }, e -> {
                     logger.warn("Failed to clean AD tasks for detector " + detectorId, e);
@@ -1286,6 +1319,33 @@ public class ADTaskManager {
         });
 
         client.search(searchRequest, searchListener);
+    }
+
+    /**
+     * Poll deleted detector task from cache and delete its child tasks and AD results.
+     */
+    public void cleanChildTasksAndADResultsOfDeletedTask() {
+        if (!adTaskCacheManager.hasDeletedDetectorTask()) {
+            return;
+        }
+        threadPool.schedule(() -> {
+            String taskId = adTaskCacheManager.pollDeletedDetectorTask();
+            if (taskId == null) {
+                return;
+            }
+            DeleteByQueryRequest deleteADResultsRequest = new DeleteByQueryRequest(ALL_AD_RESULTS_INDEX_PATTERN);
+            deleteADResultsRequest.setQuery(new TermsQueryBuilder(TASK_ID_FIELD, taskId));
+            client.execute(DeleteByQueryAction.INSTANCE, deleteADResultsRequest, ActionListener.wrap(res -> {
+                logger.debug("Successfully deleted AD results of task " + taskId);
+                DeleteByQueryRequest deleteChildTasksRequest = new DeleteByQueryRequest(CommonName.DETECTION_STATE_INDEX);
+                deleteChildTasksRequest.setQuery(new TermsQueryBuilder(PARENT_TASK_ID_FIELD, taskId));
+
+                client.execute(DeleteByQueryAction.INSTANCE, deleteChildTasksRequest, ActionListener.wrap(r -> {
+                    logger.debug("Successfully deleted child tasks of task " + taskId);
+                    cleanChildTasksAndADResultsOfDeletedTask();
+                }, e -> { logger.error("Failed to delete child tasks of task " + taskId, e); }));
+            }, ex -> { logger.error("Failed to delete AD results for task " + taskId, ex); }));
+        }, TimeValue.timeValueSeconds(DEFAULT_MAINTAIN_INTERVAL_IN_SECONDS), AD_BATCH_TASK_THREAD_POOL_NAME);
     }
 
     private void runBatchResultAction(IndexResponse response, ADTask adTask, ActionListener<AnomalyDetectorJobResponse> listener) {
@@ -1446,8 +1506,12 @@ public class ADTaskManager {
 
         request.setQuery(query);
         client.execute(DeleteByQueryAction.INSTANCE, request, ActionListener.wrap(r -> {
-            logger.info("AD tasks deleted for detector {}", detectorId);
-            function.execute();
+            if (r.getBulkFailures() == null || r.getBulkFailures().size() == 0) {
+                logger.info("AD tasks deleted for detector {}", detectorId);
+                function.execute();
+            } else {
+                listener.onFailure(new OpenSearchStatusException("Failed to delete all AD tasks", RestStatus.INTERNAL_SERVER_ERROR));
+            }
         }, e -> {
             if (e instanceof IndexNotFoundException) {
                 function.execute();
@@ -1972,4 +2036,60 @@ public class ADTaskManager {
         }
     }
 
+    /**
+     * Maintain running historical tasks.
+     *
+     * @param transportService transport service
+     * @param requestId request id
+     * @param size return how many tasks
+     */
+    public void maintainRunningHistoricalTasks(TransportService transportService, String requestId, int size) {
+        Optional<DiscoveryNode> owningNode = hashRing.getOwningNode(requestId + "");
+        if (!owningNode.isPresent() || !clusterService.localNode().getId().equals(owningNode.get().getId())) {
+            return;
+        }
+        logger.info("Start to maintain running historical tasks");
+
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        query.filter(new TermQueryBuilder(IS_LATEST_FIELD, true));
+        query.filter(new TermsQueryBuilder(TASK_TYPE_FIELD, taskTypeToString(HISTORICAL_DETECTOR_TASK_TYPES)));
+        query.filter(new TermsQueryBuilder(STATE_FIELD, NOT_ENDED_STATES));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        // default maintain interval is 5 seconds, so maintain 10 tasks will take at least 50 seconds.
+        sourceBuilder.query(query).sort(LAST_UPDATE_TIME_FIELD, SortOrder.DESC).size(size);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(sourceBuilder);
+        searchRequest.indices(CommonName.DETECTION_STATE_INDEX);
+
+        client.search(searchRequest, ActionListener.wrap(r -> {
+            if (r == null || r.getHits().getTotalHits() == null || r.getHits().getTotalHits().value == 0) {
+                return;
+            }
+            ConcurrentLinkedQueue<ADTask> taskQueue = new ConcurrentLinkedQueue();
+            Iterator<SearchHit> iterator = r.getHits().iterator();
+            while (iterator.hasNext()) {
+                SearchHit searchHit = iterator.next();
+                try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, searchHit.getSourceRef())) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                    taskQueue.add(ADTask.parse(parser, searchHit.getId()));
+                } catch (Exception e) {
+                    logger.error("Maintaining running task: failed to parse AD task " + searchHit.getId(), e);
+                }
+            }
+            maintainRunningHistoricalTask(taskQueue, transportService);
+        }, e -> { logger.error("Failed to search historical tasks in maintaining job", e); }));
+    }
+
+    private void maintainRunningHistoricalTask(ConcurrentLinkedQueue<ADTask> taskQueue, TransportService transportService) {
+        ADTask adTask = taskQueue.poll();
+        if (adTask == null) {
+            return;
+        }
+        threadPool.schedule(() -> {
+            resetHistoricalDetectorTaskState(adTask, () -> {
+                logger.debug("Finished maintaining running historical task {}", adTask.getTaskId());
+                maintainRunningHistoricalTask(taskQueue, transportService);
+            }, transportService);
+        }, TimeValue.timeValueSeconds(DEFAULT_MAINTAIN_INTERVAL_IN_SECONDS), AD_BATCH_TASK_THREAD_POOL_NAME);
+    }
 }

--- a/src/main/java/org/opensearch/ad/transport/CronNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/CronNodeRequest.java
@@ -36,10 +36,17 @@ import org.opensearch.common.io.stream.StreamInput;
  */
 public class CronNodeRequest extends BaseNodeRequest {
 
-    public CronNodeRequest() {}
+    private String requestId;
+
+    public CronNodeRequest(String requestId) {
+        this.requestId = requestId;
+    }
 
     public CronNodeRequest(StreamInput in) throws IOException {
         super(in);
     }
 
+    public String getRequestId() {
+        return this.requestId;
+    }
 }

--- a/src/main/java/org/opensearch/ad/transport/CronRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/CronRequest.java
@@ -38,15 +38,18 @@ import org.opensearch.common.io.stream.StreamInput;
  */
 public class CronRequest extends BaseNodesRequest<CronRequest> {
 
-    public CronRequest() {
-        super((String[]) null);
-    }
+    private String requestId;
 
     public CronRequest(StreamInput in) throws IOException {
         super(in);
     }
 
-    public CronRequest(DiscoveryNode... nodes) {
+    public CronRequest(String requestId, DiscoveryNode... nodes) {
         super(nodes);
+        this.requestId = requestId;
+    }
+
+    public String getRequestId() {
+        return this.requestId;
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/CronTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/CronTransportAction.java
@@ -36,6 +36,7 @@ import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.ModelManager;
+import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
@@ -48,6 +49,7 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
     private ModelManager modelManager;
     private FeatureManager featureManager;
     private CacheProvider cacheProvider;
+    private ADTaskManager adTaskManager;
 
     @Inject
     public CronTransportAction(
@@ -58,7 +60,8 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         NodeStateManager tarnsportStatemanager,
         ModelManager modelManager,
         FeatureManager featureManager,
-        CacheProvider cacheProvider
+        CacheProvider cacheProvider,
+        ADTaskManager adTaskManager
     ) {
         super(
             CronAction.NAME,
@@ -75,6 +78,7 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         this.modelManager = modelManager;
         this.featureManager = featureManager;
         this.cacheProvider = cacheProvider;
+        this.adTaskManager = adTaskManager;
     }
 
     @Override
@@ -84,7 +88,7 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
 
     @Override
     protected CronNodeRequest newNodeRequest(CronRequest request) {
-        return new CronNodeRequest();
+        return new CronNodeRequest(request.getRequestId());
     }
 
     @Override
@@ -114,6 +118,12 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
 
         // delete unused transport state
         transportStateManager.maintenance();
+
+        // clean child tasks and AD results of deleted detector level task
+        adTaskManager.cleanChildTasksAndADResultsOfDeletedTask();
+
+        // maintain running historical tasks: reset task state as stopped if not running and clean stale running entities
+        adTaskManager.maintainRunningHistoricalTasks(transportService, request.getRequestId(), 100);
 
         return new CronNodeResponse(clusterService.localNode());
     }

--- a/src/main/java/org/opensearch/ad/transport/CronTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/CronTransportAction.java
@@ -125,6 +125,9 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         // maintain running historical tasks: reset task state as stopped if not running and clean stale running entities
         adTaskManager.maintainRunningHistoricalTasks(transportService, request.getRequestId(), 100);
 
+        // maintain running realtime tasks: clean stale running realtime task cache
+        adTaskManager.maintainRunningRealtimeTasks();
+
         return new CronNodeResponse(clusterService.localNode());
     }
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Maintain running historical tasks in hour cron. 
1. Clean child tasks and AD result of deleted detector level tasks.
2. Check if running historical analysis tasks still running. If not running, reset task as stopped; otherwise, check if there are any stale running entities and clean up.

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
