### PR TITLE
Introduce compact rcf library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,8 +335,27 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.ml.EntityModel',
         'org.opensearch.ad.ml.ModelPartitioner',
         'org.opensearch.ad.ml.CheckpointDao',
-        // related to deserializeRCFBufferPool's init
-        'org.opensearch.ad.AnomalyDetectorPlugin.*',
+
+        // TODO: unified flow caused coverage drop
+        'org.opensearch.ad.transport.AnomalyDetectorJobRequest',
+        'org.opensearch.ad.transport.ADTaskProfileTransportAction',
+        'org.opensearch.ad.transport.ADCancelTaskRequest',
+        'org.opensearch.ad.transport.ADTaskProfileNodeRequest',
+        'org.opensearch.ad.transport.ADCancelTaskTransportAction',
+        'org.opensearch.ad.transport.ADTaskProfileRequest',
+        'org.opensearch.ad.transport.ADCancelTaskNodeRequest',
+        'org.opensearch.ad.task.ADTaskManager',
+        'org.opensearch.ad.transport.ForwardADTaskTransportAction',
+        'org.opensearch.ad.task.ADHCBatchTaskCache',
+        'org.opensearch.ad.task.ADBatchTaskRunner',
+        'org.opensearch.ad.transport.ForwardADTaskRequest',
+        'org.opensearch.ad.task.ADBatchTaskCache',
+        'org.opensearch.ad.transport.ADBatchAnomalyResultResponse',
+        'org.opensearch.ad.transport.AnomalyDetectorJobTransportAction',
+        'org.opensearch.ad.transport.CronNodeRequest',
+        'org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction',
+        'org.opensearch.ad.transport.EntityResultResponse',
+        'org.opensearch.ad.transport.GetAnomalyDetectorResponse'
 ]
 
 jacocoTestCoverageVerification {
@@ -406,8 +425,8 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
 
     // used for serializing/deserializing rcf models.
-    compile group: 'io.protostuff', name: 'protostuff-core', version: '1.7.2'
-    compile group: 'io.protostuff', name: 'protostuff-runtime', version: '1.7.2'
+    compile group: 'io.protostuff', name: 'protostuff-core', version: '1.7.4'
+    compile group: 'io.protostuff', name: 'protostuff-runtime', version: '1.7.4'
 
     compile "org.jacoco:org.jacoco.agent:0.8.5"
     compile ("org.jacoco:org.jacoco.ant:0.8.5") {

--- a/build.gradle
+++ b/build.gradle
@@ -405,6 +405,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
 
+    // used for serializing/deserializing rcf models.
     compile group: 'io.protostuff', name: 'protostuff-core', version: '1.7.2'
     compile group: 'io.protostuff', name: 'protostuff-runtime', version: '1.7.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ buildscript {
     ext {
         opensearch_group = "org.opensearch"
         opensearch_version = System.getProperty("opensearch.version", "1.0.0")
-        common_utils_version = '1.0.0.0'
-        job_scheduler_version = '1.0.0.0'
+        common_utils_version = System.getProperty("common_utils.version", "1.0.0.0")
+        job_scheduler_version = System.getProperty("job_scheduler.version", "1.0.0.0")
     }
 
     repositories {
@@ -62,7 +62,7 @@ repositories {
 }
 
 ext {
-    opensearchVersion = '1.0.0'
+    opensearchVersion = System.getProperty("opensearch.version", "1.0.0")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -102,8 +102,6 @@ configurations.all {
     if (it.state != Configuration.State.UNRESOLVED) return
     resolutionStrategy {
         force "joda-time:joda-time:${versions.joda}"
-        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
         force "commons-logging:commons-logging:${versions.commonslogging}"
         force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
         force "commons-codec:commons-codec:${versions.commonscodec}"
@@ -335,6 +333,10 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.util.BulkUtil',
         'org.opensearch.ad.util.ExceptionUtil',
         'org.opensearch.ad.ml.EntityModel',
+        'org.opensearch.ad.ml.ModelPartitioner',
+        'org.opensearch.ad.ml.CheckpointDao',
+        // related to deserializeRCFBufferPool's init
+        'org.opensearch.ad.AnomalyDetectorPlugin.*',
 ]
 
 jacocoTestCoverageVerification {
@@ -378,15 +380,33 @@ dependencies {
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${opensearch_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${job_scheduler_version}"
     compile "org.opensearch:common-utils:${common_utils_version}"
+    compile "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
     compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     compile group: 'com.yahoo.datasketches', name: 'sketches-core', version: '0.13.4'
     compile group: 'com.yahoo.datasketches', name: 'memory', version: '0.12.2'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile 'software.amazon.randomcutforest:randomcutforest-core:1.0'
-    compile 'software.amazon.randomcutforest:randomcutforest-serialization-json:1.0'
-    compile "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
+    compile group: 'org.apache.commons', name: 'commons-pool2', version: '2.10.0'
+
+    // randomcutforest-serialization uses jackson 2.12, but opensearch-scripting-painless-spi uses jackson 2.11.
+    // compile scope won't work due to conflict.
+    // resolutionStrategy using 2.11 won't work as 
+    // com.fasterxml.jackson.databind.ObjectMapper depends on com/fasterxml/jackson/core/util/JacksonFeature
+    // that is created since 2.12. Compile won't fail but there is a runtime ClassNotFoundException
+    // due to absent JacksonFeature.
+    // The fix is to put jackson in direct dependency and use implementation scope.
+    // implementation scope let the dependency in both compiling and running classpath, but
+    // not leaked through to clients (Opensearch). Here we force the jackson version to whatever
+    // opensearch uses.
+    compile 'software.amazon.randomcutforest:randomcutforest-core:2.0-rc2'
+    implementation 'software.amazon.randomcutforest:randomcutforest-serialization:2.0-rc2'
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+
+    compile group: 'io.protostuff', name: 'protostuff-core', version: '1.7.2'
+    compile group: 'io.protostuff', name: 'protostuff-runtime', version: '1.7.2'
 
     compile "org.jacoco:org.jacoco.agent:0.8.5"
     compile ("org.jacoco:org.jacoco.ant:0.8.5") {


### PR DESCRIPTION
Note: since there are inter-file references, I split a big PR into multiple smaller PRs based on files to save time (1.1 cut off is due at the end of this week). The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big PR in the end and merge once after all review PRs get approved. For the complete code, check https://github.com/kaituo/anomaly-detection-1/tree/compactRCF2

### Description
The PR made the following changes.
1)instead of using hard-coded common-utils and job scheduler versions, we allow people to specify customized versions using Java System properties.
2)add dependency to rcf 2.0-rc2. There is a dependency conflict on jackson. randomcutforest-serialization uses jackson 2.12, but opensearch-scripting-painless-spi uses jackson 2.11. compile scope won't work due to conflict. resolutionStrategy using 2.11 won't work as com.fasterxml.jackson.databind. ObjectMapper depends on com/fasterxml/jackson/core/util/JacksonFeature that is created since 2.12. Compile won't fail, but there is a runtime ClassNotFoundException due to the absence of JacksonFeature. The fix is to put Jackson in direct dependencies and use implementation scope. implementation scope let the dependency in both compiling and running classpath, but not leaked through to clients (Opensearch). Here we force the jackson version to whatever OpenSearch uses.

Testing done:
1. Did end-to-end testing to make sure things work.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/97
 
### Check List
- [ x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
