### PR TITLE
Deal with backward compatibility for changed transport input/output

### DIFF
--- a/src/main/java/org/opensearch/ad/constant/CommonName.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonName.java
@@ -85,6 +85,7 @@ public class CommonName {
     // Historical detectors
     // ======================================
     public static final String AD_TASK = "ad_task";
+    public static final String HISTORICAL_ANALYSIS = "historical_analysis";
     public static final String AD_TASK_REMOTE = "ad_task_remote";
     public static final String CANCEL_TASK = "cancel_task";
 

--- a/src/main/java/org/opensearch/ad/constant/CommonName.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonName.java
@@ -134,4 +134,9 @@ public class CommonName {
     public static final String END_JSON_KEY = "end";
     public static final String VALUE_JSON_KEY = "value";
     public static final String ENTITIES_JSON_KEY = "entities";
+
+    // ======================================
+    // Used for backward-compatibility in messaging
+    // ======================================
+    public static final String EMPTY_FIELD = "";
 }

--- a/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
+++ b/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
@@ -52,6 +52,10 @@ public class ModelProfileOnNode implements Writeable, ToXContent {
         return nodeId;
     }
 
+    public ModelProfile getModelProfile() {
+        return modelProfile;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();

--- a/src/main/java/org/opensearch/ad/transport/EntityProfileRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityProfileRequest.java
@@ -32,8 +32,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
@@ -48,7 +46,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 
 public class EntityProfileRequest extends ActionRequest implements ToXContentObject {
-    private static final Logger LOG = LogManager.getLogger(EntityProfileRequest.class);
     public static final String ENTITY = "entity";
     public static final String PROFILES = "profiles";
     private String adID;

--- a/src/main/java/org/opensearch/ad/transport/EntityProfileResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityProfileResponse.java
@@ -34,7 +34,9 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.ModelProfile;
 import org.opensearch.ad.model.ModelProfileOnNode;
+import org.opensearch.ad.util.Bwc;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
@@ -95,7 +97,14 @@ public class EntityProfileResponse extends ActionResponse implements ToXContentO
         lastActiveMs = in.readLong();
         totalUpdates = in.readLong();
         if (in.readBoolean()) {
-            modelProfile = new ModelProfileOnNode(in);
+            if (Bwc.supportMultiCategoryFields(in.getVersion())) {
+                modelProfile = new ModelProfileOnNode(in);
+            } else {
+                // we don't have model information from old node
+                ModelProfile profile = new ModelProfile(in);
+                modelProfile = new ModelProfileOnNode("", profile);
+            }
+
         } else {
             modelProfile = null;
         }
@@ -124,7 +133,12 @@ public class EntityProfileResponse extends ActionResponse implements ToXContentO
         out.writeLong(totalUpdates);
         if (modelProfile != null) {
             out.writeBoolean(true);
-            modelProfile.writeTo(out);
+            if (Bwc.supportMultiCategoryFields(out.getVersion())) {
+                modelProfile.writeTo(out);
+            } else {
+                ModelProfile oldFormatModelProfile = modelProfile.getModelProfile();
+                oldFormatModelProfile.writeTo(out);
+            }
         } else {
             out.writeBoolean(false);
         }

--- a/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
@@ -119,10 +119,12 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
                 Map<String, String> attributes = entry.getKey().getAttributes();
                 if (attributes.size() != 1) {
                     // cannot send a multi-category field entity to old node since it will
-                    // cause EOF exception and stop the detector. Cannot log the entity
-                    // either as there can be a huge number of entities. Since the issue
-                    // is temporary and will be gone after upgrade completes, ignore them.
-                    continue;
+                    // cause EOF exception and stop the detector. The issue
+                    // is temporary and will be gone after upgrade completes.
+                    // Since one EntityResultRequest is sent to one node, we can safely
+                    // ignore the rest of the requests.
+                    LOG.info("Skip sending multi-category entities to an incompatible node. Attributes: ", attributes);
+                    break;
                 }
                 oldFormatEntities.put(entry.getKey().getAttributes().entrySet().iterator().next().getValue(), entry.getValue());
             }

--- a/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
@@ -29,6 +29,7 @@ package org.opensearch.ad.transport;
 import static org.opensearch.action.ValidateActions.addValidationError;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -39,6 +40,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.Entity;
+import org.opensearch.ad.util.Bwc;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -47,8 +49,8 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 public class EntityResultRequest extends ActionRequest implements ToXContentObject {
     private static final Logger LOG = LogManager.getLogger(EntityResultRequest.class);
-
     private String detectorId;
+    // changed from Map<String, double[]> to Map<Entity, double[]>
     private Map<Entity, double[]> entities;
     private long start;
     private long end;
@@ -56,7 +58,25 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
     public EntityResultRequest(StreamInput in) throws IOException {
         super(in);
         this.detectorId = in.readString();
-        this.entities = in.readMap(Entity::new, StreamInput::readDoubleArray);
+
+        // guarded with version check. Just in case we receive requests from older node where we use String
+        // to represent an entity
+        if (Bwc.supportMultiCategoryFields(in.getVersion())) {
+            this.entities = in.readMap(Entity::new, StreamInput::readDoubleArray);
+        } else {
+            // receive a request from a version before OpenSearch 1.1
+            // the old request uses Map<String, double[]> instead of Map<Entity, double[]> to represent entities
+            // since it only supports one categorical field.
+            Map<String, double[]> oldFormatEntities = in.readMap(StreamInput::readString, StreamInput::readDoubleArray);
+            entities = new HashMap<>();
+            for (Map.Entry<String, double[]> entry : oldFormatEntities.entrySet()) {
+                // we don't know the category field name as we don't have access to detector config object
+                // so we put empty string as the category field name for now. Will handle the case
+                // in EntityResultTransportAciton.
+                entities.put(Entity.createSingleAttributeEntity(detectorId, CommonName.EMPTY_FIELD, entry.getKey()), entry.getValue());
+            }
+        }
+
         this.start = in.readLong();
         this.end = in.readLong();
     }
@@ -89,7 +109,26 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(this.detectorId);
-        out.writeMap(entities, (s, e) -> e.writeTo(s), StreamOutput::writeDoubleArray);
+        // guarded with version check. Just in case we send requests to older node where we use String
+        // to represent an entity
+        if (Bwc.supportMultiCategoryFields(out.getVersion())) {
+            out.writeMap(entities, (s, e) -> e.writeTo(s), StreamOutput::writeDoubleArray);
+        } else {
+            Map<String, double[]> oldFormatEntities = new HashMap<>();
+            for (Map.Entry<Entity, double[]> entry : entities.entrySet()) {
+                Map<String, String> attributes = entry.getKey().getAttributes();
+                if (attributes.size() != 1) {
+                    // cannot send a multi-category field entity to old node since it will
+                    // cause EOF exception and stop the detector. Cannot log the entity
+                    // either as there can be a huge number of entities. Since the issue
+                    // is temporary and will be gone after upgrade completes, ignore them.
+                    continue;
+                }
+                oldFormatEntities.put(entry.getKey().getAttributes().entrySet().iterator().next().getValue(), entry.getValue());
+            }
+            out.writeMap(oldFormatEntities, StreamOutput::writeString, StreamOutput::writeDoubleArray);
+        }
+
         out.writeLong(this.start);
         out.writeLong(this.end);
     }

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -190,23 +190,17 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
             for (Entry<Entity, double[]> entityEntry : request.getEntities().entrySet()) {
                 Entity categoricalValues = entityEntry.getKey();
 
-                Map<String, String> attrValues = categoricalValues.getAttributes();
-                if (attrValues.containsKey(CommonName.EMPTY_FIELD)
+                if (isEntityeFromOldNodeMsg(categoricalValues)
                     && detector.getCategoryField() != null
                     && detector.getCategoryField().size() == 1) {
-                    // handle a request from a version before OpenSearch 1.1. Read EntityResultRequest(StreamInput in) for details.
+                    Map<String, String> attrValues = categoricalValues.getAttributes();
+                    // handle a request from a version before OpenSearch 1.1.
                     categoricalValues = Entity
                         .createSingleAttributeEntity(
                             detectorId,
                             detector.getCategoryField().get(0),
                             attrValues.get(CommonName.EMPTY_FIELD)
                         );
-                }
-
-                attrValues = categoricalValues.getAttributes();
-                if (attrValues != null && attrValues.containsKey(CommonName.EMPTY_FIELD)) {
-                    // above remediation is not useful, skip the entity
-                    continue;
                 }
 
                 Optional<String> modelIdOptional = categoricalValues.getModelId(detectorId);
@@ -326,5 +320,26 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
                 );
             listener.onFailure(exception);
         });
+    }
+
+    /**
+     * Whether the received entity comes from an node that doesn't support multi-category fields.
+     * This can happen during rolling-upgrade or blue/green deployment.
+     *
+     * Specifically, when receiving an EntityResultRequest from an incompatible node,
+     * EntityResultRequest(StreamInput in) gets an String that represents an entity.
+     * But Entity class requires both an category field name and value. Since we
+     * don't have access to detector config in EntityResultRequest(StreamInput in),
+     * we put CommonName.EMPTY_FIELD as the placeholder.  In this method,
+     * we use the same CommonName.EMPTY_FIELD to check if the deserialized entity
+     * comes from an incompatible node.  If it is, we will add the field name back
+     * as EntityResultTranportAction has access to the detector config object.
+     *
+     * @param categoricalValues deserialized Entity from inbound message.
+     * @return Whether the received entity comes from an node that doesn't support multi-category fields.
+     */
+    private boolean isEntityeFromOldNodeMsg(Entity categoricalValues) {
+        Map<String, String> attrValues = categoricalValues.getAttributes();
+        return (attrValues != null && attrValues.containsKey(CommonName.EMPTY_FIELD));
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/RCFPollingTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/RCFPollingTransportAction.java
@@ -158,7 +158,7 @@ public class RCFPollingTransportAction extends HandledTransportAction<RCFPolling
             }
 
         } else {
-            LOG.error("Fail to poll rcf for model {} due to an unexpetected bug.", rcfModelID);
+            LOG.error("Fail to poll rcf for model {} due to an unexpected bug.", rcfModelID);
             listener.onFailure(new AnomalyDetectionException(adID, NO_NODE_FOUND_MSG));
         }
     }

--- a/src/main/java/org/opensearch/ad/transport/RCFPollingTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/RCFPollingTransportAction.java
@@ -120,9 +120,12 @@ public class RCFPollingTransportAction extends HandledTransportAction<RCFPolling
                             e -> listener.onFailure(new AnomalyDetectionException(adID, FAIL_TO_GET_RCF_UPDATE_MSG, e))
                         )
                 );
-        } else {
-            // redirect
-            LOG.debug("Sending RCF polling request to {} for model {}", rcfNodeId, rcfModelID);
+        } else if (request.remoteAddress() == null) {
+            // redirect if request comes from local host.
+            // If a request comes from remote machine, it is already redirected.
+            // One redirection should be enough.
+            // We don't want a potential infinite loop due to any bug and thus give up.
+            LOG.info("Sending RCF polling request to {} for model {}", rcfNodeId, rcfModelID);
 
             try {
                 transportService
@@ -154,6 +157,9 @@ public class RCFPollingTransportAction extends HandledTransportAction<RCFPolling
                 listener.onFailure(new AnomalyDetectionException(adID, FAIL_TO_GET_RCF_UPDATE_MSG, e));
             }
 
+        } else {
+            LOG.error("Fail to poll rcf for model {} due to an unexpetected bug.", rcfModelID);
+            listener.onFailure(new AnomalyDetectionException(adID, NO_NODE_FOUND_MSG));
         }
     }
 }

--- a/src/main/java/org/opensearch/ad/util/Bwc.java
+++ b/src/main/java/org/opensearch/ad/util/Bwc.java
@@ -19,14 +19,12 @@ import org.opensearch.Version;
  */
 public class Bwc {
     /**
-     * We are gonna start supporting multi-category field since version 1.1.0.
-     * Since Opendistro and Elasticsearch will use a version after 1.0.0, we
-     * have to check Lucene version as well. Elasticsearch 7.10 uses Lucene 8.7.0
+     * We are gonna start supporting multi-category fields since version 1.1.0.
      *
      * @param version test version
      * @return whether the version support multiple category fields
      */
     public static boolean supportMultiCategoryFields(Version version) {
-        return version.after(Version.V_1_0_0) && version.luceneVersion.onOrAfter(org.apache.lucene.util.Version.LUCENE_8_8_2);
+        return version.after(Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/opensearch/ad/util/Bwc.java
+++ b/src/main/java/org/opensearch/ad/util/Bwc.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.util;
+
+import org.opensearch.Version;
+
+/**
+ * A helper class for various feature backward compatibility test
+ *
+ */
+public class Bwc {
+    /**
+     * We are gonna start supporting multi-category field since version 1.1.0.
+     * Since Opendistro and Elasticsearch will use a version after 1.0.0, we
+     * have to check Lucene version as well. Elasticsearch 7.10 uses Lucene 8.7.0
+     *
+     * @param version test version
+     * @return whether the version support multiple category fields
+     */
+    public static boolean supportMultiCategoryFields(Version version) {
+        return version.after(Version.V_1_0_0) && version.luceneVersion.onOrAfter(org.apache.lucene.util.Version.LUCENE_8_8_2);
+    }
+}


### PR DESCRIPTION
Note: since there are inter-file references, I split a big PR into multiple smaller PRs based on files to save time (1.1 cut off is due at the end of this week). The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big PR in the end and merge once after all review PRs get approved. For the complete code, check https://github.com/kaituo/anomaly-detection-1/tree/compactRCF2

### Description
The PR made the following changes.

1)backward compatibility for changed transport input/output. Without the change, when the communication involves an old node during rolling upgrade or blue/green deployment, the transport layer sends EOFException. They may stop the detector on AD's side as AD doesn't know how to handle the exception. On OpenSearch's side, the impact is not evaluated. But according to https://tinyurl.com/ysrjwpp6, out-of-bounds read/write is one of the most critical and current software security weaknesses.
2)Limit the amount of redirection to match a hash ring to one. This can avoid any potential infinite loop due to any bug.

Testing done:
1. Manually verified the change in rolling upgrade tests, where we have both old (1.0) and new (1.1) versions of AD.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/141
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
