### PR TITLE
Change max shingle size and the number of trees

### DIFF
--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -45,6 +45,7 @@ import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.constant.CommonValue;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.settings.NumericSetting;
 import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.ParseField;
@@ -211,8 +212,13 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         if (detectionInterval == null) {
             throw new IllegalArgumentException("Detection interval should be set");
         }
-        if (shingleSize != null && shingleSize < 1) {
-            throw new IllegalArgumentException("Shingle size must be a positive integer");
+        if (shingleSize != null && (shingleSize < 1 || shingleSize > AnomalyDetectorSettings.MAX_SHINGLE_SIZE)) {
+            throw new IllegalArgumentException(
+                "Shingle size must be a positive integer no larger than "
+                    + AnomalyDetectorSettings.MAX_SHINGLE_SIZE
+                    + ". Got "
+                    + shingleSize
+            );
         }
         int maxCategoryFields = NumericSetting.maxCategoricalFields();
         if (categoryFields != null && categoryFields.size() > maxCategoryFields) {

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -222,6 +222,21 @@ public final class AnomalyDetectorSettings {
             Setting.Property.Dynamic
         );
 
+    // for a batch operation, we want all of the bounding box in-place for speed
+    public static final double BATCH_BOUNDING_BOX_CACHE_RATIO = 1;
+
+    // for a real-time operation, we trade off speed for memory as real time opearation
+    // only has to do one update/scoring per interval
+    public static final double REAL_TIME_BOUNDING_BOX_CACHE_RATIO = 0;
+
+    public static final int DEFAULT_SHINGLE_SIZE = 8;
+
+    // Multi-entity detector model setting:
+    // TODO (kaituo): change to 4
+    public static final int DEFAULT_MULTI_ENTITY_SHINGLE = 1;
+
+    public static final int MAX_SHINGLE_SIZE = 1024;
+
     // Thresholding
     public static final double THRESHOLD_MIN_PVALUE = 0.995;
 
@@ -244,10 +259,9 @@ public final class AnomalyDetectorSettings {
 
     public static final int MIN_TRAIN_SAMPLES = 512;
 
-    public static final int DEFAULT_SHINGLE_SIZE = 8;
-
     public static final int MAX_IMPUTATION_NEIGHBOR_DISTANCE = 2;
 
+    //shingling
     public static final double MAX_SHINGLE_PROPORTION_MISSING = 0.25;
 
     // AD JOB
@@ -264,14 +278,10 @@ public final class AnomalyDetectorSettings {
     // minute. Since these states' life time is hour, we keep its size 10 * 1000 = 10000.
     public static final int MAX_SMALL_STATES = 10000;
 
-    // Multi-entity detector model setting:
-    // TODO (kaituo): change to 4
-    public static final int DEFAULT_MULTI_ENTITY_SHINGLE = 1;
-
     // how many categorical fields we support
     public static final int CATEGORY_FIELD_LIMIT = 1;
 
-    public static final int MULTI_ENTITY_NUM_TREES = 10;
+    public static final int MULTI_ENTITY_NUM_TREES = 30;
 
     // ======================================
     // cache related parameters
@@ -632,9 +642,6 @@ public final class AnomalyDetectorSettings {
 
     public static final Duration QUEUE_MAINTENANCE = Duration.ofMinutes(10);
 
-    // we won't accept a checkpoint larger than 10MB. Or we risk OOM.
-    public static final int MAX_CHECKPOINT_BYTES = 10_000_000;
-
     public static final float MAX_QUEUED_TASKS_RATIO = 0.5f;
 
     public static final float MEDIUM_SEGMENT_PRUNE_RATIO = 0.1f;
@@ -643,6 +650,25 @@ public final class AnomalyDetectorSettings {
 
     // expensive maintenance (e.g., queue maintenance) with 1/10000 probability
     public static final int MAINTENANCE_FREQ_CONSTANT = 10000;
+
+    // ======================================
+    // Checkpoint setting
+    // ======================================
+    // we won't accept a checkpoint larger than 30MB. Or we risk OOM.
+    // For reference, in RCF 1.0, the checkpoint of a RCF with 50 trees, 10 dimensions,
+    // 256 samples is of 3.2MB.
+    // In compact rcf, the same RCF is of 163KB.
+    // Since we allow at most 5 features, and the default shingle size is 8 and default
+    // tree number size is 100, we can have at most 25.6 MB. It is possible that cx increases
+    // the max features or shingle size, but we don't want to risk OOM for the flexibility.
+    public static final int MAX_CHECKPOINT_BYTES = 30_000_000;
+
+    // Sets the cap on the number of buffer that can be allocated by the rcf deserialization
+    // buffer pool. Each buffer is of 512 bytes. Memory occupied by 20 buffers is 10.24 KB.
+    public static final int MAX_TOTAL_RCF_DESERIALIZATION_BUFFERS = 20;
+
+    // the size of the buffer used for rcf deserialization
+    public static final int DESERIALIZATION_BUFFER_BYTES = 512;
 
     // ======================================
     // pagination setting

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -202,7 +202,7 @@ public final class AnomalyDetectorSettings {
     // RCF
     public static final int NUM_SAMPLES_PER_TREE = 256;
 
-    public static final int NUM_TREES = 100;
+    public static final int NUM_TREES = 30;
 
     public static final int TRAINING_SAMPLE_INTERVAL = 64;
 
@@ -261,7 +261,7 @@ public final class AnomalyDetectorSettings {
 
     public static final int MAX_IMPUTATION_NEIGHBOR_DISTANCE = 2;
 
-    //shingling
+    // shingling
     public static final double MAX_SHINGLE_PROPORTION_MISSING = 0.25;
 
     // AD JOB
@@ -381,6 +381,9 @@ public final class AnomalyDetectorSettings {
     // number of bulk checkpoints per second
     public static double CHECKPOINT_BULK_PER_SECOND = 0.02;
 
+    // ======================================
+    // Historical analysis
+    // ======================================
     // Maximum number of batch tasks running on one node.
     // TODO: performance test and tune the setting.
     public static final Setting<Integer> MAX_BATCH_TASK_PER_NODE = Setting
@@ -393,8 +396,21 @@ public final class AnomalyDetectorSettings {
             Setting.Property.Dynamic
         );
 
-    public static int THRESHOLD_MODEL_TRAINING_SIZE = 1000;
+    // Maximum number of deleted tasks can keep in cache.
+    public static final Setting<Integer> MAX_CACHED_DELETED_TASKS = Setting
+        .intSetting(
+            "plugins.anomaly_detection.max_cached_deleted_tasks",
+            1000,
+            1,
+            10_000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 
+    public static int THRESHOLD_MODEL_TRAINING_SIZE = 128;
+
+    // Maximum number of old AD tasks we can keep.
+    public static int MAX_OLD_AD_TASK_DOCS = 1000;
     public static final Setting<Integer> MAX_OLD_AD_TASK_DOCS_PER_DETECTOR = Setting
         .intSetting(
             "plugins.anomaly_detection.max_old_ad_task_docs_per_detector",
@@ -403,7 +419,7 @@ public final class AnomalyDetectorSettings {
             // that will be 2GB.
             LegacyOpenDistroAnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR,
             1, // keep at least 1 old AD task per detector
-            1000,
+            MAX_OLD_AD_TASK_DOCS,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
@@ -424,6 +440,28 @@ public final class AnomalyDetectorSettings {
             LegacyOpenDistroAnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS,
             1,
             600,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    // Maximum number of entities we support for historical analysis.
+    public static final int MAX_TOP_ENTITIES_LIMIT_FOR_HISTORICAL_ANALYSIS = 10_000;
+    public static final Setting<Integer> MAX_TOP_ENTITIES_FOR_HISTORICAL_ANALYSIS = Setting
+        .intSetting(
+            "plugins.anomaly_detection.max_top_entities_for_historical_analysis",
+            1000,
+            1,
+            MAX_TOP_ENTITIES_LIMIT_FOR_HISTORICAL_ANALYSIS,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS = Setting
+        .intSetting(
+            "plugins.anomaly_detection.max_running_entities_per_detector_for_historical_analysis",
+            1,
+            1,
+            1000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
@@ -659,16 +697,17 @@ public final class AnomalyDetectorSettings {
     // 256 samples is of 3.2MB.
     // In compact rcf, the same RCF is of 163KB.
     // Since we allow at most 5 features, and the default shingle size is 8 and default
-    // tree number size is 100, we can have at most 25.6 MB. It is possible that cx increases
-    // the max features or shingle size, but we don't want to risk OOM for the flexibility.
+    // tree number size is 100, we can have at most 25.6 MB in RCF 1.0.
+    // It is possible that cx increases the max features or shingle size, but we don't want
+    // to risk OOM for the flexibility.
     public static final int MAX_CHECKPOINT_BYTES = 30_000_000;
 
     // Sets the cap on the number of buffer that can be allocated by the rcf deserialization
     // buffer pool. Each buffer is of 512 bytes. Memory occupied by 20 buffers is 10.24 KB.
-    public static final int MAX_TOTAL_RCF_DESERIALIZATION_BUFFERS = 20;
+    public static final int MAX_TOTAL_RCF_SERIALIZATION_BUFFERS = 20;
 
     // the size of the buffer used for rcf deserialization
-    public static final int DESERIALIZATION_BUFFER_BYTES = 512;
+    public static final int SERIALIZATION_BUFFER_BYTES = 512;
 
     // ======================================
     // pagination setting


### PR DESCRIPTION
Note: since there are inter-file references, I split a big PR into multiple smaller PRs based on files to save time (1.1 cut off is due at the end of this week). The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big PR in the end and merge once after all review PRs get approved. For the complete code, check https://github.com/kaituo/anomaly-detection-1/tree/compactRCF2

### Description
The PR made the following changes.

1)Change to limit max shingle size to 1024. Previously, it was unbounded. The reasons are twofold. First, it may not work on the RCF side. It is unknown that a huge shingle size could give better accuracy. Second, the larger the shingle, the more resources (e.g., CPU for tree construction/traversal, memory for models, and disk for checkpoint) RCF will use. For example, a compact RCF model with 100 trees and 932 dimensions uses around 241 MB of memory. The same model in RCF 1.0 uses 958 MB.
2)Change the number of trees used in HCAD RCF from 10 to 30 trees. Ten trees are too aggressive and may hurt precision.

Testing done:
1. tested the change does not impact existing functionality.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/97
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
