### PR TITLE
avoid sending back verbose error message and wrong 500 error to user; fix hard code query size of historical analysis

### DIFF
--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -76,6 +76,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
     private final Logger logger = LogManager.getLogger(EntityProfileRunner.class);
 
     static final String NOT_HC_DETECTOR_ERR_MSG = "This is not a high cardinality detector";
+    static final String EMPTY_ENTITY_ATTRIBUTES = "Empty entity attributes";
     static final String NO_ENTITY = "Cannot find entity";
     private Client client;
     private NamedXContentRegistry xContentRegistry;
@@ -159,7 +160,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
     ) {
         Map<String, String> attributes = entity.getAttributes();
         if (attributes == null || attributes.size() != categoryFields.size()) {
-            listener.onFailure(new IllegalArgumentException("Empty entity attributes"));
+            listener.onFailure(new IllegalArgumentException(EMPTY_ENTITY_ATTRIBUTES));
             return;
         }
         for (String field : categoryFields) {

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -30,7 +30,6 @@ import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
-import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -102,7 +101,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
         ActionListener<EntityProfile> listener
     ) {
         if (profilesToCollect == null || profilesToCollect.size() == 0) {
-            listener.onFailure(new InvalidParameterException(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
+            listener.onFailure(new IllegalArgumentException(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
             return;
         }
         GetRequest getDetectorRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
@@ -119,10 +118,10 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                     List<String> categoryFields = detector.getCategoryField();
                     int maxCategoryFields = NumericSetting.maxCategoricalFields();
                     if (categoryFields == null || categoryFields.size() == 0) {
-                        listener.onFailure(new InvalidParameterException(NOT_HC_DETECTOR_ERR_MSG));
+                        listener.onFailure(new IllegalArgumentException(NOT_HC_DETECTOR_ERR_MSG));
                     } else if (categoryFields.size() > maxCategoryFields) {
                         listener
-                            .onFailure(new InvalidParameterException(CommonErrorMessages.getTooManyCategoricalFieldErr(maxCategoryFields)));
+                            .onFailure(new IllegalArgumentException(CommonErrorMessages.getTooManyCategoricalFieldErr(maxCategoryFields)));
                     } else {
                         validateEntity(entityValue, categoryFields, detectorId, profilesToCollect, detector, listener);
                     }
@@ -130,7 +129,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                     listener.onFailure(t);
                 }
             } else {
-                listener.onFailure(new InvalidParameterException(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG + detectorId));
+                listener.onFailure(new IllegalArgumentException(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG + detectorId));
             }
         }, listener::onFailure));
     }
@@ -160,12 +159,12 @@ public class EntityProfileRunner extends AbstractProfileRunner {
     ) {
         Map<String, String> attributes = entity.getAttributes();
         if (attributes == null || attributes.size() != categoryFields.size()) {
-            listener.onFailure(new InvalidParameterException("Empty entity attributes"));
+            listener.onFailure(new IllegalArgumentException("Empty entity attributes"));
             return;
         }
         for (String field : categoryFields) {
             if (false == attributes.containsKey(field)) {
-                listener.onFailure(new InvalidParameterException("Cannot find " + field));
+                listener.onFailure(new IllegalArgumentException("Cannot find " + field));
                 return;
             }
         }
@@ -184,15 +183,15 @@ public class EntityProfileRunner extends AbstractProfileRunner {
         client.search(searchRequest, ActionListener.wrap(searchResponse -> {
             try {
                 if (searchResponse.getHits().getHits().length == 0) {
-                    listener.onFailure(new InvalidParameterException(NO_ENTITY));
+                    listener.onFailure(new IllegalArgumentException(NO_ENTITY));
                     return;
                 }
                 prepareEntityProfile(listener, detectorId, entity, profilesToCollect, detector, categoryFields.get(0));
             } catch (Exception e) {
-                listener.onFailure(new InvalidParameterException(NO_ENTITY));
+                listener.onFailure(new IllegalArgumentException(NO_ENTITY));
                 return;
             }
-        }, e -> listener.onFailure(new InvalidParameterException(NO_ENTITY))));
+        }, e -> listener.onFailure(new IllegalArgumentException(NO_ENTITY))));
 
     }
 

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -53,10 +53,10 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.OpenSearchException;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.MemoryTracker.Origin;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.CheckpointDao;
@@ -637,7 +637,7 @@ public class PriorityCache implements EntityCache {
             });
         } catch (Exception e) {
             // will be thrown to ES's transport broadcast handler
-            throw new OpenSearchException("Fail to maintain cache", e);
+            throw new AnomalyDetectionException("Fail to maintain cache", e);
         }
 
     }

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -45,9 +45,12 @@ public class CommonErrorMessages {
         "Having trouble querying data because all of your features have been disabled.";
     public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
     public static String FAIL_TO_PARSE_DETECTOR_MSG = "Fail to parse detector with id: ";
-    public static String FAIL_TO_FIND_DETECTOR_MSG = "Fail to find detector with id: ";
+    // change this error message to make it compatible with old version's integration(nexus) test
+    public static String FAIL_TO_FIND_DETECTOR_MSG = "Can't find detector with id: ";
     public static String FAIL_TO_GET_PROFILE_MSG = "Fail to get profile for detector ";
     public static String FAIL_TO_GET_TOTAL_ENTITIES = "Failed to get total entities for detector ";
+    public static String FAIL_TO_GET_USER_INFO = "Unable to get user information from detector ";
+    public static String NO_PERMISSION_TO_ACCESS_DETECTOR = "User does not have permissions to access detector: ";
     public static String CATEGORICAL_FIELD_NUMBER_SURPASSED = "We don't support categorical fields more than ";
     public static String EMPTY_PROFILES_COLLECT = "profiles to collect are missing or invalid";
     public static String FAIL_FETCH_ERR_MSG = "Fail to fetch profile for ";
@@ -72,4 +75,16 @@ public class CommonErrorMessages {
     public static String EXCEED_HISTORICAL_ANALYSIS_LIMIT = "Exceed max historical analysis limit per node";
     public static String NO_ELIGIBLE_NODE_TO_RUN_DETECTOR = "No eligible node to run detector ";
     public static String EMPTY_STALE_RUNNING_ENTITIES = "Empty stale running entities";
+
+    public static String FAIL_TO_GET_DETECTOR = "Fail to get detector";
+    public static String FAIL_TO_GET_DETECTOR_INFO = "Fail to get detector info";
+    public static String FAIL_TO_CREATE_DETECTOR = "Fail to create detector";
+    public static String FAIL_TO_UPDATE_DETECTOR = "Fail to update detector";
+    public static String FAIL_TO_PREVIEW_DETECTOR = "Fail to preview detector";
+    public static String FAIL_TO_START_DETECTOR = "Fail to start detector";
+    public static String FAIL_TO_STOP_DETECTOR = "Fail to stop detector";
+    public static String FAIL_TO_DELETE_DETECTOR = "Fail to delete detector";
+    public static String FAIL_TO_DELETE_AD_RESULT = "Fail to delete anomaly result";
+    public static String FAIL_TO_GET_STATS = "Fail to get stats";
+    public static String FAIL_TO_SEARCH = "Fail to search";
 }

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -44,6 +44,7 @@ public class CommonErrorMessages {
     public static final String ALL_FEATURES_DISABLED_ERR_MSG =
         "Having trouble querying data because all of your features have been disabled.";
     public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
+    public static String FAIL_TO_PARSE_DETECTOR_MSG = "Fail to parse detector with id: ";
     public static String FAIL_TO_FIND_DETECTOR_MSG = "Fail to find detector with id: ";
     public static String FAIL_TO_GET_PROFILE_MSG = "Fail to get profile for detector ";
     public static String FAIL_TO_GET_TOTAL_ENTITIES = "Failed to get total entities for detector ";

--- a/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
@@ -55,6 +55,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.dataprocessor.Interpolator;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -425,7 +426,7 @@ public class SearchFeatureDao extends AbstractRetriever {
                         listener.onResponse(topEntities);
                     } else if (expirationEpochMs < clock.millis()) {
                         if (topEntities.isEmpty()) {
-                            listener.onFailure(new IllegalStateException("timeout to get preview results.  Please retry later."));
+                            listener.onFailure(new AnomalyDetectionException("timeout to get preview results.  Please retry later."));
                         } else {
                             logger.info("timeout to get preview results. Send whatever we have.");
                             listener.onResponse(topEntities);

--- a/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
@@ -66,6 +66,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.indices.ADIndex;
@@ -674,7 +675,7 @@ public class CheckpointDao {
                     clientUtil.<BulkRequest, BulkResponse>execute(BulkAction.INSTANCE, request, listener);
                 } else {
                     // create index failure. Notify callers using listener.
-                    listener.onFailure(new RuntimeException("Creating checkpoint with mappings call not acknowledged."));
+                    listener.onFailure(new AnomalyDetectionException("Creating checkpoint with mappings call not acknowledged."));
                 }
             }, exception -> {
                 if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.rest.handler;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
@@ -229,7 +230,7 @@ public class IndexAnomalyDetectorActionHandler {
 
     private void onGetAnomalyDetectorResponse(GetResponse response) {
         if (!response.isExists()) {
-            listener.onFailure(new OpenSearchStatusException("AnomalyDetector is not found with id: " + detectorId, RestStatus.NOT_FOUND));
+            listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG, RestStatus.NOT_FOUND));
             return;
         }
         try (XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -233,7 +233,7 @@ public class IndexAnomalyDetectorJobActionHandler {
             );
     }
 
-    private void onIndexAnomalyDetectorJobResponse(IndexResponse response, AnomalyDetectorFunction function) throws IOException {
+    private void onIndexAnomalyDetectorJobResponse(IndexResponse response, AnomalyDetectorFunction function) {
         if (response == null || (response.getResult() != CREATED && response.getResult() != UPDATED)) {
             String errorMsg = getShardsFailure(response);
             listener.onFailure(new OpenSearchStatusException(errorMsg, response.status()));

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -424,12 +424,13 @@ public final class AnomalyDetectorSettings {
             Setting.Property.Dynamic
         );
 
+    public static final int MAX_BATCH_TASK_PIECE_SIZE = 10_000;
     public static final Setting<Integer> BATCH_TASK_PIECE_SIZE = Setting
         .intSetting(
             "plugins.anomaly_detection.batch_task_piece_size",
             LegacyOpenDistroAnomalyDetectorSettings.BATCH_TASK_PIECE_SIZE,
             1,
-            10_000,
+            MAX_BATCH_TASK_PIECE_SIZE,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -30,6 +30,7 @@ import static org.opensearch.action.DocWriteResponse.Result.CREATED;
 import static org.opensearch.ad.AnomalyDetectorPlugin.AD_BATCH_TASK_THREAD_POOL_NAME;
 import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
 import static org.opensearch.ad.constant.CommonErrorMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
 import static org.opensearch.ad.constant.CommonErrorMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
 import static org.opensearch.ad.indices.AnomalyDetectionIndices.ALL_AD_RESULTS_INDEX_PATTERN;
 import static org.opensearch.ad.model.ADTask.DETECTOR_ID_FIELD;
@@ -548,7 +549,7 @@ public class ADTaskManager {
         GetRequest getRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
         client.get(getRequest, ActionListener.wrap(response -> {
             if (!response.isExists()) {
-                listener.onFailure(new OpenSearchStatusException("AnomalyDetector is not found", RestStatus.NOT_FOUND));
+                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG, RestStatus.NOT_FOUND));
                 return;
             }
             try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
@@ -574,7 +575,7 @@ public class ADTaskManager {
         GetRequest getRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
         client.get(getRequest, ActionListener.wrap(response -> {
             if (!response.isExists()) {
-                listener.onFailure(new OpenSearchStatusException("AnomalyDetector is not found", RestStatus.NOT_FOUND));
+                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG, RestStatus.NOT_FOUND));
                 return;
             }
             try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_START_DETECTOR;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_STOP_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
@@ -97,8 +99,8 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         long primaryTerm = request.getPrimaryTerm();
         String rawPath = request.getRawPath();
         TimeValue requestTimeout = REQUEST_TIMEOUT.get(settings);
-        String action = rawPath.endsWith(RestHandlerUtils.START_JOB) ? "start" : "stop";
-        ActionListener<AnomalyDetectorJobResponse> listener = wrapRestActionListener(actionListener, "Failed to " + action + " detector");
+        String errorMessage = rawPath.endsWith(RestHandlerUtils.START_JOB) ? FAIL_TO_START_DETECTOR : FAIL_TO_STOP_DETECTOR;
+        ActionListener<AnomalyDetectorJobResponse> listener = wrapRestActionListener(actionListener, errorMessage);
 
         // By the time request reaches here, the user permissions are validated by Security plugin.
         User user = getUserContext(client);

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -30,6 +30,7 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKE
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,7 +89,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
     }
 
     @Override
-    protected void doExecute(Task task, AnomalyDetectorJobRequest request, ActionListener<AnomalyDetectorJobResponse> listener) {
+    protected void doExecute(Task task, AnomalyDetectorJobRequest request, ActionListener<AnomalyDetectorJobResponse> actionListener) {
         String detectorId = request.getDetectorID();
         DetectionDateRange detectionDateRange = request.getDetectionDateRange();
         boolean historical = request.isHistorical();
@@ -96,6 +97,8 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         long primaryTerm = request.getPrimaryTerm();
         String rawPath = request.getRawPath();
         TimeValue requestTimeout = REQUEST_TIMEOUT.get(settings);
+        String action = rawPath.endsWith(RestHandlerUtils.START_JOB) ? "start" : "stop";
+        ActionListener<AnomalyDetectorJobResponse> listener = wrapRestActionListener(actionListener, "Failed to " + action + " detector");
 
         // By the time request reaches here, the user permissions are validated by Security plugin.
         User user = getUserContext(client);

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -31,6 +31,7 @@ import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_IN
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
@@ -98,10 +99,11 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
     }
 
     @Override
-    protected void doExecute(Task task, DeleteAnomalyDetectorRequest request, ActionListener<DeleteResponse> listener) {
+    protected void doExecute(Task task, DeleteAnomalyDetectorRequest request, ActionListener<DeleteResponse> actionListener) {
         String detectorId = request.getDetectorID();
         LOG.info("Delete anomaly detector job {}", detectorId);
         User user = getUserContext(client);
+        ActionListener<DeleteResponse> listener = wrapRestActionListener(actionListener, "Failed to delete detector");
         // By the time request reaches here, the user permissions are validated by Security plugin.
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_DELETE_DETECTOR;
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
@@ -103,7 +104,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
         String detectorId = request.getDetectorID();
         LOG.info("Delete anomaly detector job {}", detectorId);
         User user = getUserContext(client);
-        ActionListener<DeleteResponse> listener = wrapRestActionListener(actionListener, "Failed to delete detector");
+        ActionListener<DeleteResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_DELETE_DETECTOR);
         // By the time request reaches here, the user permissions are validated by Security plugin.
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -14,6 +14,7 @@ package org.opensearch.ad.transport;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,7 +54,8 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
     }
 
     @Override
-    protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+    protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> actionListener) {
+        ActionListener<BulkByScrollResponse> listener = wrapRestActionListener(actionListener, "Failed to delete anomaly result");
         delete(request, listener);
     }
 

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_DELETE_AD_RESULT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
@@ -55,7 +56,7 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> actionListener) {
-        ActionListener<BulkByScrollResponse> listener = wrapRestActionListener(actionListener, "Failed to delete anomaly result");
+        ActionListener<BulkByScrollResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_DELETE_AD_RESULT);
         delete(request, listener);
     }
 

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_DETECTOR;
 import static org.opensearch.ad.model.ADTaskType.ALL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
@@ -144,7 +146,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     protected void doExecute(Task task, GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> actionListener) {
         String detectorID = request.getDetectorID();
         User user = getUserContext(client);
-        ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to get detector");
+        ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(
                 user,
@@ -295,10 +297,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                 for (MultiGetItemResponse response : responses) {
                     if (ANOMALY_DETECTORS_INDEX.equals(response.getIndex())) {
                         if (response.getResponse() == null || !response.getResponse().isExists()) {
-                            listener
-                                .onFailure(
-                                    new OpenSearchStatusException("Can't find detector with id:  " + detectorId, RestStatus.NOT_FOUND)
-                                );
+                            listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, RestStatus.NOT_FOUND));
                             return;
                         }
                         id = response.getId();

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -33,6 +33,7 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKE
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.ad.util.RestHandlerUtils.PROFILE;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.util.Arrays;
@@ -140,9 +141,10 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     }
 
     @Override
-    protected void doExecute(Task task, GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> listener) {
+    protected void doExecute(Task task, GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> actionListener) {
         String detectorID = request.getDetectorID();
         User user = getUserContext(client);
+        ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to get detector");
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(
                 user,

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -30,6 +30,7 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKE
 import static org.opensearch.ad.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.ad.util.ParseUtils.getDetector;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -95,10 +96,12 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
     }
 
     @Override
-    protected void doExecute(Task task, IndexAnomalyDetectorRequest request, ActionListener<IndexAnomalyDetectorResponse> listener) {
+    protected void doExecute(Task task, IndexAnomalyDetectorRequest request, ActionListener<IndexAnomalyDetectorResponse> actionListener) {
         User user = getUserContext(client);
         String detectorId = request.getDetectorID();
         RestRequest.Method method = request.getMethod();
+        String action = method == RestRequest.Method.PUT ? "update" : "create";
+        ActionListener<IndexAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to " + action + " detector");
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(user, detectorId, method, listener, (detector) -> adExecute(request, user, detector, context, listener));
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_CREATE_DETECTOR;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_UPDATE_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.ad.util.ParseUtils.getDetector;
@@ -100,8 +102,8 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         User user = getUserContext(client);
         String detectorId = request.getDetectorID();
         RestRequest.Method method = request.getMethod();
-        String action = method == RestRequest.Method.PUT ? "update" : "create";
-        ActionListener<IndexAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to " + action + " detector");
+        String errorMessage = method == RestRequest.Method.PUT ? FAIL_TO_UPDATE_DETECTOR : FAIL_TO_CREATE_DETECTOR;
+        ActionListener<IndexAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, errorMessage);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(user, detectorId, method, listener, (detector) -> adExecute(request, user, detector, context, listener));
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_PREVIEW_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CONCURRENT_PREVIEW;
@@ -116,7 +117,7 @@ public class PreviewAnomalyDetectorTransportAction extends
     ) {
         String detectorId = request.getDetectorId();
         User user = getUserContext(client);
-        ActionListener<PreviewAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to preview detector");
+        ActionListener<PreviewAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_PREVIEW_DETECTOR);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(
                 user,

--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_DETECTOR_INFO;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
@@ -74,7 +75,7 @@ public class SearchAnomalyDetectorInfoTransportAction extends
     ) {
         String name = request.getName();
         String rawPath = request.getRawPath();
-        ActionListener<SearchAnomalyDetectorInfoResponse> listener = wrapRestActionListener(actionListener, "Failed to get detector info");
+        ActionListener<SearchAnomalyDetectorInfoResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR_INFO);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             SearchRequest searchRequest = new SearchRequest().indices(ANOMALY_DETECTORS_INDEX);
             if (rawPath.endsWith(RestHandlerUtils.COUNT)) {

--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
@@ -27,6 +27,7 @@
 package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,10 +70,11 @@ public class SearchAnomalyDetectorInfoTransportAction extends
     protected void doExecute(
         Task task,
         SearchAnomalyDetectorInfoRequest request,
-        ActionListener<SearchAnomalyDetectorInfoResponse> listener
+        ActionListener<SearchAnomalyDetectorInfoResponse> actionListener
     ) {
         String name = request.getName();
         String rawPath = request.getRawPath();
+        ActionListener<SearchAnomalyDetectorInfoResponse> listener = wrapRestActionListener(actionListener, "Failed to get detector info");
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             SearchRequest searchRequest = new SearchRequest().indices(ANOMALY_DETECTORS_INDEX);
             if (rawPath.endsWith(RestHandlerUtils.COUNT)) {

--- a/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +82,8 @@ public class StatsAnomalyDetectorTransportAction extends HandledTransportAction<
     }
 
     @Override
-    protected void doExecute(Task task, ADStatsRequest request, ActionListener<StatsAnomalyDetectorResponse> listener) {
+    protected void doExecute(Task task, ADStatsRequest request, ActionListener<StatsAnomalyDetectorResponse> actionListener) {
+        ActionListener<StatsAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to get stats");
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             getStats(client, listener, request);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_STATS;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class StatsAnomalyDetectorTransportAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, ADStatsRequest request, ActionListener<StatsAnomalyDetectorResponse> actionListener) {
-        ActionListener<StatsAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, "Failed to get stats");
+        ActionListener<StatsAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_STATS);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             getStats(client, listener, request);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/transport/StopDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StopDetectorTransportAction.java
@@ -87,9 +87,10 @@ public class StopDetectorTransportAction extends HandledTransportAction<ActionRe
                 listener.onResponse(new StopDetectorResponse(false));
             }));
         } catch (Exception e) {
-            LOG.error("Fail to stop detector " + adID, e);
+            String errorMessage = "Fail to stop detector " + adID;
+            LOG.error(errorMessage, e);
             Throwable cause = ExceptionsHelper.unwrapCause(e);
-            listener.onFailure(new InternalFailure(adID, cause));
+            listener.onFailure(new InternalFailure(adID, errorMessage, cause));
         }
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/StopDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StopDetectorTransportAction.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.transport;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_STOP_DETECTOR;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -87,10 +89,9 @@ public class StopDetectorTransportAction extends HandledTransportAction<ActionRe
                 listener.onResponse(new StopDetectorResponse(false));
             }));
         } catch (Exception e) {
-            String errorMessage = "Fail to stop detector " + adID;
-            LOG.error(errorMessage, e);
+            LOG.error(FAIL_TO_STOP_DETECTOR + " " + adID, e);
             Throwable cause = ExceptionsHelper.unwrapCause(e);
-            listener.onFailure(new InternalFailure(adID, errorMessage, cause));
+            listener.onFailure(new InternalFailure(adID, FAIL_TO_STOP_DETECTOR, cause));
         }
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.transport.handler;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_SEARCH;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
@@ -66,7 +67,7 @@ public class ADSearchHandler {
      */
     public void search(SearchRequest request, ActionListener<SearchResponse> actionListener) {
         User user = getUserContext(client);
-        ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, "Failed to get stats");
+        ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_SEARCH);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             validateRole(request, user, listener);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -29,6 +29,7 @@ package org.opensearch.ad.transport.handler;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,10 +62,11 @@ public class ADSearchHandler {
      * and execute search.
      *
      * @param request search request
-     * @param listener action listerner
+     * @param actionListener action listerner
      */
-    public void search(SearchRequest request, ActionListener<SearchResponse> listener) {
+    public void search(SearchRequest request, ActionListener<SearchResponse> actionListener) {
         User user = getUserContext(client);
+        ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, "Failed to get stats");
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             validateRole(request, user, listener);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -26,6 +26,9 @@
 
 package org.opensearch.ad.util;
 
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_USER_INFO;
+import static org.opensearch.ad.constant.CommonErrorMessages.NO_PERMISSION_TO_ACCESS_DETECTOR;
 import static org.opensearch.ad.constant.CommonName.DATE_HISTOGRAM;
 import static org.opensearch.ad.constant.CommonName.EPOCH_MILLIS_FORMAT;
 import static org.opensearch.ad.constant.CommonName.FEATURE_AGGS;
@@ -562,13 +565,13 @@ public final class ParseUtils {
                     function.accept(detector);
                 } else {
                     logger.debug("User: " + requestUser.getName() + " does not have permissions to access detector: " + detectorId);
-                    listener.onFailure(new AnomalyDetectionException("User does not have permissions to access detector: " + detectorId));
+                    listener.onFailure(new AnomalyDetectionException(NO_PERMISSION_TO_ACCESS_DETECTOR + detectorId));
                 }
             } catch (Exception e) {
-                listener.onFailure(new AnomalyDetectionException("Unable to get user information from detector " + detectorId));
+                listener.onFailure(new AnomalyDetectionException(FAIL_TO_GET_USER_INFO + detectorId));
             }
         } else {
-            listener.onFailure(new ResourceNotFoundException(detectorId, "AnomalyDetector is not found with id: " + detectorId));
+            listener.onFailure(new ResourceNotFoundException(detectorId, FAIL_TO_FIND_DETECTOR_MSG + detectorId));
         }
     }
 

--- a/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
@@ -57,6 +57,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.OpenSearchException;
 import org.opensearch.ad.MemoryTracker;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.ml.CheckpointDao;
 import org.opensearch.ad.ml.EntityModel;
@@ -418,7 +419,7 @@ public class PriorityCacheTests extends AbstractCacheTest {
             new Thread(new FailedCleanRunnable(scheduledThreadCountDown)).start();
 
             cacheProvider.maintenance();
-        } catch (OpenSearchException e) {
+        } catch (AnomalyDetectionException e) {
             scheduledThreadCountDown.countDown();
         }
 

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -27,6 +27,7 @@
 package org.opensearch.ad.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -837,7 +838,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                "AnomalyDetector is not found",
+                FAIL_TO_FIND_DETECTOR_MSG,
                 () -> TestHelpers
                     .makeRequest(
                         client(),
@@ -939,7 +940,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                "AnomalyDetector is not found",
+                FAIL_TO_FIND_DETECTOR_MSG,
                 () -> TestHelpers
                     .makeRequest(
                         client(),

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -27,6 +27,7 @@
 package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
+import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
@@ -118,7 +119,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalAnalysisIn
             OpenSearchStatusException.class,
             () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
         );
-        assertTrue(exception.getMessage().contains("AnomalyDetector is not found"));
+        assertTrue(exception.getMessage().contains(FAIL_TO_FIND_DETECTOR_MSG));
     }
 
     @Ignore

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
@@ -33,13 +33,13 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 
 import java.io.IOException;
-import java.security.InvalidParameterException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
@@ -136,7 +136,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);
-        assertException(future, InvalidParameterException.class, CommonErrorMessages.EMPTY_PROFILES_COLLECT);
+        assertException(future, OpenSearchStatusException.class, CommonErrorMessages.EMPTY_PROFILES_COLLECT);
     }
 
     @SuppressWarnings("unchecked")
@@ -161,6 +161,6 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);
-        assertException(future, InvalidParameterException.class, CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG);
+        assertException(future, OpenSearchStatusException.class, CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -62,7 +62,6 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.ad.AnomalyDetectorRunner;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
-import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.Features;
@@ -351,7 +350,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
 
             @Override
             public void onFailure(Exception e) {
-                Assert.assertTrue(e.getClass() == OpenSearchException.class);
+                Assert.assertEquals(OpenSearchStatusException.class, e.getClass());
                 inProgressLatch.countDown();
             }
         };
@@ -437,7 +436,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
 
             @Override
             public void onFailure(Exception e) {
-                Assert.assertTrue("actual class: " + e.getClass(), e instanceof LimitExceededException);
+                Assert.assertTrue("actual class: " + e.getClass(), e instanceof OpenSearchStatusException);
                 Assert.assertTrue(e.getMessage().contains(CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
                 inProgressLatch.countDown();
             }

--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -223,7 +223,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
                 + "\"to\":20,\"include_lower\":true,\"include_upper\":true,\"boost\":1.0}}}],\"should\":[{\"term\":{\"tag\":"
                 + "{\"value\":\"wow\",\"boost\":1.0}}},{\"term\":{\"tag\":{\"value\":\"elasticsearch\",\"boost\":1.0}}}],"
                 + "\"adjust_pure_negative\":true,\"minimum_should_match\":\"1\",\"boost\":1.0}}],\"adjust_pure_negative"
-                + "\":true,\"boost\":1.0}},\"aggregations\":{\"feature_aggs\":{\"composite\":{\"size\":1000,\"sources\":"
+                + "\":true,\"boost\":1.0}},\"aggregations\":{\"feature_aggs\":{\"composite\":{\"size\":10000,\"sources\":"
                 + "[{\"date_histogram\":{\"date_histogram\":{\"field\":\""
                 + detector.getTimeField()
                 + "\",\"missing_bucket\":false,\"order\":\"asc\","


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
1. Avoid sending back verbose error message and wrong 500 error to user. This is for security consideration.
2. Fix hard code query size of historical analysis
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
