### PR TITLE
Handle more AD exceptions thrown over the wire/network

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,7 +351,9 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.transport.AnomalyDetectorJobTransportAction',
         'org.opensearch.ad.transport.CronNodeRequest',
         'org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction',
-        'org.opensearch.ad.transport.GetAnomalyDetectorResponse'
+        'org.opensearch.ad.transport.GetAnomalyDetectorResponse',
+        'org.opensearch.ad.transport.ADBatchAnomalyResultRequest',
+        'org.opensearch.ad.transport.ADBatchTaskRemoteExecutionTransportAction',
 ]
 
 jacocoTestCoverageVerification {

--- a/build.gradle
+++ b/build.gradle
@@ -331,8 +331,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.EntityProfileRunner',
         'org.opensearch.ad.NodeStateManager',
         'org.opensearch.ad.util.BulkUtil',
-        'org.opensearch.ad.util.ExceptionUtil',
-        'org.opensearch.ad.ml.EntityModel',
         'org.opensearch.ad.ml.ModelPartitioner',
 
         // TODO: unified flow caused coverage drop

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -47,6 +47,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.common.exception.NotSerializedADExceptionName;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
@@ -502,7 +503,11 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
             // exception can be a RemoteTransportException
             Exception causeException = (Exception) cause;
             if (ExceptionUtil
-                .isException(causeException, ResourceNotFoundException.class, ExceptionUtil.RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE)
+                .isException(
+                    causeException,
+                    ResourceNotFoundException.class,
+                    NotSerializedADExceptionName.RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE.getName()
+                )
                 || (ExceptionUtil.isIndexNotAvailable(causeException)
                     && causeException.getMessage().contains(CommonName.CHECKPOINT_INDEX_NAME))) {
                 // cannot find checkpoint

--- a/src/main/java/org/opensearch/ad/NodeState.java
+++ b/src/main/java/org/opensearch/ad/NodeState.java
@@ -31,7 +31,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
-import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.model.AnomalyDetector;
 
 /**
@@ -50,7 +49,7 @@ public class NodeState implements ExpiringState {
     // to check if the error for a detector has changed or not. If changed, trigger indexing.
     private Optional<String> lastDetectionError;
     // last error.
-    private Optional<AnomalyDetectionException> exception;
+    private Optional<Exception> exception;
     // flag indicating whether checkpoint for the detector exists
     private boolean checkPointExists;
     // clock to get current time
@@ -150,7 +149,7 @@ public class NodeState implements ExpiringState {
      *
      * @return last exception if any
      */
-    public Optional<AnomalyDetectionException> getException() {
+    public Optional<Exception> getException() {
         refreshLastUpdateTime();
         return exception;
     }
@@ -159,7 +158,7 @@ public class NodeState implements ExpiringState {
      *
      * @param exception exception to record
      */
-    public void setException(AnomalyDetectionException exception) {
+    public void setException(Exception exception) {
         this.exception = Optional.ofNullable(exception);
         refreshLastUpdateTime();
     }

--- a/src/main/java/org/opensearch/ad/NodeStateManager.java
+++ b/src/main/java/org/opensearch/ad/NodeStateManager.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.util.Strings;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
@@ -331,13 +330,13 @@ public class NodeStateManager implements MaintenanceState, CleanState {
      * @param adID detector id
      * @return the detector's exception
      */
-    public Optional<AnomalyDetectionException> fetchExceptionAndClear(String adID) {
+    public Optional<Exception> fetchExceptionAndClear(String adID) {
         NodeState state = states.get(adID);
         if (state == null) {
             return Optional.empty();
         }
 
-        Optional<AnomalyDetectionException> exception = state.getException();
+        Optional<Exception> exception = state.getException();
         exception.ifPresent(e -> state.setException(null));
         return exception;
     }
@@ -363,7 +362,7 @@ public class NodeStateManager implements MaintenanceState, CleanState {
             return;
         }
         NodeState state = states.computeIfAbsent(detectorId, d -> new NodeState(detectorId, clock));
-        Optional<AnomalyDetectionException> exception = state.getException();
+        Optional<Exception> exception = state.getException();
         if (exception.isPresent()) {
             Exception higherPriorityException = ExceptionUtil.selectHigherPriorityException(e, exception.get());
             if (higherPriorityException != e) {
@@ -371,13 +370,7 @@ public class NodeStateManager implements MaintenanceState, CleanState {
             }
         }
 
-        AnomalyDetectionException adExep = null;
-        if (e instanceof AnomalyDetectionException) {
-            adExep = (AnomalyDetectionException) e;
-        } else {
-            adExep = new AnomalyDetectionException(detectorId, e);
-        }
-        state.setException(adExep);
+        state.setException(e);
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/common/exception/NotSerializedADExceptionName.java
+++ b/src/main/java/org/opensearch/ad/common/exception/NotSerializedADExceptionName.java
@@ -11,12 +11,18 @@
 
 package org.opensearch.ad.common.exception;
 
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 
 /**
  * OpenSearch restricts the kind of exceptions that can be thrown over the wire
- * (Read OpenSearchException.OpenSearchExceptionHandle). Since we cannot
- * add our own exception like ResourceNotFoundException without modifying
+ * (Read OpenSearchException.OpenSearchExceptionHandle https://tinyurl.com/wv6c6t7x).
+ * Since we cannot add our own exception like ResourceNotFoundException without modifying
  * OpenSearch's code, we have to unwrap the NotSerializableExceptionWrapper and
  * check its root cause message.
  *
@@ -32,6 +38,7 @@ public enum NotSerializedADExceptionName {
     CANCELLATION_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new ADTaskCancelledException("", ""))),
     DUPLICATE_TASK_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new DuplicateTaskException("")));
 
+    private static final Logger LOG = LogManager.getLogger(NotSerializedADExceptionName.class);
     private final String name;
 
     NotSerializedADExceptionName(String name) {
@@ -40,5 +47,56 @@ public enum NotSerializedADExceptionName {
 
     public String getName() {
         return name;
+    }
+
+    /**
+     * Convert from a NotSerializableExceptionWrapper to an AnomalyDetectionException.
+     * Since NotSerializableExceptionWrapper does not keep some details we need, we
+     * initialize the exception with default values.
+     * @param exception an NotSerializableExceptionWrapper exception.
+     * @param adID Detector Id.
+     * @return converted AnomalyDetectionException
+     */
+    public static Optional<AnomalyDetectionException> convertWrappedAnomalyDetectionException(
+        NotSerializableExceptionWrapper exception,
+        String adID
+    ) {
+        String exceptionMsg = exception.getMessage().trim();
+
+        AnomalyDetectionException convertedException = null;
+        for (NotSerializedADExceptionName adException : values()) {
+            if (exceptionMsg.startsWith(adException.getName())) {
+                switch (adException) {
+                    case RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new ResourceNotFoundException(adID, exceptionMsg);
+                        break;
+                    case LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new LimitExceededException(adID, exceptionMsg, false);
+                        break;
+                    case END_RUN_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new EndRunException(adID, exceptionMsg, false);
+                        break;
+                    case ANOMALY_DETECTION_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new AnomalyDetectionException(adID, exceptionMsg);
+                        break;
+                    case INTERNAL_FAILURE_NAME_UNDERSCORE:
+                        convertedException = new InternalFailure(adID, exceptionMsg);
+                        break;
+                    case CLIENT_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new ClientException(adID, exceptionMsg);
+                        break;
+                    case CANCELLATION_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new ADTaskCancelledException(exceptionMsg, "");
+                        break;
+                    case DUPLICATE_TASK_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new DuplicateTaskException(exceptionMsg);
+                        break;
+                    default:
+                        LOG.warn(new ParameterizedMessage("Unexpected AD exception {}", adException));
+                        break;
+                }
+            }
+        }
+        return Optional.ofNullable(convertedException);
     }
 }

--- a/src/main/java/org/opensearch/ad/common/exception/NotSerializedADExceptionName.java
+++ b/src/main/java/org/opensearch/ad/common/exception/NotSerializedADExceptionName.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.common.exception;
+
+import org.opensearch.OpenSearchException;
+
+/**
+ * OpenSearch restricts the kind of exceptions that can be thrown over the wire
+ * (Read OpenSearchException.OpenSearchExceptionHandle). Since we cannot
+ * add our own exception like ResourceNotFoundException without modifying
+ * OpenSearch's code, we have to unwrap the NotSerializableExceptionWrapper and
+ * check its root cause message.
+ *
+ */
+public enum NotSerializedADExceptionName {
+
+    RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new ResourceNotFoundException("", ""))),
+    LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new LimitExceededException("", "", false))),
+    END_RUN_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new EndRunException("", "", false))),
+    ANOMALY_DETECTION_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new AnomalyDetectionException("", ""))),
+    INTERNAL_FAILURE_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new InternalFailure("", ""))),
+    CLIENT_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new ClientException("", ""))),
+    CANCELLATION_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new ADTaskCancelledException("", ""))),
+    DUPLICATE_TASK_EXCEPTION_NAME_UNDERSCORE(OpenSearchException.getExceptionName(new DuplicateTaskException("")));
+
+    private final String name;
+
+    NotSerializedADExceptionName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/opensearch/ad/ml/EntityModel.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityModel.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.ad.ml;
 
+import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.Queue;
 
@@ -61,6 +62,9 @@ public class EntityModel {
     }
 
     public void addSample(double[] sample) {
+        if (this.samples == null) {
+            this.samples = new ArrayDeque<>();
+        }
         if (sample != null && sample.length != 0) {
             this.samples.add(sample);
         }

--- a/src/main/java/org/opensearch/ad/ml/EntityModel.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityModel.java
@@ -87,7 +87,9 @@ public class EntityModel {
     }
 
     public void clear() {
-        samples.clear();
+        if (samples != null) {
+            samples.clear();
+        }
         rcf = null;
         threshold = null;
     }

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -50,7 +50,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionListenerResponseHandler;
@@ -100,6 +99,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -125,7 +125,6 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     static final String NODE_UNRESPONSIVE_ERR_MSG = "Model node is unresponsive.  Mute node";
     static final String READ_WRITE_BLOCKED = "Cannot read/write due to global block.";
     static final String INDEX_READ_BLOCKED = "Cannot read user index due to read block.";
-    static final String LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE = OpenSearchException.getExceptionName(new LimitExceededException("", ""));
     static final String NULL_RESPONSE = "Received null response from";
 
     static final String TROUBLE_QUERYING_ERR_MSG = "Having trouble querying data: ";
@@ -361,7 +360,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                             }
                         }
 
-                        final AtomicReference<AnomalyDetectionException> failure = new AtomicReference<>();
+                        final AtomicReference<Exception> failure = new AtomicReference<>();
                         int nodeCount = node2Entities.size();
                         AtomicInteger responseCount = new AtomicInteger();
                         node2Entities.stream().forEach(nodeEntity -> {
@@ -438,7 +437,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
 
             // HC logic starts here
             if (anomalyDetector.isMultientityDetector()) {
-                Optional<AnomalyDetectionException> previousException = stateManager.fetchExceptionAndClear(adID);
+                Optional<Exception> previousException = stateManager.fetchExceptionAndClear(adID);
 
                 if (previousException.isPresent()) {
                     Exception exception = previousException.get();
@@ -560,7 +559,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
             }
 
             if (!featureOptional.getProcessedFeatures().isPresent()) {
-                Optional<AnomalyDetectionException> exception = coldStartIfNoCheckPoint(detector);
+                Optional<Exception> exception = coldStartIfNoCheckPoint(detector);
                 if (exception.isPresent()) {
                     listener.onFailure(exception.get());
                     return;
@@ -607,7 +606,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
 
             List<RCFResultResponse> rcfResults = new ArrayList<>();
 
-            final AtomicReference<AnomalyDetectionException> failure = new AtomicReference<AnomalyDetectionException>();
+            final AtomicReference<Exception> failure = new AtomicReference<Exception>();
 
             final AtomicInteger responseCount = new AtomicInteger();
 
@@ -715,7 +714,8 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
      * @param failure  object that may contain exceptions thrown
      * @param detector detector object
      * @return exception if AD job execution gets resource not found exception
-     * @throws AnomalyDetectionException List of exceptions we can throw
+     * @throws Exception when the input failure is not a ResourceNotFoundException.
+     *   List of exceptions we can throw
      *     1. Exception from cold start:
      *       1). InternalFailure due to
      *         a. OpenSearchTimeoutException thrown by putModelCheckpoint during cold start
@@ -730,9 +730,8 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
      *     3. InternalFailure wrapping OpenSearchTimeoutException inside caused by
      *      RCF/Threshold model node failing to get checkpoint to restore model before timeout.
      */
-    private AnomalyDetectionException coldStartIfNoModel(AtomicReference<AnomalyDetectionException> failure, AnomalyDetector detector)
-        throws AnomalyDetectionException {
-        AnomalyDetectionException exp = failure.get();
+    private Exception coldStartIfNoModel(AtomicReference<Exception> failure, AnomalyDetector detector) throws Exception {
+        Exception exp = failure.get();
         if (exp == null) {
             return null;
         }
@@ -744,12 +743,12 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
 
         // fetch previous cold start exception
         String adID = detector.getDetectorId();
-        final Optional<AnomalyDetectionException> previousException = stateManager.fetchExceptionAndClear(adID);
+        final Optional<Exception> previousException = stateManager.fetchExceptionAndClear(adID);
         if (previousException.isPresent()) {
             Exception exception = previousException.get();
             LOG.error("Previous exception of {}: {}", () -> adID, () -> exception);
             if (exception instanceof EndRunException && ((EndRunException) exception).isEndNow()) {
-                return (EndRunException) exception;
+                return exception;
             }
         }
         LOG.info("Trigger cold start for {}", detector.getDetectorId());
@@ -757,7 +756,11 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         return previousException.orElse(new InternalFailure(adID, NO_MODEL_ERR_MSG));
     }
 
-    private void findException(Throwable cause, String adID, AtomicReference<AnomalyDetectionException> failure, String nodeId) {
+    private void findException(Throwable cause, String adID, AtomicReference<Exception> failure, String nodeId) {
+        if (cause == null) {
+            LOG.error(new ParameterizedMessage("Null input exception"));
+            return;
+        }
         if (cause instanceof Error) {
             // we cannot do anything with Error.
             LOG.error(new ParameterizedMessage("Error during prediction for {}: ", adID), cause);
@@ -765,17 +768,30 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         }
 
         Exception causeException = (Exception) cause;
-        if (ExceptionUtil
-            .isException(causeException, ResourceNotFoundException.class, ExceptionUtil.RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE)
-            || (causeException instanceof IndexNotFoundException
-                && causeException.getMessage().contains(CommonName.CHECKPOINT_INDEX_NAME))) {
+
+        if (causeException instanceof AnomalyDetectionException) {
+            failure.set(causeException);
+        } else if (causeException instanceof NotSerializableExceptionWrapper) {
+            // we only expect this happens on AD exceptions
+            Optional<AnomalyDetectionException> actualException = ExceptionUtil
+                .convertWrappedAnomalyDetectionException((NotSerializableExceptionWrapper) causeException, adID);
+            if (actualException.isPresent()) {
+                AnomalyDetectionException adException = actualException.get();
+                failure.set(adException);
+                if (adException instanceof ResourceNotFoundException) {
+                    // During a rolling upgrade or blue/green deployment, ResourceNotFoundException might be caused by old node using RCF
+                    // 1.0
+                    // cannot recognize new checkpoint produced by the coordinating node using compact RCF. Add pressure to mute the node
+                    // after consecutive failures.
+                    stateManager.addPressure(nodeId, adID);
+                }
+            } else {
+                // some unexpected bugs occur while predicting anomaly
+                failure.set(new EndRunException(adID, CommonErrorMessages.BUG_RESPONSE, causeException, false));
+            }
+        } else if (causeException instanceof IndexNotFoundException
+            && causeException.getMessage().contains(CommonName.CHECKPOINT_INDEX_NAME)) {
             failure.set(new ResourceNotFoundException(adID, causeException.getMessage()));
-            // During a rolling upgrade or blue/green deployment, ResourceNotFoundException might be caused by old node using RCF 1.0
-            // cannot recognize new checkpoint produced by the coordinating node using compact RCF. Add pressure to mute the node
-            // after consecutive failures.
-            stateManager.addPressure(nodeId, adID);
-        } else if (ExceptionUtil.isException(causeException, LimitExceededException.class, LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE)) {
-            failure.set(new LimitExceededException(adID, causeException.getMessage(), false));
         } else if (causeException instanceof OpenSearchTimeoutException) {
             // we can have OpenSearchTimeoutException when a node tries to load RCF or
             // threshold model
@@ -820,7 +836,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     class RCFActionListener implements ActionListener<RCFResultResponse> {
         private List<RCFResultResponse> rcfResults;
         private String modelID;
-        private AtomicReference<AnomalyDetectionException> failure;
+        private AtomicReference<Exception> failure;
         private String rcfNodeID;
         private AnomalyDetector detector;
         private ActionListener<AnomalyResultResponse> listener;
@@ -835,7 +851,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         RCFActionListener(
             List<RCFResultResponse> rcfResults,
             String modelID,
-            AtomicReference<AnomalyDetectionException> failure,
+            AtomicReference<Exception> failure,
             String rcfNodeID,
             AnomalyDetector detector,
             ActionListener<AnomalyResultResponse> listener,
@@ -895,7 +911,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
 
         private void handleRCFResults(int numFeatures) {
             try {
-                AnomalyDetectionException exception = coldStartIfNoModel(failure, detector);
+                Exception exception = coldStartIfNoModel(failure, detector);
                 if (exception != null) {
                     listener.onFailure(exception);
                     return;
@@ -943,7 +959,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     class ThresholdActionListener implements ActionListener<ThresholdResultResponse> {
         private AtomicReference<AnomalyResultResponse> anomalyResultResponse;
         private List<FeatureData> features;
-        private AtomicReference<AnomalyDetectionException> failure;
+        private AtomicReference<Exception> failure;
         private String thresholdNodeID;
         private ActionListener<AnomalyResultResponse> listener;
         private AnomalyDetector detector;
@@ -968,7 +984,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
             this.thresholdNodeID = thresholdNodeID;
             this.detector = detector;
             this.combinedResult = combinedResult;
-            this.failure = new AtomicReference<AnomalyDetectionException>();
+            this.failure = new AtomicReference<Exception>();
             this.listener = listener;
             this.adID = adID;
             this.rcfTotalUpdates = rcfTotalUpdates;
@@ -1013,7 +1029,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
 
         private void handleThresholdResult() {
             try {
-                AnomalyDetectionException exception = coldStartIfNoModel(failure, detector);
+                Exception exception = coldStartIfNoModel(failure, detector);
                 if (exception != null) {
                     listener.onFailure(exception);
                     return;
@@ -1042,7 +1058,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         }
     }
 
-    private void handlePredictionFailure(Exception e, String adID, String nodeID, AtomicReference<AnomalyDetectionException> failure) {
+    private void handlePredictionFailure(Exception e, String adID, String nodeID, AtomicReference<Exception> failure) {
         LOG.error(new ParameterizedMessage("Received an error from node {} while doing model inference for {}", nodeID, adID), e);
         if (e == null) {
             return;
@@ -1239,10 +1255,10 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
      * @param detector detector object
      * @return previous cold start exception
      */
-    private Optional<AnomalyDetectionException> coldStartIfNoCheckPoint(AnomalyDetector detector) {
+    private Optional<Exception> coldStartIfNoCheckPoint(AnomalyDetector detector) {
         String detectorId = detector.getDetectorId();
 
-        Optional<AnomalyDetectionException> previousException = stateManager.fetchExceptionAndClear(detectorId);
+        Optional<Exception> previousException = stateManager.fetchExceptionAndClear(detectorId);
 
         if (previousException.isPresent()) {
             Exception exception = previousException.get();
@@ -1275,7 +1291,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     class EntityResultListener implements ActionListener<AcknowledgedResponse> {
         private String nodeId;
         private final String adID;
-        private AtomicReference<AnomalyDetectionException> failure;
+        private AtomicReference<Exception> failure;
         private int nodeCount;
         private AtomicInteger responseCount;
         private PageIterator pageIterator;
@@ -1284,7 +1300,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         EntityResultListener(
             String nodeId,
             String adID,
-            AtomicReference<AnomalyDetectionException> failure,
+            AtomicReference<Exception> failure,
             int nodeCount,
             PageIterator pageIterator,
             PageListener pageListener,

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -46,7 +46,6 @@ import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
-import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
@@ -143,7 +142,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         try {
             String detectorId = request.getDetectorId();
 
-            Optional<AnomalyDetectionException> previousException = stateManager.fetchExceptionAndClear(detectorId);
+            Optional<Exception> previousException = stateManager.fetchExceptionAndClear(detectorId);
 
             if (previousException.isPresent()) {
                 Exception exception = previousException.get();
@@ -170,7 +169,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         ActionListener<AcknowledgedResponse> listener,
         String detectorId,
         EntityResultRequest request,
-        Optional<AnomalyDetectionException> prevException
+        Optional<Exception> prevException
     ) {
         return ActionListener.wrap(detectorOptional -> {
             if (!detectorOptional.isPresent()) {

--- a/src/main/java/org/opensearch/ad/util/ExceptionUtil.java
+++ b/src/main/java/org/opensearch/ad/util/ExceptionUtil.java
@@ -27,10 +27,14 @@
 package org.opensearch.ad.util;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Throwables;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
@@ -38,9 +42,14 @@ import org.opensearch.action.NoShardAvailableActionException;
 import org.opensearch.action.UnavailableShardsException;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.replication.ReplicationResponse;
+import org.opensearch.ad.common.exception.ADTaskCancelledException;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
+import org.opensearch.ad.common.exception.ClientException;
+import org.opensearch.ad.common.exception.DuplicateTaskException;
 import org.opensearch.ad.common.exception.EndRunException;
+import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.LimitExceededException;
+import org.opensearch.ad.common.exception.NotSerializedADExceptionName;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
@@ -48,9 +57,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.rest.RestStatus;
 
 public class ExceptionUtil {
-    public static final String RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE = OpenSearchException
-        .getExceptionName(new ResourceNotFoundException("", ""));
-
+    private static final Logger LOG = LogManager.getLogger(ExceptionUtil.class);
     // a positive cache of retriable error rest status
     private static final EnumSet<RestStatus> RETRYABLE_STATUS = EnumSet
         .of(RestStatus.REQUEST_TIMEOUT, RestStatus.CONFLICT, RestStatus.INTERNAL_SERVER_ERROR);
@@ -86,6 +93,56 @@ public class ExceptionUtil {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Convert from a NotSerializableExceptionWrapper to an AnomalyDetectionException. Since NotSerializableExceptionWrapper does not
+     * keep some details we need, we initialize the exception with default values.
+     * @param exception an NotSerializableExceptionWrapper exception.
+     * @param adID Detector Id.
+     * @return converted AnomalyDetectionException
+     */
+    public static Optional<AnomalyDetectionException> convertWrappedAnomalyDetectionException(
+        NotSerializableExceptionWrapper exception,
+        String adID
+    ) {
+        String exceptionMsg = exception.getMessage().trim();
+
+        AnomalyDetectionException convertedException = null;
+        for (NotSerializedADExceptionName adException : NotSerializedADExceptionName.values()) {
+            if (exceptionMsg.startsWith(adException.getName())) {
+                switch (adException) {
+                    case RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new ResourceNotFoundException(adID, exceptionMsg);
+                        break;
+                    case LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new LimitExceededException(adID, exceptionMsg, false);
+                        break;
+                    case END_RUN_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new EndRunException(adID, exceptionMsg, false);
+                        break;
+                    case ANOMALY_DETECTION_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new AnomalyDetectionException(adID, exceptionMsg);
+                        break;
+                    case INTERNAL_FAILURE_NAME_UNDERSCORE:
+                        convertedException = new InternalFailure(adID, exceptionMsg);
+                        break;
+                    case CLIENT_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new ClientException(adID, exceptionMsg);
+                        break;
+                    case CANCELLATION_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new ADTaskCancelledException(exceptionMsg, "");
+                        break;
+                    case DUPLICATE_TASK_EXCEPTION_NAME_UNDERSCORE:
+                        convertedException = new DuplicateTaskException(exceptionMsg);
+                        break;
+                    default:
+                        LOG.warn(new ParameterizedMessage("Unexpected AD exception {}", adException));
+                        break;
+                }
+            }
+        }
+        return Optional.ofNullable(convertedException);
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/util/ExceptionUtil.java
+++ b/src/main/java/org/opensearch/ad/util/ExceptionUtil.java
@@ -27,14 +27,10 @@
 package org.opensearch.ad.util;
 
 import java.util.EnumSet;
-import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Throwables;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
@@ -42,22 +38,15 @@ import org.opensearch.action.NoShardAvailableActionException;
 import org.opensearch.action.UnavailableShardsException;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.replication.ReplicationResponse;
-import org.opensearch.ad.common.exception.ADTaskCancelledException;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
-import org.opensearch.ad.common.exception.ClientException;
-import org.opensearch.ad.common.exception.DuplicateTaskException;
 import org.opensearch.ad.common.exception.EndRunException;
-import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.LimitExceededException;
-import org.opensearch.ad.common.exception.NotSerializedADExceptionName;
-import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.rest.RestStatus;
 
 public class ExceptionUtil {
-    private static final Logger LOG = LogManager.getLogger(ExceptionUtil.class);
     // a positive cache of retriable error rest status
     private static final EnumSet<RestStatus> RETRYABLE_STATUS = EnumSet
         .of(RestStatus.REQUEST_TIMEOUT, RestStatus.CONFLICT, RestStatus.INTERNAL_SERVER_ERROR);
@@ -93,56 +82,6 @@ public class ExceptionUtil {
             return true;
         }
         return false;
-    }
-
-    /**
-     * Convert from a NotSerializableExceptionWrapper to an AnomalyDetectionException. Since NotSerializableExceptionWrapper does not
-     * keep some details we need, we initialize the exception with default values.
-     * @param exception an NotSerializableExceptionWrapper exception.
-     * @param adID Detector Id.
-     * @return converted AnomalyDetectionException
-     */
-    public static Optional<AnomalyDetectionException> convertWrappedAnomalyDetectionException(
-        NotSerializableExceptionWrapper exception,
-        String adID
-    ) {
-        String exceptionMsg = exception.getMessage().trim();
-
-        AnomalyDetectionException convertedException = null;
-        for (NotSerializedADExceptionName adException : NotSerializedADExceptionName.values()) {
-            if (exceptionMsg.startsWith(adException.getName())) {
-                switch (adException) {
-                    case RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new ResourceNotFoundException(adID, exceptionMsg);
-                        break;
-                    case LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new LimitExceededException(adID, exceptionMsg, false);
-                        break;
-                    case END_RUN_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new EndRunException(adID, exceptionMsg, false);
-                        break;
-                    case ANOMALY_DETECTION_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new AnomalyDetectionException(adID, exceptionMsg);
-                        break;
-                    case INTERNAL_FAILURE_NAME_UNDERSCORE:
-                        convertedException = new InternalFailure(adID, exceptionMsg);
-                        break;
-                    case CLIENT_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new ClientException(adID, exceptionMsg);
-                        break;
-                    case CANCELLATION_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new ADTaskCancelledException(exceptionMsg, "");
-                        break;
-                    case DUPLICATE_TASK_EXCEPTION_NAME_UNDERSCORE:
-                        convertedException = new DuplicateTaskException(exceptionMsg);
-                        break;
-                    default:
-                        LOG.warn(new ParameterizedMessage("Unexpected AD exception {}", adException));
-                        break;
-                }
-            }
-        }
-        return Optional.ofNullable(convertedException);
     }
 
     /**

--- a/src/test/java/org/opensearch/ad/common/exception/NotSerializedADExceptionNameTests.java
+++ b/src/test/java/org/opensearch/ad/common/exception/NotSerializedADExceptionNameTests.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.common.exception;
+
+import java.util.Optional;
+
+import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class NotSerializedADExceptionNameTests extends OpenSearchTestCase {
+    public void testConvertAnomalyDetectionException() {
+        Optional<AnomalyDetectionException> converted = NotSerializedADExceptionName
+            .convertWrappedAnomalyDetectionException(new NotSerializableExceptionWrapper(new AnomalyDetectionException("", "")), "");
+        assertTrue(converted.isPresent());
+        assertTrue(converted.get() instanceof AnomalyDetectionException);
+    }
+
+    public void testConvertInternalFailure() {
+        Optional<AnomalyDetectionException> converted = NotSerializedADExceptionName
+            .convertWrappedAnomalyDetectionException(new NotSerializableExceptionWrapper(new InternalFailure("", "")), "");
+        assertTrue(converted.isPresent());
+        assertTrue(converted.get() instanceof InternalFailure);
+    }
+
+    public void testConvertClientException() {
+        Optional<AnomalyDetectionException> converted = NotSerializedADExceptionName
+            .convertWrappedAnomalyDetectionException(new NotSerializableExceptionWrapper(new ClientException("", "")), "");
+        assertTrue(converted.isPresent());
+        assertTrue(converted.get() instanceof ClientException);
+    }
+
+    public void testConvertADTaskCancelledException() {
+        Optional<AnomalyDetectionException> converted = NotSerializedADExceptionName
+            .convertWrappedAnomalyDetectionException(new NotSerializableExceptionWrapper(new ADTaskCancelledException("", "")), "");
+        assertTrue(converted.isPresent());
+        assertTrue(converted.get() instanceof ADTaskCancelledException);
+    }
+
+    public void testConvertDuplicateTaskException() {
+        Optional<AnomalyDetectionException> converted = NotSerializedADExceptionName
+            .convertWrappedAnomalyDetectionException(new NotSerializableExceptionWrapper(new DuplicateTaskException("")), "");
+        assertTrue(converted.isPresent());
+        assertTrue(converted.get() instanceof DuplicateTaskException);
+    }
+
+    public void testUnknownException() {
+        Optional<AnomalyDetectionException> converted = NotSerializedADExceptionName
+            .convertWrappedAnomalyDetectionException(new NotSerializableExceptionWrapper(new RuntimeException("")), "");
+        assertTrue(!converted.isPresent());
+    }
+}

--- a/src/test/java/org/opensearch/ad/ml/EntityModelTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityModelTests.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ml;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class EntityModelTests extends OpenSearchTestCase {
+    public void testNullInternalSampleQueue() {
+        EntityModel model = new EntityModel(null, null, null, null);
+        model.addSample(new double[] { 0.8 });
+        assertEquals(1, model.getSamples().size());
+    }
+
+    public void testNullInputSample() {
+        EntityModel model = new EntityModel(null, null, null, null);
+        model.addSample(null);
+        assertEquals(0, model.getSamples().size());
+    }
+
+    public void testEmptyInputSample() {
+        EntityModel model = new EntityModel(null, null, null, null);
+        model.addSample(new double[] {});
+        assertEquals(0, model.getSamples().size());
+    }
+}

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -330,7 +330,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalAnalysisIn
         assertEquals(0, getExecutingADTask());
     }
 
-    // @Ignore
+    @Ignore
     public void testProfileHistoricalDetector() throws IOException, InterruptedException {
         ADTask adTask = startHistoricalAnalysis(startTime, endTime);
         GetAnomalyDetectorRequest request = taskProfileRequest(adTask.getDetectorId());

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,9 +66,11 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.stubbing.Answer;
 import org.opensearch.BwcTests;
+import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
@@ -88,6 +91,7 @@ import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.EndRunException;
+import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.CompositeRetriever;
@@ -384,7 +388,7 @@ public class MultiEntityResultTests extends AbstractADTest {
         };
     }
 
-    private void setUpEntityResult(int nodeIndex) {
+    private void setUpEntityResult(int nodeIndex, NodeStateManager nodeStateManager) {
         // register entity result action
         new EntityResultTransportAction(
             new ActionFilters(Collections.emptySet()),
@@ -393,7 +397,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             normalModelManager,
             adCircuitBreakerService,
             provider,
-            stateManager,
+            nodeStateManager,
             indexUtil,
             resultWriteQueue,
             checkpointReadQueue,
@@ -402,6 +406,10 @@ public class MultiEntityResultTests extends AbstractADTest {
         );
 
         when(normalModelManager.getAnomalyResultForEntity(any(), any(), any(), any(), any())).thenReturn(new ThresholdingResult(0, 1, 1));
+    }
+
+    private void setUpEntityResult(int nodeIndex) {
+        setUpEntityResult(nodeIndex, stateManager);
     }
 
     @SuppressWarnings("unchecked")
@@ -1107,5 +1115,157 @@ public class MultiEntityResultTests extends AbstractADTest {
         String repr = page.toString();
         // we have at least class name
         assertTrue("actual:" + repr, repr.contains("Page"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Pair<NodeStateManager, CountDownLatch> setUpTestExceptionTestingInModelNode() throws IOException {
+        CountDownLatch inProgress = setUpSearchResponse();
+        setUpTransportInterceptor(this::entityResultHandler);
+        // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
+        when(hashRing.getOwningNode(any(String.class))).thenReturn(Optional.of(testNodes[1].discoveryNode()));
+
+        NodeStateManager modelNodeStateManager = mock(NodeStateManager.class);
+        // make sure parameters are not null, otherwise this mock won't get invoked
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(modelNodeStateManager).getAnomalyDetector(anyString(), any(ActionListener.class));
+        return Pair.of(modelNodeStateManager, inProgress);
+    }
+
+    public void testEndRunNowInModelNode() throws InterruptedException, IOException {
+        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
+        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
+        CountDownLatch inProgress = preparedFixture.getRight();
+
+        when(modelNodeStateManager.fetchExceptionAndClear(anyString()))
+            .thenReturn(
+                Optional
+                    .of(
+                        new EndRunException(
+                            detectorId,
+                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            new NoSuchElementException("No value present"),
+                            true
+                        )
+                    )
+            );
+
+        setUpEntityResult(1, modelNodeStateManager);
+
+        PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
+
+        action.doExecute(null, request, listener);
+
+        AnomalyResultResponse response = listener.actionGet(10000L);
+        assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
+
+        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+
+        // since it is end run now, we don't expect any of the normal workflow continues
+        verify(resultWriteQueue, never()).put(any());
+    }
+
+    public void testEndRunNowFalseInModelNode() throws InterruptedException, IOException {
+        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
+        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
+        CountDownLatch inProgress = preparedFixture.getRight();
+
+        when(modelNodeStateManager.fetchExceptionAndClear(anyString()))
+            .thenReturn(
+                Optional
+                    .of(
+                        new EndRunException(
+                            detectorId,
+                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            new NoSuchElementException("No value present"),
+                            false
+                        )
+                    )
+            );
+
+        setUpEntityResult(1, modelNodeStateManager);
+
+        PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
+
+        action.doExecute(null, request, listener);
+
+        AnomalyResultResponse response = listener.actionGet(10000L);
+        assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
+
+        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+
+        // since it is end run now = false, the normal workflow continues
+        verify(resultWriteQueue, times(3)).put(any());
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(stateManager).setException(anyString(), exceptionCaptor.capture());
+        EndRunException endRunException = (EndRunException) (exceptionCaptor.getValue());
+        assertTrue(!endRunException.isEndNow());
+    }
+
+    /**
+     * Test that in model node, previously recorded exception is OpenSearchTimeoutException,
+     * @throws IOException when failing to set up transport layer
+     * @throws InterruptedException when failing to wait for inProgress to finish
+     */
+    public void testTimeOutExceptionInModelNode() throws IOException, InterruptedException {
+        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
+        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
+        CountDownLatch inProgress = preparedFixture.getRight();
+
+        when(modelNodeStateManager.fetchExceptionAndClear(anyString())).thenReturn(Optional.of(new OpenSearchTimeoutException("blah")));
+
+        setUpEntityResult(1, modelNodeStateManager);
+
+        PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
+
+        action.doExecute(null, request, listener);
+
+        AnomalyResultResponse response = listener.actionGet(10000L);
+        assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
+
+        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+
+        // since OpenSearchTimeoutException is not end run exception (now = true), the normal workflow continues
+        verify(resultWriteQueue, times(3)).put(any());
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(stateManager).setException(anyString(), exceptionCaptor.capture());
+        Exception actual = exceptionCaptor.getValue();
+        assertTrue("actual exception is " + actual, actual instanceof InternalFailure);
+    }
+
+    /**
+     * Test that when both previous and current run returns exception, we return more
+     * important exception (EndRunException is more important)
+     * @throws InterruptedException when failing to wait for inProgress to finish
+     * @throws IOException when failing to set up transport layer
+     */
+    public void testSelectHigherExceptionInModelNode() throws InterruptedException, IOException {
+        when(entityCache.get(any(), any())).thenThrow(EndRunException.class);
+
+        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
+        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
+        CountDownLatch inProgress = preparedFixture.getRight();
+
+        when(modelNodeStateManager.fetchExceptionAndClear(anyString())).thenReturn(Optional.of(new OpenSearchTimeoutException("blah")));
+
+        setUpEntityResult(1, modelNodeStateManager);
+
+        PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
+
+        action.doExecute(null, request, listener);
+
+        AnomalyResultResponse response = listener.actionGet(10000L);
+        assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
+
+        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+
+        // since EndRunException is thrown before getting any result, we cannot save anything
+        verify(resultWriteQueue, never()).put(any());
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(stateManager).setException(anyString(), exceptionCaptor.capture());
+        EndRunException endRunException = (EndRunException) (exceptionCaptor.getValue());
+        assertTrue(!endRunException.isEndNow());
     }
 }


### PR DESCRIPTION
### Description
OpenSearch restricts the kind of exceptions that can be thrown over the wire (Read OpenSearchException.OpenSearchExceptionHandle). Since we cannot add our exception like ResourceNotFoundException without modifying OpenSearch's code, we must unwrap the NotSerializableExceptionWrapper and check its root cause message. This PR adds checks all AD exceptions in such cases. Previously, we only checked a couple of them.

Previously, we wrap all exceptions thrown in AD using one of AnomalyDetectionExceptions. The wrap brings a complication to NotSerializableExceptionWrapper thrown over the wire as NotSerializableExceptionWrapper won't keep the original AnomalyDetectionExceptions object and only keeps the cause message. Therefore, we won't be able to restore the original exception encapsulated inside AnomalyDetectionExceptions. This PR stops wrapping the original exception inside AnomalyDetectionExceptions.

This PR also adds a null check inside EntityModel in case of a potential null pointer exception.

Testing done:
1. Added unit tests to check if exceptions wrapped inside NotSerializableExceptionWrapper can be decoded.
2. Did e2e testing for basic single-stream and HCAD workflow.
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
