### PR TITLE
Disable model splitting in single-stream detectors

### DIFF
--- a/src/main/java/org/opensearch/ad/MemoryTracker.java
+++ b/src/main/java/org/opensearch/ad/MemoryTracker.java
@@ -226,7 +226,13 @@ public class MemoryTracker {
      *   + IndexManager
      *     - int array for free indexes: 256 * numberOfTrees * 4, where 4 is the size of an integer
      *   - two int array for locationList and refCount: 256 * numberOfTrees * 4 bytes * 2
-     *   - a float array for data store: 256 * trees * dimension * 4 bytes
+     *   - a float array for data store: 256 * trees * dimension * 4 bytes: due to various
+     *     optimization like shingleSize(dimensions), we don't use all of the array.  The actual
+     *     usage percentage is
+     *     {@code IF(dimensions>=32, 1/(LOG(dimensions+1, 2)+LOG(dimensions+1, 10)), 1/LOG(dimensions+1, 2))}
+     *     where LOG gets the logarithm of a number and the syntax of LOG is {@code LOG (number, [base])}.
+     *     We derive the formula by observing the point store usage ratio is a decreasing function of dimensions
+     *     and the relationship is logarithm. Adding 1 to dimension to ensure dimension 1 results in a ratio 1.
      * - ComponentList: an array of size numberOfTrees
      *   + SamplerPlusTree
      *    - CompactSampler: 2248
@@ -248,7 +254,7 @@ public class MemoryTracker {
      *  56 + # trees * (2248 + 152 + 6120 + 104 + (1040 + 255* (dimension * 4 * 2 + 64)) * adjusted bounding box cache ratio) +
      *  (256 * # trees  * 2 + 256 * # trees * dimension) * 4 bytes  * 0.5 + 1064 + 24 + 24 + 16
      *  = 56 + # trees * (8624 + (1040 + 255 * (dimension * 8 + 64)) * adjusted bounding box cache ratio) + 256 * # trees *
-     *   (2 + dimension) * 4 * 0.5 + 1128
+     *   (3 + dimension) * 4 * 0.5 + 1128
      *
      * @param dimension The number of feature dimensions in RCF
      * @param numberOfTrees The number of trees in RCF
@@ -256,11 +262,28 @@ public class MemoryTracker {
      * @return estimated RCF model size
      */
     public long estimateRCFModelSize(int dimension, int numberOfTrees, double boundingBoxCacheFraction) {
-        float averagePointStoreUsage = dimension == 1 ? 1 : 0.5f;
-        float actualBoundingBoxUsage = boundingBoxCacheFraction >= 0.3 ? 1 : (float) boundingBoxCacheFraction;
+        double averagePointStoreUsage = 0;
+        int logNumber = dimension + 1;
+        if (dimension >= 32) {
+            averagePointStoreUsage = 1.0d / (log2(logNumber) + Math.log10(logNumber));
+        } else {
+            averagePointStoreUsage = 1.0d / log2(logNumber);
+        }
+        double actualBoundingBoxUsage = boundingBoxCacheFraction >= 0.3 ? 1d : boundingBoxCacheFraction;
         long compactRcfSize = (long) (56 + numberOfTrees * (8624 + (1040 + 255 * (dimension * 8 + 64)) * actualBoundingBoxUsage) + 256
-            * numberOfTrees * (2 + dimension) * 4 * averagePointStoreUsage + 1128);
+            * numberOfTrees * (3 + dimension) * 4 * averagePointStoreUsage + 1128);
         return compactRcfSize;
+    }
+
+    /**
+     * Function to calculate the log base 2 of an integer
+     *
+     * @param N input number
+     * @return the base 2 logarithm of an integer value
+     */
+    public static double log2(int N) {
+        // calculate log2 N indirectly using log() method
+        return Math.log(N) / Math.log(2);
     }
 
     public long estimateTotalModelSize(int dimension, int numberOfTrees, double boundingBoxCacheFraction) {

--- a/src/main/java/org/opensearch/ad/MemoryTracker.java
+++ b/src/main/java/org/opensearch/ad/MemoryTracker.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.util.MathUtil;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.monitor.jvm.JvmService;
 
@@ -265,25 +266,14 @@ public class MemoryTracker {
         double averagePointStoreUsage = 0;
         int logNumber = dimension + 1;
         if (dimension >= 32) {
-            averagePointStoreUsage = 1.0d / (log2(logNumber) + Math.log10(logNumber));
+            averagePointStoreUsage = 1.0d / (MathUtil.log2(logNumber) + Math.log10(logNumber));
         } else {
-            averagePointStoreUsage = 1.0d / log2(logNumber);
+            averagePointStoreUsage = 1.0d / MathUtil.log2(logNumber);
         }
         double actualBoundingBoxUsage = boundingBoxCacheFraction >= 0.3 ? 1d : boundingBoxCacheFraction;
         long compactRcfSize = (long) (56 + numberOfTrees * (8624 + (1040 + 255 * (dimension * 8 + 64)) * actualBoundingBoxUsage) + 256
             * numberOfTrees * (3 + dimension) * 4 * averagePointStoreUsage + 1128);
         return compactRcfSize;
-    }
-
-    /**
-     * Function to calculate the log base 2 of an integer
-     *
-     * @param N input number
-     * @return the base 2 logarithm of an integer value
-     */
-    public static double log2(int N) {
-        // calculate log2 N indirectly using log() method
-        return Math.log(N) / Math.log(2);
     }
 
     public long estimateTotalModelSize(int dimension, int numberOfTrees, double boundingBoxCacheFraction) {

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -63,7 +63,7 @@ public final class AnomalyDetectorSettings {
             "plugins.anomaly_detection.max_anomaly_features",
             LegacyOpenDistroAnomalyDetectorSettings.MAX_ANOMALY_FEATURES,
             0,
-            100,
+            10,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
@@ -212,14 +212,15 @@ public final class AnomalyDetectorSettings {
 
     // The threshold for splitting RCF models in single-stream detectors.
     // The smallest machine in the Amazon managed service has 1GB heap.
-    // With the setting, the desired model size there is of 1 MB.
-    // By default, we can have at most 5 features.  Since the default shingle size
+    // With the setting, the desired model size there is of 2 MB.
+    // By default, we can have at most 5 features. Since the default shingle size
     // is 8, we have at most 40 dimensions in RCF. In our current RCF setting,
-    // 30 trees, and bounding box cache ratio 0, 40 dimensions use 920KB.
-    // Since the size is smaller than the threshold 1 MB, we won't split models
-    // even in the smallest machine. Of course, when users increase the shingle
-    // size, we may split models.
-    public static final double DESIRED_MODEL_SIZE_PERCENTAGE = 0.001;
+    // 30 trees, and bounding box cache ratio 0, 40 dimensions use 449KB.
+    // Users can increase the number of features to 10 and shingle size to 60,
+    // 30 trees, bounding box cache ratio 0, 600 dimensions use 1.8 MB.
+    // Since these sizes are smaller than the threshold 2 MB, we won't split models
+    // even in the smallest machine.
+    public static final double DESIRED_MODEL_SIZE_PERCENTAGE = 0.002;
 
     public static final Setting<Double> MODEL_MAX_SIZE_PERCENTAGE = Setting
         .doubleSetting(
@@ -244,7 +245,9 @@ public final class AnomalyDetectorSettings {
     // TODO (kaituo): change to 4
     public static final int DEFAULT_MULTI_ENTITY_SHINGLE = 1;
 
-    public static final int MAX_SHINGLE_SIZE = 1024;
+    // max shingle size we have seen from external users
+    // the larger shingle size, the harder to fill in a complete shingle
+    public static final int MAX_SHINGLE_SIZE = 60;
 
     // Thresholding
     public static final double THRESHOLD_MIN_PVALUE = 0.995;

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -210,7 +210,16 @@ public final class AnomalyDetectorSettings {
 
     public static final int NUM_MIN_SAMPLES = 128;
 
-    public static final double DESIRED_MODEL_SIZE_PERCENTAGE = 0.0002;
+    // The threshold for splitting RCF models in single-stream detectors.
+    // The smallest machine in the Amazon managed service has 1GB heap.
+    // With the setting, the desired model size there is of 1 MB.
+    // By default, we can have at most 5 features.  Since the default shingle size
+    // is 8, we have at most 40 dimensions in RCF. In our current RCF setting,
+    // 30 trees, and bounding box cache ratio 0, 40 dimensions use 920KB.
+    // Since the size is smaller than the threshold 1 MB, we won't split models
+    // even in the smallest machine. Of course, when users increase the shingle
+    // size, we may split models.
+    public static final double DESIRED_MODEL_SIZE_PERCENTAGE = 0.001;
 
     public static final Setting<Double> MODEL_MAX_SIZE_PERCENTAGE = Setting
         .doubleSetting(

--- a/src/main/java/org/opensearch/ad/util/MathUtil.java
+++ b/src/main/java/org/opensearch/ad/util/MathUtil.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.util;
+
+public class MathUtil {
+    /*
+     * Private constructor to avoid Jacoco complain about public constructor
+     * not covered: https://tinyurl.com/yetc7tra
+     */
+    private MathUtil() {}
+
+    /**
+     * Function to calculate the log base 2 of an integer
+     *
+     * @param N input number
+     * @return the base 2 logarithm of an integer value
+     */
+    public static double log2(int N) {
+        // calculate log2 N indirectly using log() method
+        return Math.log(N) / Math.log(2);
+    }
+
+}

--- a/src/test/java/org/opensearch/ad/MemoryTrackerTests.java
+++ b/src/test/java/org/opensearch/ad/MemoryTrackerTests.java
@@ -76,7 +76,7 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
         super.setUp();
         rcfNumFeatures = 1;
         rcfSampleSize = 256;
-        numberOfTrees = 10;
+        numberOfTrees = 30;
         rcfTimeDecay = 0.2;
         numMinSamples = 128;
 
@@ -102,7 +102,7 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
-        expectedRCFModelSize = 118144;
+        expectedRCFModelSize = 382784;
         detectorId = "123";
 
         rcf = RandomCutForest
@@ -164,6 +164,23 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
             expectedRCFModelSize + tracker.getThresholdModelBytes(),
             tracker.estimateTotalModelSize(detector, numberOfTrees, AnomalyDetectorSettings.REAL_TIME_BOUNDING_BOX_CACHE_RATIO)
         );
+
+        RandomCutForest rcf2 = RandomCutForest
+            .builder()
+            .dimensions(32) // 32 to trigger another calculation of point store usage
+            .sampleSize(rcfSampleSize)
+            .numberOfTrees(numberOfTrees)
+            .timeDecay(rcfTimeDecay)
+            .outputAfter(numMinSamples)
+            .parallelExecutionEnabled(false)
+            .compact(true)
+            .precision(Precision.FLOAT_32)
+            .boundingBoxCacheFraction(AnomalyDetectorSettings.REAL_TIME_BOUNDING_BOX_CACHE_RATIO)
+            // same with dimension for opportunistic memory saving
+            .shingleSize(rcfNumFeatures)
+            .build();
+        assertEquals(423733 + tracker.getThresholdModelBytes(), tracker.estimateTotalModelSize(rcf2));
+        assertTrue(tracker.isHostingAllowed(detectorId, rcf2));
     }
 
     public void testCanAllocate() {

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -47,6 +47,7 @@ import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.DetectionDateRange;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -107,7 +108,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             TestHelpers.randomQuery(),
             TestHelpers.randomIntervalTimeConfiguration(),
             TestHelpers.randomIntervalTimeConfiguration(),
-            randomIntBetween(1, 1024),
+            randomIntBetween(1, AnomalyDetectorSettings.MAX_SHINGLE_SIZE),
             TestHelpers.randomUiMetadata(),
             randomInt(),
             null,

--- a/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
+++ b/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
@@ -237,8 +237,8 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
         assertEquals(AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(98));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(10));
 
-        settings = Settings.builder().put("plugins.anomaly_detection.max_anomaly_features", 97).build();
-        assertEquals(AnomalyDetectorSettings.MAX_ANOMALY_FEATURES.get(settings), Integer.valueOf(97));
+        settings = Settings.builder().put("plugins.anomaly_detection.max_anomaly_features", 7).build();
+        assertEquals(AnomalyDetectorSettings.MAX_ANOMALY_FEATURES.get(settings), Integer.valueOf(7));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_ANOMALY_FEATURES.get(settings), Integer.valueOf(5));
 
         settings = Settings.builder().put("plugins.anomaly_detection.detection_interval", TimeValue.timeValueMinutes(96)).build();


### PR DESCRIPTION
### Description

We split and distribute models to different nodes to avoid large models on a single node. The splitting is unnecessary after introducing compact rcf as the model is smaller (at least 4x smaller). Splitting also undoes the shared point store optimization among trees. Also, splitting brings complications when computing expected values. Thus, this PR disables splitting by increasing the desired model size. We won't split a model whose size is less than the desired size.

This PR adjusts max features and shingle size accordingly to avoid huge models without explicit benefits.

This PR also adjusts the model size formula due to the change https://github.com/aws/random-cut-forest-by-aws/pull/265. I will update the rcf version once rcf 2.0 is released in maven.

Experiments on estimated vs actual model size: https://gist.github.com/kaituo/eeacd12c952363ef3a635ff12674197b

Testing done:
1. tested single-stream models won't be split after the change.
2. Updated unit tests.
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
