### PR TITLE
extended rcf with thresholding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ out/
 .vscode
 bin/
 src/test/resources/job-scheduler
+lombok.config

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ plugins {
     id "com.diffplug.gradle.spotless" version "3.26.1"
     id 'java-library'
     id 'checkstyle'
+    id "io.freefair.lombok" version "5.1.0"
 }
 
 repositories {
@@ -354,6 +355,9 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.transport.CronNodeRequest',
         'org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction',
         'org.opensearch.ad.transport.GetAnomalyDetectorResponse'
+
+        // TODO: until ercf move to rcf repo,
+        ,'com.amazon.randomcutforest.*'
 ]
 
 jacocoTestCoverageVerification {
@@ -450,6 +454,9 @@ dependencies {
 }
 
 compileJava.options.compilerArgs << "-Xlint:-deprecation,-rawtypes,-serial,-try,-unchecked"
+compileJava {
+    options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
+}
 
 apply plugin: 'nebula.ospackage'
 

--- a/src/main/java/com/amazon/randomcutforest/ERCF/AnomalyDescriptor.java
+++ b/src/main/java/com/amazon/randomcutforest/ERCF/AnomalyDescriptor.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+import lombok.Data;
+
+import com.amazon.randomcutforest.returntypes.DiVector;
+
+@Data
+public class AnomalyDescriptor {
+
+    // anomalies should have score for postprocessing
+    private double rcfScore;
+
+    // the following describes the grade of the anomaly in the range [0:1] where
+    // 0 is not an anomaly
+    private double anomalyGrade;
+
+    // same for attribution; this is basic RCF attribution which has high/low information
+    private DiVector attribution;
+
+    // timestamp (basically a sequence index); kept as long for potential future use
+    private long timeStamp;
+
+    // number of trees in the forest
+    private int forestSize;
+
+    // flag indicating of expected values are present -- one reason for them not being present
+    // is that forecasting can requires more values than anomaly detection,
+    private boolean expectedValuesPresent;
+
+    // flag indicating if the anomaly is the start of an anomaly or part of a run of anomalies
+    private boolean startOfAnomaly;
+
+    /**
+     * position of the anomaly vis a vis the current time (can be -ve) if anomaly is detected late, which can
+     * and should happen sometime; for shingle size 1; this is always 0
+     * */
+    private int relativeIndex;
+
+    // a flattened version denoting the basic contribution of each input variable (not shingled) for the
+    // time slice indicated by relativeIndex
+    private double[] flattenedAttribution;
+
+    // current values
+    private double[] currentValues;
+
+    // the values being replaced; may correspond to past
+    private double[] oldValues;
+
+    private double[][] expectedValuesList;
+
+    private double[] likelihoodOfValues;
+}

--- a/src/main/java/com/amazon/randomcutforest/ERCF/ERCFMapper.java
+++ b/src/main/java/com/amazon/randomcutforest/ERCF/ERCFMapper.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.state.IStateMapper;
+import com.amazon.randomcutforest.state.RandomCutForestMapper;
+import com.amazon.randomcutforest.threshold.CorrectorThresholder;
+import com.amazon.randomcutforest.threshold.state.CorrectorThresholderMapper;
+
+public class ERCFMapper implements IStateMapper<ExtendedRandomCutForest, ERCFState> {
+
+    @Override
+    public ExtendedRandomCutForest toModel(ERCFState state, long seed) {
+
+        RandomCutForestMapper randomCutForestMapper = new RandomCutForestMapper();
+        CorrectorThresholderMapper correctorThresholderMapper = new CorrectorThresholderMapper();
+
+        RandomCutForest forest = randomCutForestMapper.toModel(state.getForestState());
+        CorrectorThresholder thresholder = correctorThresholderMapper.toModel(state.getThresholderState());
+        return new ExtendedRandomCutForest(
+            forest,
+            thresholder,
+            state.getCount(),
+            state.getNumberOfAttributors(),
+            state.getLastAnomalyPoint(),
+            state.getLastAnomalyTimeStamp()
+        );
+    }
+
+    @Override
+    public ERCFState toState(ExtendedRandomCutForest model) {
+        ERCFState state = new ERCFState();
+        RandomCutForestMapper randomCutForestMapper = new RandomCutForestMapper();
+        randomCutForestMapper.setPartialTreeStateEnabled(true);
+        randomCutForestMapper.setSaveTreeStateEnabled(true);
+        randomCutForestMapper.setCompressionEnabled(true);
+        randomCutForestMapper.setSaveCoordinatorStateEnabled(true);
+        randomCutForestMapper.setSaveExecutorContextEnabled(true);
+
+        state.setForestState(randomCutForestMapper.toState(model.getForest()));
+
+        CorrectorThresholderMapper correctorThresholderMapper = new CorrectorThresholderMapper();
+        state.setThresholderState(correctorThresholderMapper.toState(model.getCorrectorThresholder()));
+        state.setCount(model.getCount());
+        state.setLastAnomalyTimeStamp(model.getLastAnomalyTimeStamp());
+        state.setLastAnomalyPoint(model.getLastAnomalyPoint());
+        state.setNumberOfAttributors(model.getNumberOfAttributors());
+        return state;
+    }
+
+}

--- a/src/main/java/com/amazon/randomcutforest/ERCF/ERCFState.java
+++ b/src/main/java/com/amazon/randomcutforest/ERCF/ERCFState.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+import static com.amazon.randomcutforest.ERCF.Version.V2_1;
+
+import lombok.Data;
+
+import com.amazon.randomcutforest.state.RandomCutForestState;
+import com.amazon.randomcutforest.threshold.state.CorrectorThresholderState;
+
+@Data
+public class ERCFState {
+    private final String version = V2_1;
+    private RandomCutForestState forestState;
+    private CorrectorThresholderState thresholderState;
+    private int count;
+    private int numberOfAttributors;
+    private double[] lastAnomalyPoint;
+    private int lastAnomalyTimeStamp;
+}

--- a/src/main/java/com/amazon/randomcutforest/ERCF/ExtendedRandomCutForest.java
+++ b/src/main/java/com/amazon/randomcutforest/ERCF/ExtendedRandomCutForest.java
@@ -1,0 +1,280 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+
+import java.util.Arrays;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.returntypes.DiVector;
+import com.amazon.randomcutforest.threshold.BasicThresholder;
+import com.amazon.randomcutforest.threshold.CorrectorThresholder;
+
+public class ExtendedRandomCutForest {
+
+    public static int MINIMUM_OBSERVATIONS_FOR_EXPECTED = 100;
+
+    private CorrectorThresholder correctorThresholder;
+
+    private RandomCutForest forest;
+
+    private int count = 0;
+
+    private int baseDimensions;
+
+    private int shingleSize;
+
+    // for anomaly description we would only look at these may top attributors
+    // note that expected value is not well defined when this number is greater than 1
+    private int numberOfAttributors = 2;
+
+    // the number of scores we should see before vending judgements of anomaly/anomaly
+    // more is better, the setting below is an optimistic setting
+    private int minimumScores = 10;
+
+    // the score below which we will ignore anomalies; there can be examples where the setting of 1.0
+    // is large -- but the setting below (and increasing it) should reduce the number of anomalies flagged.
+    private double lowerThreshold = 1.0;
+
+    // used for filtering shingles
+    private double[] lastAnomalyPoint;
+
+    private int lastAnomalyTimeStamp;
+
+    public ExtendedRandomCutForest(RandomCutForest.Builder<?> builder, double anomalyRate) {
+        forest = new RandomCutForest(builder);
+        checkArgument(!forest.isInternalShinglingEnabled(), "internal shingling not suported");
+        baseDimensions = forest.getDimensions() / forest.getShingleSize();
+        shingleSize = forest.getShingleSize();
+        if (forest.getDimensions() <= 5) {
+            lowerThreshold = 1.1;
+        }
+        correctorThresholder = new CorrectorThresholder(
+            anomalyRate,
+            baseDimensions,
+            shingleSize,
+            true,
+            lowerThreshold,
+            minimumScores,
+            false
+        );
+    }
+
+    public ExtendedRandomCutForest(
+        RandomCutForest forest,
+        CorrectorThresholder thresholder,
+        int count,
+        int numberOfAttributors,
+        double[] lastAnomalyPoint,
+        int lastAnomalyTimeStamp
+    ) {
+        checkArgument(!forest.isInternalShinglingEnabled(), "internal shingling not suported");
+        this.forest = forest;
+        baseDimensions = forest.getDimensions() / forest.getShingleSize();
+        shingleSize = forest.getShingleSize();
+        this.correctorThresholder = thresholder;
+        this.numberOfAttributors = numberOfAttributors;
+        this.count = count;
+        this.lastAnomalyTimeStamp = lastAnomalyTimeStamp;
+        this.lastAnomalyPoint = (lastAnomalyPoint == null) ? null : Arrays.copyOf(lastAnomalyPoint, lastAnomalyPoint.length);
+    }
+
+    public AnomalyDescriptor process(double[] point) {
+        AnomalyDescriptor result = new AnomalyDescriptor();
+        result.setRcfScore(forest.getAnomalyScore(point));
+        result.setTimeStamp(count);
+        result.setForestSize(forest.getNumberOfTrees());
+        result.setAttribution(forest.getAnomalyAttribution(point));
+        result.setCurrentValues(new double[baseDimensions]);
+        int startPosition = (shingleSize - 1) * baseDimensions;
+        boolean reasonableForecast = (count > MINIMUM_OBSERVATIONS_FOR_EXPECTED) && (shingleSize * baseDimensions >= 4);
+
+        for (int i = 0; i < baseDimensions; i++) {
+            result.getCurrentValues()[i] = point[startPosition + i];
+        }
+
+        if (result.getRcfScore() <= 0 || correctorThresholder.process(result.getRcfScore(), count) != BasicThresholder.MORE_INFORMATION) {
+            result.setAnomalyGrade(0);
+            ++count;
+            forest.update(point);
+            return result;
+        }
+
+        // note that MORE_INFORMATION would not process the current score yet
+
+        /**
+         * we consider what the most recent values should have been, reflected in newPoint;
+         * and then pass the score, score of newPoint, attribution and attribution of newPoint
+         * to the thresholder. The idea is that "if the most likely least anomalous score is high"
+         * (reflected in forest.getAnomalyScore(newPoint) then the most recent observations are not
+         * an anomaly. If the still are considered an anomaly, then we look at the most egregious
+         * subobservations in the shingle, given by maxContribution() and predict those values
+         * -- note that this may correspond to anomalies being detecting late; and deciding on the
+         * values when we detect anomalies (based on what we know now, as opposed to pure forecasting)
+         *
+         * The parameter CONFIG_NUMBER_OF_ATTRIBUTORS determines the maximum number of different attributors
+         * we could consider; note that larger number of contributors are difficult to visualize/control
+         */
+
+        if (reasonableForecast && lastAnomalyPoint != null && count - lastAnomalyTimeStamp < shingleSize) {
+            double[] correctedPoint = Arrays.copyOf(point, point.length);
+            for (int i = 0; i < point.length - (count - lastAnomalyTimeStamp) * baseDimensions; i++) {
+                correctedPoint[i] = lastAnomalyPoint[i + (count - lastAnomalyTimeStamp) * baseDimensions];
+            }
+            double correctedScore = forest.getAnomalyScore(correctedPoint);
+            if (!correctorThresholder.isPotentialAnomaly(correctedScore)) {
+                // fixing the past makes this anomaly go away; nothing to do but process the score
+                correctorThresholder.process(result.getRcfScore(), correctedScore, result.getAttribution(), null, count);
+                result.setAnomalyGrade(0);
+                ++count;
+                forest.update(point);
+                return result;
+            }
+        }
+
+        double[] newPoint = null;
+        double newScore = 0;
+        DiVector newAttribution = null;
+        if (reasonableForecast) {
+            int[] likelyMissingIndices = largestFeatures(result.getAttribution(), startPosition, baseDimensions, numberOfAttributors);
+            newPoint = forest.imputeMissingValues(point, likelyMissingIndices.length, likelyMissingIndices);
+            newAttribution = forest.getAnomalyAttribution(newPoint);
+            newScore = forest.getAnomalyScore(newPoint);
+        }
+
+        int index = maxContribution(result.getAttribution(), baseDimensions, -shingleSize) + 1;
+        boolean inAnomaly = correctorThresholder.isInAnomaly();
+        int signal = correctorThresholder.process(result.getRcfScore(), newScore, result.getAttribution(), newAttribution, count);
+
+        if (signal > 0) {
+            result.setAnomalyGrade(0.01 * signal);
+            result.setRelativeIndex(index);
+            result.setStartOfAnomaly(!inAnomaly);
+            result.setExpectedValuesPresent((count > MINIMUM_OBSERVATIONS_FOR_EXPECTED) && (shingleSize * baseDimensions >= 4));
+            if (result.getRelativeIndex() < 0 && result.isStartOfAnomaly()) {
+                // anomaly in the past and detected late
+                startPosition = result.getAttribution().getDimensions() + (result.getRelativeIndex() - 1) * baseDimensions;
+                if (result.isExpectedValuesPresent()) {
+                    int[] missingIndices = largestFeatures(result.getAttribution(), startPosition, baseDimensions, numberOfAttributors);
+                    newPoint = forest.imputeMissingValues(point, missingIndices.length, missingIndices);
+                    result.setOldValues(new double[baseDimensions]);
+                    for (int i = 0; i < baseDimensions; i++) {
+                        result.getOldValues()[i] = point[startPosition + i];
+                    }
+                }
+            }
+            if (result.isExpectedValuesPresent()) {
+                result.setExpectedValuesList(new double[1][]);
+                result.getExpectedValuesList()[0] = new double[baseDimensions];
+                for (int i = 0; i < baseDimensions; i++) {
+                    result.getExpectedValuesList()[0][i] = newPoint[startPosition + i];
+                }
+                result.setLikelihoodOfValues(new double[] { 1.0 });
+                lastAnomalyPoint = newPoint;
+                lastAnomalyTimeStamp = count;
+            }
+            result.setFlattenedAttribution(new double[baseDimensions]);
+            for (int i = 0; i < baseDimensions; i++) {
+                result.getFlattenedAttribution()[i] = result.getAttribution().getHighLowSum(startPosition + i);
+            }
+
+        } else {
+            result.setAnomalyGrade(0);
+        }
+
+        ++count;
+        forest.update(point);
+        return result;
+
+    }
+
+    private int maxContribution(DiVector diVector, int baseDimension, int startIndex) {
+        double val = 0;
+        int index = startIndex;
+        int position = diVector.getDimensions() + startIndex * baseDimension;
+        for (int i = 0; i < baseDimension; i++) {
+            val += diVector.getHighLowSum(i + position);
+        }
+        for (int i = position + baseDimension; i < diVector.getDimensions(); i += baseDimension) {
+            double sum = 0;
+            for (int j = 0; j < baseDimension; j++) {
+                sum += diVector.getHighLowSum(i + j);
+            }
+            if (sum > val) {
+                val = sum;
+                index = (i - diVector.getDimensions()) / baseDimension;
+            }
+        }
+        return index;
+    }
+
+    private int[] largestFeatures(DiVector diVector, int position, int baseDimension, int max_number) {
+        if (baseDimension == 1) {
+            return new int[] { position };
+        }
+        double sum = 0;
+        double[] values = new double[baseDimension];
+        for (int i = 0; i < baseDimension; i++) {
+            sum += values[i] = diVector.getHighLowSum(i + position);
+        }
+        Arrays.sort(values);
+        double cutoff = values[baseDimension - Math.min(max_number, baseDimension)];
+        int[] answer = new int[Math.min(max_number, baseDimension)];
+        int count = 0;
+        for (int i = 0; i < baseDimension; i++) {
+            if (diVector.getHighLowSum(i + position) >= cutoff && diVector.getHighLowSum(i + position) > sum * 0.1) {
+                answer[count++] = position + i;
+            }
+        }
+        return Arrays.copyOf(answer, count);
+    }
+
+    public RandomCutForest getForest() {
+        return forest;
+    }
+
+    public CorrectorThresholder getCorrectorThresholder() {
+        return correctorThresholder;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public int getNumberOfAttributors() {
+        return numberOfAttributors;
+    }
+
+    public double[] getLastAnomalyPoint() {
+        return (lastAnomalyPoint == null) ? null : Arrays.copyOf(lastAnomalyPoint, lastAnomalyPoint.length);
+    }
+
+    public int getLastAnomalyTimeStamp() {
+        return lastAnomalyTimeStamp;
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/ERCF/Version.java
+++ b/src/main/java/com/amazon/randomcutforest/ERCF/Version.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+public class Version {
+    public static final String V2_1 = "2.1";
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/BasicThresholder.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/BasicThresholder.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold;
+
+public class BasicThresholder {
+
+    public static int IS_ANOMALY = 1;
+
+    public static int NOT_ANOMALY = 0;
+
+    public static int MORE_INFORMATION = -1;
+
+    protected boolean moreInformation;
+
+    protected boolean inAnomaly = false;
+
+    protected double elasticity = 0.01;
+
+    protected int count = 0;
+
+    protected double discount;
+
+    protected int baseDimension;
+
+    protected int shingleSize;
+
+    protected int minimumScores = 10;
+
+    protected Deviation simpleDeviation;
+
+    protected int lastAnomalyTimeStamp;
+
+    protected double lowerThreshold = 0.8;
+
+    protected double lastAnomalyScore;
+
+    protected double lastScore;
+
+    protected double basicFactor = 3.0;
+
+    public BasicThresholder(double discount, int baseDimension, int shingleSize) {
+        this.discount = discount;
+        simpleDeviation = new Deviation(discount);
+        this.baseDimension = baseDimension;
+        this.shingleSize = shingleSize;
+    }
+
+    public BasicThresholder(Deviation deviation) {
+        this.simpleDeviation = deviation;
+        moreInformation = false;
+    }
+
+    public double basicThreshold() {
+        return simpleDeviation.getMean() + this.basicFactor * simpleDeviation.getDeviation();
+    }
+
+    public boolean isPotentialAnomaly(double newScore) {
+        // cannot change any state
+
+        if (count <= minimumScores || newScore < lowerThreshold) {
+            return false;
+        }
+
+        if (inAnomaly && shingleSize > 1) {
+            return (newScore > basicThreshold() - elasticity);
+        } else {
+            return (newScore > basicThreshold());
+        }
+    }
+
+    public int process(double newScore, int timeStamp) {
+        final int answer;
+        if (isPotentialAnomaly(newScore)) {
+            lastAnomalyScore = newScore;
+            lastAnomalyTimeStamp = timeStamp;
+            inAnomaly = true;
+            answer = IS_ANOMALY;
+        } else {
+            answer = NOT_ANOMALY;
+            inAnomaly = false;
+        }
+        ++count;
+        simpleDeviation.update(newScore);
+        lastScore = newScore;
+        return answer;
+    }
+
+    public boolean isInAnomaly() {
+        return inAnomaly;
+    }
+
+    public Deviation getSimpleDeviation() {
+        return simpleDeviation;
+    }
+
+    public double getLowerThreshold() {
+        return lowerThreshold;
+    }
+
+    public double getDiscount() {
+        return discount;
+    }
+
+    public double getElasticity() {
+        return elasticity;
+    }
+
+    public double getLastAnomalyScore() {
+        return lastAnomalyScore;
+    }
+
+    public double getLastScore() {
+        return lastScore;
+    }
+
+    public int getBaseDimension() {
+        return baseDimension;
+    }
+
+    public int getShingleSize() {
+        return shingleSize;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public int getMinimumScores() {
+        return minimumScores;
+    }
+
+    public int getLastAnomalyTimeStamp() {
+        return lastAnomalyTimeStamp;
+    }
+
+    public double getBasicFactor() {
+        return this.basicFactor;
+    }
+
+    public void setBasicFactor(double factor) {
+        this.basicFactor = factor;
+    }
+
+    public void setElasticity(double elasticity) {
+        this.elasticity = elasticity;
+    }
+
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/CorrectorThresholder.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/CorrectorThresholder.java
@@ -1,0 +1,341 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+
+import com.amazon.randomcutforest.returntypes.DiVector;
+import com.amazon.randomcutforest.threshold.state.CorrectorThresholderState;
+
+public class CorrectorThresholder extends BasicThresholder {
+
+    // the upper threshold of scores above which points are likely anomalies
+    protected double upperThreshold = 2.0;
+    // the upper threshold of scores above which points are likely anomalies
+    protected double lowerThreshold = 1.0;
+    // initial absolute threshold used to determine anomalies before sufficient values are seen
+    protected double initialThreshold = 1.5;
+    // used to determine the suprise coefficient above which we can call a potential anomaly
+    protected double zFactor = 2.5;
+    // a conservative upper bound of zFactor, when we are seeing a continuous run of anomalies
+    protected double triggerFactor = 3.0;
+    // an upper bound of zFactor and triggerFactor beyond which the point is mathematically anomalous
+    // is useful in determining grade
+    protected double upperZfactor = 5.0;
+    // a parameter that determines if the current potential anomaly is describing the same anomaly
+    // within the same shingle or across different time points
+    protected double ignoreSimilarFactor = 0.3;
+    // uses attribution by default; can be useful without attribution as a general featurization
+    protected boolean attributionEnabled = true;
+    // is the previously seen point a potential anomaly
+    protected boolean previousIsPotentialAnomaly;
+    // a statistical measure of score difference (ignoring the anomaly -> not an anomaly transition)
+    protected Deviation scoreDiff;
+    // saved attribution of the last seen anomaly
+    protected DiVector lastAnomalyAttribution;
+    // flag that determines if we should dedup similar anomalies not in the same shingle, for example an
+    // anomaly, with the same pattern is repeated across more than a shingle
+    protected boolean ignoreSimilar;
+    // fraction of the grade that comes from absolute scores in the long run
+    protected double absoluteScoreFraction = 0.5;
+    // minimum number of scores at which
+
+    public CorrectorThresholder(
+        double discount,
+        int baseDimension,
+        int shingleSize,
+        boolean attributionEnabled,
+        double absoluteThreshold,
+        int minimumScores,
+        boolean ignoreSimilar
+    ) {
+        super(discount, baseDimension, shingleSize);
+        this.ignoreSimilar = ignoreSimilar;
+        this.lowerThreshold = absoluteThreshold;
+        this.attributionEnabled = attributionEnabled;
+        this.minimumScores = minimumScores;
+        this.scoreDiff = new Deviation(discount);
+    }
+
+    public CorrectorThresholder(CorrectorThresholderState state, Deviation simpleDeviation, Deviation scoreDiff) {
+        super(simpleDeviation);
+        this.scoreDiff = scoreDiff;
+        this.lastAnomalyAttribution = (state.getLastAnomalyAttribution() != null) ? new DiVector(state.getLastAnomalyAttribution()) : null;
+        this.ignoreSimilar = state.isIgnoreSimilar();
+        this.shingleSize = state.getShingleSize();
+        this.attributionEnabled = state.isAttributionEnabled();
+        this.previousIsPotentialAnomaly = state.isPreviousIsPotentialAnomaly();
+        this.zFactor = state.getZFactor();
+        this.ignoreSimilarFactor = state.getIgnoreSimilarFactor();
+        this.upperZfactor = state.getUpperZfactor();
+        this.triggerFactor = state.getTriggerFactor();
+        this.upperThreshold = state.getUpperThreshold();
+        this.lowerThreshold = state.getLowerThreshold();
+        this.initialThreshold = state.getInitialThreshold();
+        this.absoluteScoreFraction = state.getAbsoluteScoreFraction();
+        this.inAnomaly = state.isInAnomaly();
+        this.discount = state.getDiscount();
+        this.count = state.getCount();
+        this.baseDimension = state.getBaseDimension();
+        this.minimumScores = state.getMinimumScores();
+        this.lastAnomalyScore = state.getLastAnomalyScore();
+        this.lastScore = state.getLastScore();
+        checkArgument(initialThreshold <= upperThreshold, "incorrect setting of threshold");
+        checkArgument(lowerThreshold <= initialThreshold, "incorrect setting of threshold");
+        checkArgument(zFactor <= triggerFactor, "incorrect factor settings");
+        checkArgument(triggerFactor <= upperZfactor, "incorrect factor settings");
+    }
+
+    @Override
+    public int process(double newScore, int timeStamp) {
+        return process(newScore, newScore, null, null, timeStamp);
+    }
+
+    public int process(double newScore, double idealScore, int timeStamp) {
+        checkArgument(!attributionEnabled, "need attribution information");
+        return process(newScore, idealScore, null, null, timeStamp);
+    }
+
+    public int process(double newScore, double idealScore, DiVector attribution, DiVector idealAttribution, int timeStamp) {
+        checkArgument(!moreInformation || attribution != null, "incorrect state, need more information");
+
+        final int answer;
+        if (isPotentialAnomaly(newScore)) {
+            if (attributionEnabled) {
+                if (attribution == null) {
+                    moreInformation = true;
+                    return MORE_INFORMATION;
+                } else {
+                    moreInformation = false;
+                    if (!inAnomaly && trigger(attribution, timeStamp, null)) {
+                        answer = getGrade(newScore);
+                        lastAnomalyScore = newScore;
+                        inAnomaly = true;
+                        lastAnomalyAttribution = new DiVector(attribution);
+                        lastAnomalyTimeStamp = timeStamp;
+                        if (useLastScore()) {
+                            scoreDiff.update(Math.max(0, Math.min(upperThreshold, newScore) - lastScore));
+                        }
+                    } else {
+                        if (trigger(attribution, timeStamp, idealAttribution) && newScore > idealScore) {
+                            answer = getGrade(newScore);
+                            lastAnomalyScore = newScore;
+                            lastAnomalyAttribution = new DiVector(attribution);
+                            lastAnomalyTimeStamp = timeStamp;
+                        } else {
+                            // this is to enable easier grade computation
+                            answer = NOT_ANOMALY;
+                        }
+                    }
+                }
+            } else {
+                if (!inAnomaly) {
+                    answer = getGrade(newScore);
+                    lastAnomalyScore = newScore;
+                    inAnomaly = true;
+                    lastAnomalyTimeStamp = timeStamp;
+                    if (useLastScore()) {
+                        scoreDiff.update(Math.min(upperThreshold, newScore) - lastScore);
+                    }
+                } else {
+                    if (newScore > idealScore) {
+                        answer = getGrade(newScore);
+                        lastAnomalyScore = newScore;
+                        lastAnomalyTimeStamp = timeStamp;
+                    } else {
+                        // easier for grade
+                        answer = NOT_ANOMALY;
+                    }
+                }
+            }
+            previousIsPotentialAnomaly = true;
+        } else {
+            answer = NOT_ANOMALY;
+            inAnomaly = false;
+            if (useLastScore()) {
+                scoreDiff.update(newScore - lastScore);
+            }
+            previousIsPotentialAnomaly = false;
+        }
+        ++count;
+        simpleDeviation.update(newScore);
+        lastScore = newScore;
+        return answer;
+    }
+
+    protected boolean trigger(DiVector candidate, int timeStamp, DiVector ideal) {
+        if (lastAnomalyAttribution == null) {
+            return true;
+        }
+        checkArgument(lastAnomalyAttribution.getDimensions() == candidate.getDimensions(), " error in DiVectors");
+        int dimensions = candidate.getDimensions();
+
+        int difference = baseDimension * (timeStamp - lastAnomalyTimeStamp);
+
+        if (difference < dimensions) {
+            if (ideal == null) {
+                double remainder = 0;
+                for (int i = dimensions - difference; i < dimensions; i++) {
+                    remainder += candidate.getHighLowSum(i);
+                }
+                return (remainder * dimensions / difference - simpleDeviation.getMean() > triggerFactor * simpleDeviation.getDeviation());
+            } else {
+                double differentialRemainder = 0;
+                for (int i = dimensions - difference; i < dimensions; i++) {
+                    differentialRemainder += Math.abs(candidate.low[i] - ideal.low[i]) + Math.abs(candidate.high[i] - ideal.high[i]);
+                }
+                return (differentialRemainder > ignoreSimilarFactor * lastAnomalyScore)
+                    && (differentialRemainder * dimensions / difference - simpleDeviation.getMean() > triggerFactor * simpleDeviation
+                        .getDeviation());
+            }
+        } else {
+            if (!ignoreSimilar) {
+                return true;
+            }
+            double sum = 0;
+            for (int i = 0; i < dimensions; i++) {
+                sum += Math.abs(lastAnomalyAttribution.high[i] - candidate.high[i]) + Math
+                    .abs(lastAnomalyAttribution.low[i] - candidate.low[i]);
+            }
+            return (sum > ignoreSimilarFactor * lastScore);
+        }
+    }
+
+    @Override
+    public boolean isPotentialAnomaly(double newScore) {
+        // cannot change any state
+
+        if (newScore < lowerThreshold) {
+            return false;
+        }
+
+        if (scoreDiff.getCount() < minimumScores) {
+            return newScore * minimumScores > (minimumScores - scoreDiff.getCount()) * upperThreshold + scoreDiff.getCount()
+                * initialThreshold;
+        } else {
+            if (inAnomaly && shingleSize > 1) {
+                return (newScore > basicThreshold() - elasticity);
+            } else {
+                return (newScore > basicThreshold());
+            }
+        }
+    }
+
+    protected boolean useLastScore() {
+        return count > 0 && !previousIsPotentialAnomaly;
+    }
+
+    @Override
+    public double basicThreshold() {
+        return simpleDeviation.getMean() + zFactor * (scoreDiff.getDeviation());
+    }
+
+    public int getGrade(double score) {
+        int valuesSeen = Math.min(scoreDiff.getCount(), minimumScores);
+        double normalizedScore = Math.min(upperThreshold, score);
+        double interpolate = (1 - absoluteScoreFraction) * valuesSeen / minimumScores;
+        double absolutePart = (1 - interpolate) * (normalizedScore - lowerThreshold) / (upperThreshold - lowerThreshold);
+        double factorPart = 0;
+        if (valuesSeen > 0) {
+            double factor = Math.min((score - simpleDeviation.getMean()) / scoreDiff.getDeviation(), upperZfactor);
+            factorPart = interpolate * (1 - 1 / factor) / (1 - 1 / upperZfactor);
+        }
+        return Math.min(100, (int) Math.floor(100 * (absolutePart + factorPart)));
+    }
+
+    public boolean isAttributionEnabled() {
+        return attributionEnabled;
+    }
+
+    public boolean isPreviousIsPotentialAnomaly() {
+        return previousIsPotentialAnomaly;
+    }
+
+    public boolean isIgnoreSimilar() {
+        return ignoreSimilar;
+    }
+
+    public Deviation getScoreDiff() {
+        return scoreDiff;
+    }
+
+    public DiVector getLastAnomalyAttribution() {
+        return lastAnomalyAttribution;
+    }
+
+    public double getTriggerFactor() {
+        return triggerFactor;
+    }
+
+    public double getzFactor() {
+        return zFactor;
+    }
+
+    public double getUpperZFactor() {
+        return upperZfactor;
+    }
+
+    public double getUpperThreshold() {
+        return upperThreshold;
+    }
+
+    public double getLowerThreshold() {
+        return lowerThreshold;
+    }
+
+    public void setUpperThreshold(double score) {
+        upperThreshold = score;
+    }
+
+    public void setTriggerFactor(double factor) {
+        triggerFactor = factor;
+    }
+
+    public void setzFactor(double factor) {
+        zFactor = factor;
+    }
+
+    public double getIgnoreSimilarFactor() {
+        return ignoreSimilarFactor;
+    }
+
+    public void setIgnoreSimilarFactor(double factor) {
+        ignoreSimilarFactor = factor;
+    }
+
+    public void setMoreInformation(boolean flag) {
+        moreInformation = false;
+    }
+
+    public double getAbsoluteScoreFraction() {
+        return absoluteScoreFraction;
+    }
+
+    public double getInitialThreshold() {
+        return initialThreshold;
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/Deviation.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/Deviation.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+
+public class Deviation {
+
+    protected final double discount;
+
+    protected double weight = 0;
+
+    protected double sumSquared = 0;
+
+    protected double sum = 0;
+
+    protected int count = 0;
+
+    public Deviation() {
+        discount = 0;
+    }
+
+    public Deviation(double discount) {
+        this.discount = discount;
+    }
+
+    public Deviation(double discount, double weight, double sumSquared, double sum, int count) {
+        this.discount = discount;
+        this.weight = weight;
+        this.sumSquared = sumSquared;
+        this.sum = sum;
+        this.count = 0;
+    }
+
+    public double getMean() {
+        checkArgument(weight > 0, "incorrect invocation for mean");
+        return sum / weight;
+    }
+
+    public void update(double score) {
+        double factor = Math.min(1 - discount, 1 - 1.0 / (count + 2));
+        sum = sum * factor + score;
+        sumSquared = sumSquared * factor + score * score;
+        weight = weight * factor + 1.0;
+        ++count;
+    }
+
+    public double getDeviation() {
+        checkArgument(weight > 0, "incorrect invocation for standard deviation");
+        double temp = sum / weight;
+        double answer = sumSquared / weight - temp * temp;
+        return (answer > 0) ? Math.sqrt(answer) : 0;
+    }
+
+    public boolean isEmpty() {
+        return weight == 0;
+    }
+
+    public double getDiscount() {
+        return discount;
+    }
+
+    public double getSum() {
+        return sum;
+    }
+
+    public double getSumSquared() {
+        return sumSquared;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/state/CorrectorThresholderMapper.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/state/CorrectorThresholderMapper.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold.state;
+
+import com.amazon.randomcutforest.state.IStateMapper;
+import com.amazon.randomcutforest.threshold.CorrectorThresholder;
+import com.amazon.randomcutforest.threshold.Deviation;
+
+public class CorrectorThresholderMapper implements IStateMapper<CorrectorThresholder, CorrectorThresholderState> {
+
+    @Override
+    public CorrectorThresholder toModel(CorrectorThresholderState state, long seed) {
+        DeviationMapper deviationMapper = new DeviationMapper();
+        Deviation simpleDeviation = deviationMapper.toModel(state.getSimpleDeviationState());
+        Deviation scoreDiff = deviationMapper.toModel(state.getScoreDiffState());
+        return new CorrectorThresholder(state, simpleDeviation, scoreDiff);
+    }
+
+    @Override
+    public CorrectorThresholderState toState(CorrectorThresholder model) {
+        CorrectorThresholderState state = new CorrectorThresholderState();
+        DeviationMapper deviationMapper = new DeviationMapper();
+
+        state.setZFactor(model.getzFactor());
+        state.setUpperZfactor(model.getUpperZFactor());
+        state.setTriggerFactor(model.getTriggerFactor());
+        state.setUpperThreshold(model.getUpperThreshold());
+        state.setLowerThreshold(model.getLowerThreshold());
+        state.setInitialThreshold(model.getInitialThreshold());
+        state.setAbsoluteScoreFraction(model.getAbsoluteScoreFraction());
+        state.setDiscount(model.getDiscount());
+        state.setElasticity(model.getElasticity());
+        state.setCount(model.getCount());
+        state.setInAnomaly(model.isInAnomaly());
+        state.setBaseDimension(model.getBaseDimension());
+        state.setShingleSize(model.getShingleSize());
+        state.setElasticity(model.getElasticity());
+        state.setMinimumScores(model.getMinimumScores());
+        state.setAttributionEnabled(model.isAttributionEnabled());
+        state.setSimpleDeviationState(deviationMapper.toState(model.getSimpleDeviation()));
+        state.setLastScore(model.getLastScore());
+        state.setLastAnomalyTimeStamp(model.getLastAnomalyTimeStamp());
+        state.setLastAnomalyScore(model.getLastAnomalyScore());
+        state.setLastAnomalyAttribution(model.getLastAnomalyAttribution());
+        state.setIgnoreSimilar(model.isIgnoreSimilar());
+        state.setIgnoreSimilarFactor(model.getIgnoreSimilarFactor());
+        state.setPreviousIsPotentialAnomaly(model.isPreviousIsPotentialAnomaly());
+        state.setScoreDiffState(deviationMapper.toState(model.getScoreDiff()));
+        return state;
+    }
+
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/state/CorrectorThresholderState.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/state/CorrectorThresholderState.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold.state;
+
+import static com.amazon.randomcutforest.threshold.state.Version.V2_1;
+
+import lombok.Data;
+
+import com.amazon.randomcutforest.returntypes.DiVector;
+
+@Data
+public class CorrectorThresholderState {
+
+    private final String version = V2_1;
+
+    private long randomseed;
+
+    private boolean inAnomaly;
+
+    private double elasticity;
+
+    private boolean attributionEnabled;
+
+    private int count;
+
+    private double discount;
+
+    private int baseDimension;
+
+    private int shingleSize;
+
+    private int minimumScores;
+
+    private DeviationState simpleDeviationState;
+
+    private int lastAnomalyTimeStamp;
+
+    private double lastAnomalyScore;
+
+    private DiVector lastAnomalyAttribution;
+
+    private DeviationState scoreDiffState;
+
+    private double lastScore;
+
+    private boolean ignoreSimilar;
+
+    private boolean previousIsPotentialAnomaly;
+
+    private double absoluteScoreFraction;
+
+    private double upperThreshold;
+
+    private double lowerThreshold;
+
+    private double initialThreshold;
+
+    private double zFactor;
+
+    private double triggerFactor;
+
+    private double upperZfactor;
+
+    private double ignoreSimilarFactor;
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/state/DeviationMapper.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/state/DeviationMapper.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold.state;
+
+import com.amazon.randomcutforest.state.IStateMapper;
+import com.amazon.randomcutforest.threshold.Deviation;
+
+public class DeviationMapper implements IStateMapper<Deviation, DeviationState> {
+
+    @Override
+    public Deviation toModel(DeviationState state, long seed) {
+        return new Deviation(state.getDiscount(), state.getWeight(), state.getSumSquared(), state.getSum(), state.getCount());
+    }
+
+    @Override
+    public DeviationState toState(Deviation model) {
+        DeviationState state = new DeviationState();
+        state.setDiscount(model.getDiscount());
+        state.setSum(model.getSum());
+        state.setSumSquared(model.getSumSquared());
+        state.setWeight(model.getWeight());
+        state.setCount(model.getCount());
+        return state;
+    }
+
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/state/DeviationState.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/state/DeviationState.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold.state;
+
+import lombok.Data;
+
+@Data
+public class DeviationState {
+    private double discount;
+
+    private double weight;
+
+    private double sumSquared;
+
+    private double sum;
+
+    private int count;
+}

--- a/src/main/java/com/amazon/randomcutforest/threshold/state/Version.java
+++ b/src/main/java/com/amazon/randomcutforest/threshold/state/Version.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.threshold.state;
+
+public class Version {
+    public static final String V2_1 = "2.1";
+}

--- a/src/test/java/com/amazon/randomcutforest/ERCF/ERCFMapperTests.java
+++ b/src/test/java/com/amazon/randomcutforest/ERCF/ERCFMapperTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.Test;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.config.Precision;
+
+public class ERCFMapperTests {
+
+    private ERCFMapper mapper = new ERCFMapper();
+
+    private Random random = new Random();
+
+    @Test
+    public void toState_toModel() {
+        int shingle = 8;
+        int sample = 256;
+        ExtendedRandomCutForest ercf = new ExtendedRandomCutForest(
+            RandomCutForest
+                .builder()
+                .compact(true)
+                .dimensions(shingle)
+                .numberOfTrees(100)
+                .shingleSize(shingle)
+                .sampleSize(sample)
+                .precision(Precision.FLOAT_32),
+            0.005
+        );
+
+        ERCFState state = mapper.toState(ercf);
+        ExtendedRandomCutForest clone = mapper.toModel(state);
+
+        int normalHigh = 10;
+        int normalLow = 0;
+        for (int i = 0; i < sample; i++) {
+            AnomalyDescriptor result = ercf.process(this.random.doubles(shingle, normalLow, normalHigh).toArray());
+        }
+
+        state = mapper.toState(ercf);
+        clone = mapper.toModel(state);
+
+        double[] input = this.random.doubles(shingle, normalLow, normalHigh).toArray();
+        int anomalyIndex = 7;
+        input[anomalyIndex] = normalHigh * 2;
+
+        AnomalyDescriptor result = ercf.process(input);
+        assertTrue(result.getAnomalyGrade() > 0);
+        Arrays.stream(result.getExpectedValuesList()[0]).forEach(v -> assertTrue(v >= normalLow && v <= normalHigh));
+
+        result = clone.process(input);
+        assertTrue(result.getAnomalyGrade() > 0);
+        Arrays.stream(result.getExpectedValuesList()[0]).forEach(v -> assertTrue(v >= normalLow && v <= normalHigh));
+    }
+}

--- a/src/test/java/com/amazon/randomcutforest/ERCF/ExtendedRandomCutForestTests.java
+++ b/src/test/java/com/amazon/randomcutforest/ERCF/ExtendedRandomCutForestTests.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.ERCF;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.Test;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.config.Precision;
+
+public class ExtendedRandomCutForestTests {
+
+    private Random random = new Random();
+
+    @Test
+    public void constructor_succeed() {
+        new ExtendedRandomCutForest(
+            RandomCutForest
+                .builder()
+                .compact(true)
+                .dimensions(8)
+                .numberOfTrees(100)
+                .shingleSize(8)
+                .sampleSize(256)
+                .precision(Precision.FLOAT_32),
+            0.005
+        );
+    }
+
+    @Test
+    public void process_output_anomaly() {
+        int shingle = 8;
+        int sample = 256;
+        ExtendedRandomCutForest ercf = new ExtendedRandomCutForest(
+            RandomCutForest
+                .builder()
+                .compact(true)
+                .dimensions(shingle)
+                .numberOfTrees(100)
+                .shingleSize(shingle)
+                .sampleSize(sample)
+                .precision(Precision.FLOAT_32),
+            0.005
+        );
+
+        int normalHigh = 10;
+        int normalLow = 0;
+        for (int i = 0; i < sample; i++) {
+            AnomalyDescriptor result = ercf.process(this.random.doubles(shingle, normalLow, normalHigh).toArray());
+        }
+
+        double[] input = this.random.doubles(shingle, normalLow, normalHigh).toArray();
+        int anomalyIndex = 7;
+        input[anomalyIndex] = normalHigh * 2;
+        AnomalyDescriptor result = ercf.process(input);
+
+        assertTrue(result.getAnomalyGrade() > 0);
+        assertTrue(result.getFlattenedAttribution()[0] > result.getRcfScore() / shingle);
+        Arrays.stream(result.getExpectedValuesList()[0]).forEach(v -> assertTrue(v >= normalLow && v <= normalHigh));
+    }
+}


### PR DESCRIPTION
### Description
This is the initial pr for adding a new anomaly detection model that extends the current rcf with thresholding, named Extended Random Cut Forest (ERCF). For the sake of time and unblocking further development, the initial unit tests only include those for the primary features/api to be used in this plugin. Implementation changes, testing, and documentation will ensue in following pr for this plugin or the rcf package.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
