### PR TITLE
enable junit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ configurations.all {
         force "net.bytebuddy:byte-buddy:1.9.15"
         force "net.bytebuddy:byte-buddy-agent:1.9.15"
         force "com.google.code.gson:gson:2.8.6"
+        force "junit:junit:4.12"
     }
 }
 
@@ -445,11 +446,21 @@ dependencies {
     testImplementation group: 'org.javassist', name: 'javassist', version: '3.27.0-GA'
     testCompile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.9.15'
     testCompile group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.9.15'
+    testCompileOnly 'org.apiguardian:apiguardian-api:1.1.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'
+    testCompileOnly 'junit:junit:4.12'
 
     checkstyle "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"
 }
 
 compileJava.options.compilerArgs << "-Xlint:-deprecation,-rawtypes,-serial,-try,-unchecked"
+
+test {
+    useJUnitPlatform()
+}
 
 apply plugin: 'nebula.ospackage'
 


### PR DESCRIPTION
Signed-off-by: lai <laijiang@amazon.com>

### Description
This pr enables junit 5 test framework with advanced testing features while maintaining backwards compatibility with current test cases in junit 4.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
