### PR TITLE
Bumping anomaly-detection to 1.1.0.0 to use OpenSearch (main) 1.1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
@@ -59,11 +59,11 @@ jobs:
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,37 +33,37 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: 'main'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
 
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: '1.0'
+          ref: 'main'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
         with:
-          ref: '1.0'
+          ref: 'main'
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.0.0 -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd
@@ -75,11 +75,11 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0
+          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Multi Nodes Integration Testing
         run: |
@@ -91,8 +91,8 @@ jobs:
           ## version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
           ## plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
           ## TODO: remove these two hard code versions below after GA release
-          version=1.0.0
-          plugin_version=1.0.0.0
+          version=1.1.0-SNAPSHOT
+          plugin_version=1.1.0.0
           echo $version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
-        common_utils_version = System.getProperty("common_utils.version", "1.0.0.0")
-        job_scheduler_version = System.getProperty("job_scheduler.version", "1.0.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        common_utils_version = System.getProperty("common_utils.version", "1.1.0.0")
+        job_scheduler_version = System.getProperty("job_scheduler.version", "1.1.0.0")
     }
 
     repositories {
@@ -63,7 +63,7 @@ repositories {
 }
 
 ext {
-    opensearchVersion = System.getProperty("opensearch.version", "1.0.0")
+    opensearchVersion = System.getProperty("opensearch.version", "1.1.0")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -274,7 +274,7 @@ String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
 testClusters {
     "${baseName}" {
         testDistribution = "ARCHIVE"
-        versions = ["7.10.2","1.0.0"]
+        versions = ["7.10.2","1.1.0-SNAPSHOT"]
         numberOfNodes = 3
         plugin(provider(new Callable<RegularFile>(){
             @Override

--- a/src/main/java/org/opensearch/ad/util/Bwc.java
+++ b/src/main/java/org/opensearch/ad/util/Bwc.java
@@ -27,7 +27,6 @@ public class Bwc {
      * @return whether the version support multiple category fields
      */
     public static boolean supportMultiCategoryFields(Version version) {
-        // TODO: remove DISABLE_BWC before 1.1 release
-        return DISABLE_BWC || version.after(Version.V_1_0_0);
+        return version.after(Version.V_1_0_0);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/CronTransportActionTests.java
@@ -118,6 +118,7 @@ public class CronTransportActionTests extends AbstractADTest {
         nodeRequestOut.setVersion(Version.V_1_0_0);
         nodeRequest.writeTo(nodeRequestOut);
         StreamInput siNode = nodeRequestOut.bytes().streamInput();
+        siNode.setVersion(Version.V_1_0_0);
 
         CronNodeRequest nodeResponseRead = new CronNodeRequest(siNode);
 


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Bumping up`anomaly-detection` to build with OpenSearch main which is 1.1.0 and use 1.1.0.0 for `job-scheduler` and `common-utils`.
As with the branching and release strategy for the project opensearch-project/.github#13
Here is how it should look like:

Plugin/library main builds out of OpenSearch main.
Plugin/library 1.x builds out of OpenSearch 1.x.
Plugin/library 1.0 builds out of OpenSearch 1.0.
This allows us to fail fast and get ready for release.

As part of adding backwards compatibility test framework, we are developing tests as an example in Anomaly Detection which needs the bwc framework from OpenSearch main.
Ref: opensearch-project/OpenSearch#1002
Meta issue: opensearch-project/opensearch-build#90 
 
### Issues Resolved
#156 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
