### PR TITLE
Fix snapshot assemble and build 1.1.0.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: 'main'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal
@@ -59,11 +59,11 @@ jobs:
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd
@@ -83,17 +83,14 @@ jobs:
 
       - name: Multi Nodes Integration Testing
         run: |
-          ./gradlew integTest  -PnumNodes=3
+          ./gradlew integTest -PnumNodes=3
 
       - name: Pull and Run Docker
         run: |
-          ## plugin=`ls build/distributions/*.zip`
-          ## version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
-          ## plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
-          ## TODO: remove these two hard code versions below after GA release
+          plugin=`ls build/distributions/*.zip`
           version=1.1.0-SNAPSHOT
-          plugin_version=1.1.0.0
-          echo $version
+          plugin_version=1.1.0.0-SNAPSHOT
+          echo Using OpenSearch $version with AD $plugin_version
           cd ..
           if docker pull opensearchstaging/opensearch:$version
           then

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
-        // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        // 1.1.0 -> 1.1.0.0, and 1.1.0-SNAPSHOT -> 1.1.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
@@ -79,7 +79,7 @@ ext {
 allprojects {
     group = 'org.opensearch'
 
-    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    version = opensearch_version - "-SNAPSHOT" + ".0"
     if (isSnapshot) {
         version += "-SNAPSHOT"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,11 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
-        common_utils_version = System.getProperty("common_utils.version", "1.1.0.0")
-        job_scheduler_version = System.getProperty("job_scheduler.version", "1.1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
+        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
+        job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
     }
 
     repositories {
@@ -62,11 +64,6 @@ repositories {
     jcenter()
 }
 
-ext {
-    opensearchVersion = System.getProperty("opensearch.version", "1.1.0")
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-}
-
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
@@ -74,6 +71,10 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'base'
 apply plugin: 'jacoco'
 apply plugin: 'eclipse'
+
+ext {
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+}
 
 allprojects {
     group = 'org.opensearch'

--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,6 @@ ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
-version = "${opensearchVersion}.0"
-
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
@@ -79,6 +77,11 @@ apply plugin: 'eclipse'
 
 allprojects {
     group = 'org.opensearch'
+
+    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"


### PR DESCRIPTION
Requires https://github.com/opensearch-project/common-utils/pull/58 and https://github.com/opensearch-project/job-scheduler/pull/49, and cleaned up on top of https://github.com/opensearch-project/anomaly-detection/pull/175.

Signed-off-by: dblock <dblock@amazon.com>

### Description

Fix assembly with `-Dbuild.snapshot=true`. The full syntax required passing the version of job scheduler and common utils, which would cause us to need a custom script for the bundle build. Changed build.gradle to default those to the same build as OpenSearch (e.g. 1.0.0 becomes 1.0.0.0 and 1.0.0-SNAPSHOT becomes 1.0.0.0-SNAPSHOT).

So to build a snapshot:

```
./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=1.0.0-SNAPSHOT -Dbuild.snapshot=true
```
 
### Issues Resolved

Closes #173.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
