### PR TITLE
Bug fixes and unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -507,16 +507,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.transport.SearchAnomalyResultTransportAction*',
         'org.opensearch.ad.transport.SearchAnomalyDetectorInfoTransportAction*',
 
-        // TODO: hc caused coverage to drop
-        'org.opensearch.ad.indices.AnomalyDetectionIndices',
-        'org.opensearch.ad.transport.handler.MultiEntityResultHandler',
-        'org.opensearch.ad.util.ThrowingSupplierWrapper',
-        'org.opensearch.ad.transport.ProfileNodeResponse',
-        'org.opensearch.ad.transport.ADResultBulkResponse',
-        'org.opensearch.ad.transport.AggregationType',
-        'org.opensearch.ad.EntityProfileRunner',
-        'org.opensearch.ad.NodeStateManager',
-        'org.opensearch.ad.util.BulkUtil',
 
         // TODO: unified flow caused coverage drop
         'org.opensearch.ad.transport.AnomalyDetectorJobRequest',

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -649,7 +649,7 @@ public class PriorityCache implements EntityCache {
      */
     @Override
     public void clear(String detectorId) {
-        if (detectorId == null) {
+        if (Strings.isEmpty(detectorId)) {
             return;
         }
         CacheBuffer buffer = activeEnities.remove(detectorId);

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -103,7 +103,8 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     // The index name pattern to query all AD result, history and current AD result
     public static final String ALL_AD_RESULTS_INDEX_PATTERN = ".opendistro-anomaly-results*";
 
-    private static final String META = "_meta";
+    // package private for testing
+    static final String META = "_meta";
     private static final String SCHEMA_VERSION = "schema_version";
 
     private ClusterService clusterService;

--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -600,6 +600,8 @@ public class EntityColdStarter implements MaintenanceState {
             try {
                 double[][] trainData = featureManager.batchShingle(samples.toArray(new double[0][0]), this.shingleSize);
                 trainModelFromDataSegments(Collections.singletonList(trainData), model.getEntity().orElse(null), modelState);
+                // clear samples after using
+                samples.clear();
             } catch (Exception e) {
                 // e.g., exception from rcf. We can do nothing except logging the error
                 // We won't retry training for the same entity in the cooldown period

--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -56,7 +56,6 @@ import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.FeatureManager;
-import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.ml.rcf.CombinedRcfResult;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
@@ -288,7 +287,6 @@ public class ModelManager implements DetectorModelSize {
         int forestSize = rcf.getNumberOfTrees();
         double[] attribution = getAnomalyAttribution(rcf, point);
         rcf.update(point);
-        long totalUpdates = rcf.getTotalUpdates();
         listener.onResponse(new RcfResult(score, confidence, forestSize, attribution, rcf.getTotalUpdates()));
     }
 
@@ -797,7 +795,6 @@ public class ModelManager implements DetectorModelSize {
      * @param datapoint Data point
      * @param modelState the state associated with the entity
      * @param modelId the model Id
-     * @param detector Detector accessor
      * @param entity entity accessor
      *
      * @return anomaly result, confidence, and the corresponding RCF score.
@@ -806,7 +803,6 @@ public class ModelManager implements DetectorModelSize {
         double[] datapoint,
         ModelState<EntityModel> modelState,
         String modelId,
-        AnomalyDetector detector,
         Entity entity
     ) {
         if (modelState != null) {
@@ -816,12 +812,10 @@ public class ModelManager implements DetectorModelSize {
                 entityModel = new EntityModel(entity, new ArrayDeque<>(), null, null);
                 modelState.setModel(entityModel);
             }
-
             // trainModelFromExistingSamples may be able to make models not null
             if (entityModel.getRcf() == null || entityModel.getThreshold() == null) {
                 entityColdStarter.trainModelFromExistingSamples(modelState);
             }
-
             if (entityModel.getRcf() != null && entityModel.getThreshold() != null) {
                 return score(datapoint, modelId, modelState);
             } else {

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -757,7 +757,7 @@ public final class AnomalyDetectorSettings {
 
     // max concurrent preview to limit resource usage
     public static final Setting<Integer> MAX_CONCURRENT_PREVIEW = Setting
-        .intSetting("plugins.anomaly_detection.max_concurrent_preview", 5, 1, 20, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .intSetting("plugins.anomaly_detection.max_concurrent_preview", 2, 1, 20, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     // preview timeout in terms of milliseconds
     public static final long PREVIEW_TIMEOUT_IN_MILLIS = 60_000;

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -215,8 +215,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
                     cacheMissEntities.put(categoricalValues, datapoint);
                     continue;
                 }
-                ThresholdingResult result = modelManager
-                    .getAnomalyResultForEntity(datapoint, entityModel, modelId, detector, categoricalValues);
+                ThresholdingResult result = modelManager.getAnomalyResultForEntity(datapoint, entityModel, modelId, categoricalValues);
                 // result.getRcfScore() = 0 means the model is not initialized
                 // result.getGrade() = 0 means it is not an anomaly
                 // So many OpenSearchRejectedExecutionException if we write no matter what

--- a/src/main/java/org/opensearch/ad/transport/handler/MultiEntityResultHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/MultiEntityResultHandler.java
@@ -59,8 +59,9 @@ import org.opensearch.threadpool.ThreadPool;
  */
 public class MultiEntityResultHandler extends AnomalyIndexHandler<AnomalyResult> {
     private static final Logger LOG = LogManager.getLogger(MultiEntityResultHandler.class);
-    private static final String SUCCESS_SAVING_RESULT_MSG = "Result saved successfully.";
-    private static final String CANNOT_SAVE_RESULT_ERR_MSG = "Cannot save results due to write block.";
+    // package private for testing
+    static final String SUCCESS_SAVING_RESULT_MSG = "Result saved successfully.";
+    static final String CANNOT_SAVE_RESULT_ERR_MSG = "Cannot save results due to write block.";
 
     @Inject
     public MultiEntityResultHandler(

--- a/src/main/java/org/opensearch/ad/util/BulkUtil.java
+++ b/src/main/java/org/opensearch/ad/util/BulkUtil.java
@@ -42,30 +42,6 @@ import org.opensearch.action.index.IndexRequest;
 public class BulkUtil {
     private static final Logger logger = LogManager.getLogger(BulkUtil.class);
 
-    public static List<IndexRequest> getIndexRequestToRetry(BulkRequest bulkRequest, BulkResponse bulkResponse) {
-        List<IndexRequest> res = new ArrayList<>();
-
-        Set<String> failedId = new HashSet<>();
-        for (BulkItemResponse response : bulkResponse.getItems()) {
-            if (response.isFailed() && ExceptionUtil.isRetryAble(response.getFailure().getStatus())) {
-                failedId.add(response.getId());
-            }
-        }
-
-        for (DocWriteRequest<?> request : bulkRequest.requests()) {
-            try {
-                if (failedId.contains(request.id())) {
-                    res.add(cloneIndexRequest((IndexRequest) request));
-                }
-            } catch (ClassCastException e) {
-                logger.error("We only support IndexRequest", e);
-                throw e;
-            }
-
-        }
-        return res;
-    }
-
     public static List<IndexRequest> getFailedIndexRequest(BulkRequest bulkRequest, BulkResponse bulkResponse) {
         List<IndexRequest> res = new ArrayList<>();
 

--- a/src/main/java/org/opensearch/ad/util/MathUtil.java
+++ b/src/main/java/org/opensearch/ad/util/MathUtil.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.util;
 
 public class MathUtil {
     /*
-     * Private constructor to avoid Jacoco complain about public constructor
+     * Private constructor to avoid Jacoco complaining about public constructor
      * not covered: https://tinyurl.com/yetc7tra
      */
     private MathUtil() {}

--- a/src/main/java/org/opensearch/ad/util/ThrowingSupplierWrapper.java
+++ b/src/main/java/org/opensearch/ad/util/ThrowingSupplierWrapper.java
@@ -29,6 +29,12 @@ package org.opensearch.ad.util;
 import java.util.function.Supplier;
 
 public class ThrowingSupplierWrapper {
+    /*
+     * Private constructor to avoid Jacoco complaining about public constructor
+     * not covered: https://tinyurl.com/yetc7tra
+     */
+    private ThrowingSupplierWrapper() {}
+
     /**
      * Utility method to use a method throwing checked exception inside a place
      *  that does not allow throwing the corresponding checked exception (e.g.,

--- a/src/test/java/org/opensearch/AnomalyResultResponse1_0.java
+++ b/src/test/java/org/opensearch/AnomalyResultResponse1_0.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.ad.model.FeatureData;
+import org.opensearch.common.io.stream.InputStreamStreamInput;
+import org.opensearch.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+public class AnomalyResultResponse1_0 extends ActionResponse implements ToXContentObject {
+    public static final String ANOMALY_GRADE_JSON_KEY = "anomalyGrade";
+    public static final String CONFIDENCE_JSON_KEY = "confidence";
+    public static final String ANOMALY_SCORE_JSON_KEY = "anomalyScore";
+    public static final String ERROR_JSON_KEY = "error";
+    public static final String FEATURES_JSON_KEY = "features";
+    public static final String FEATURE_VALUE_JSON_KEY = "value";
+
+    private double anomalyGrade;
+    private double confidence;
+    private double anomalyScore;
+    private String error;
+    private List<FeatureData> features;
+
+    public AnomalyResultResponse1_0(double anomalyGrade, double confidence, double anomalyScore, List<FeatureData> features) {
+        this(anomalyGrade, confidence, anomalyScore, features, null);
+    }
+
+    public AnomalyResultResponse1_0(double anomalyGrade, double confidence, double anomalyScore, List<FeatureData> features, String error) {
+        this.anomalyGrade = anomalyGrade;
+        this.confidence = confidence;
+        this.anomalyScore = anomalyScore;
+        this.features = features;
+        this.error = error;
+    }
+
+    public AnomalyResultResponse1_0(StreamInput in) throws IOException {
+        super(in);
+        anomalyGrade = in.readDouble();
+        confidence = in.readDouble();
+        anomalyScore = in.readDouble();
+        int size = in.readVInt();
+        features = new ArrayList<FeatureData>();
+        for (int i = 0; i < size; i++) {
+            features.add(new FeatureData(in));
+        }
+        error = in.readOptionalString();
+    }
+
+    public double getAnomalyGrade() {
+        return anomalyGrade;
+    }
+
+    public List<FeatureData> getFeatures() {
+        return features;
+    }
+
+    public double getConfidence() {
+        return confidence;
+    }
+
+    public double getAnomalyScore() {
+        return anomalyScore;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(anomalyGrade);
+        out.writeDouble(confidence);
+        out.writeDouble(anomalyScore);
+        out.writeVInt(features.size());
+        for (FeatureData feature : features) {
+            feature.writeTo(out);
+        }
+        if (error != null) {
+            out.writeBoolean(true);
+            out.writeString(error);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ANOMALY_GRADE_JSON_KEY, anomalyGrade);
+        builder.field(CONFIDENCE_JSON_KEY, confidence);
+        builder.field(ANOMALY_SCORE_JSON_KEY, anomalyScore);
+        builder.field(ERROR_JSON_KEY, error);
+        builder.startArray(FEATURES_JSON_KEY);
+        for (FeatureData feature : features) {
+            feature.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+
+    public static AnomalyResultResponse1_0 fromActionResponse(final ActionResponse actionResponse) {
+        if (actionResponse instanceof AnomalyResultResponse1_0) {
+            return (AnomalyResultResponse1_0) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new AnomalyResultResponse1_0(input);
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("failed to parse ActionResponse into AnomalyResultResponse", e);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/BwcTests.java
+++ b/src/test/java/org/opensearch/BwcTests.java
@@ -16,6 +16,9 @@ import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,8 +35,12 @@ import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
+import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.model.ModelProfile;
 import org.opensearch.ad.model.ModelProfileOnNode;
+import org.opensearch.ad.transport.AnomalyResultResponse;
+import org.opensearch.ad.transport.CronNodeRequest;
+import org.opensearch.ad.transport.CronRequest;
 import org.opensearch.ad.transport.EntityProfileAction;
 import org.opensearch.ad.transport.EntityProfileRequest;
 import org.opensearch.ad.transport.EntityProfileResponse;
@@ -80,6 +87,13 @@ public class BwcTests extends AbstractADTest {
     private ModelProfile1_0[] convertedModelProfile;
     private RCFResultResponse rcfResultResponse1_1;
     private RCFResultResponse1_0 rcfResultResponse1_0;
+    private CronRequest cronRequest1_1;
+    private CronRequest1_0 cronRequest1_0;
+    private DiscoveryNode node;
+    private CronNodeRequest cronNodeRequest1_1;
+    private CronNodeRequest1_0 cronNodeRequest1_0;
+    private AnomalyResultResponse adResultResponse1_1;
+    private AnomalyResultResponse1_0 adResultResponse1_0;
 
     private boolean areEqualWithArrayValue(Map<Entity, double[]> first, Map<Entity, double[]> second) {
         if (first.size() != second.size()) {
@@ -533,5 +547,154 @@ public class BwcTests extends AbstractADTest {
         assertThat(readResponse.getConfidence(), equalTo(rcfResultResponse1_0.getConfidence()));
         assertThat(readResponse.getForestSize(), equalTo(rcfResultResponse1_0.getForestSize()));
         assertThat(readResponse.getRCFScore(), equalTo(rcfResultResponse1_0.getRCFScore()));
+    }
+
+    private void setUpCronRequest() throws UnknownHostException {
+        node = new DiscoveryNode(
+            nodeId,
+            new TransportAddress(new InetSocketAddress(InetAddress.getByName("1.2.3.4"), 9300)),
+            Version.V_1_0_0.minimumCompatibilityVersion()
+        );
+        cronRequest1_1 = new CronRequest("foo", node);
+        cronRequest1_0 = new CronRequest1_0(node);
+    }
+
+    public void testDeserializeCronRequest1_1() throws IOException {
+        setUpCronRequest();
+
+        cronRequest1_1.writeTo(output1_1);
+
+        StreamInput streamInput = output1_1.bytes().streamInput();
+        streamInput.setVersion(V_1_1_0);
+        CronRequest readRequest = new CronRequest(streamInput);
+        assertEquals(readRequest.getRequestId(), cronRequest1_1.getRequestId());
+        assertEquals(1, readRequest.concreteNodes().length);
+        assertEquals(node, readRequest.concreteNodes()[0]);
+    }
+
+    public void testDeserializeCronRequest1_0() throws IOException {
+        setUpCronRequest();
+
+        cronRequest1_0.writeTo(output1_0);
+
+        StreamInput streamInput = output1_0.bytes().streamInput();
+        streamInput.setVersion(Version.V_1_0_0);
+        CronRequest readRequest = new CronRequest(streamInput);
+        assertEquals(1, readRequest.concreteNodes().length);
+        assertEquals(node, readRequest.concreteNodes()[0]);
+    }
+
+    public void testSerializeCronRequest1_0() throws IOException {
+        setUpCronRequest();
+
+        cronRequest1_1.writeTo(output1_0);
+
+        StreamInput streamInput = output1_0.bytes().streamInput();
+        streamInput.setVersion(Version.V_1_0_0);
+        CronRequest1_0 readRequest = new CronRequest1_0(streamInput);
+        assertEquals(1, readRequest.concreteNodes().length);
+        assertEquals(node, readRequest.concreteNodes()[0]);
+    }
+
+    private void setUpCronNodeRequest() {
+        cronNodeRequest1_1 = new CronNodeRequest("blah");
+        cronNodeRequest1_0 = new CronNodeRequest1_0();
+    }
+
+    public void testDeserializeCronNodeRequest1_1() throws IOException {
+        setUpCronNodeRequest();
+
+        cronNodeRequest1_1.writeTo(output1_1);
+
+        StreamInput streamInput = output1_1.bytes().streamInput();
+        streamInput.setVersion(V_1_1_0);
+        CronNodeRequest readRequest = new CronNodeRequest(streamInput);
+        assertEquals(readRequest.getRequestId(), cronNodeRequest1_1.getRequestId());
+    }
+
+    public void testDeserializeCronNodeRequest1_0() throws IOException {
+        setUpCronNodeRequest();
+
+        cronNodeRequest1_0.writeTo(output1_0);
+
+        StreamInput streamInput = output1_0.bytes().streamInput();
+        streamInput.setVersion(Version.V_1_0_0);
+        CronNodeRequest readRequest = new CronNodeRequest(streamInput);
+        assertTrue(readRequest != null);
+    }
+
+    public void testSerializeCronNodeRequest1_0() throws IOException {
+        setUpCronNodeRequest();
+
+        cronNodeRequest1_1.writeTo(output1_0);
+
+        StreamInput streamInput = output1_0.bytes().streamInput();
+        streamInput.setVersion(Version.V_1_0_0);
+        CronNodeRequest1_0 readRequest = new CronNodeRequest1_0(streamInput);
+        assertTrue(readRequest != null);
+    }
+
+    private void setUpAnomalyResultResponse() {
+        adResultResponse1_1 = new AnomalyResultResponse(
+            0.5,
+            0.993,
+            1.01,
+            Collections.singletonList(new FeatureData("id", "name", 0d)),
+            null,
+            15L,
+            10L
+        );
+        adResultResponse1_0 = new AnomalyResultResponse1_0(0.5, 0.993, 1.01, Collections.singletonList(new FeatureData("id", "name", 0d)));
+    }
+
+    public void testDeserializeAnomalyResultResponse1_1() throws IOException {
+        setUpAnomalyResultResponse();
+
+        adResultResponse1_1.writeTo(output1_1);
+
+        StreamInput streamInput = output1_1.bytes().streamInput();
+        streamInput.setVersion(V_1_1_0);
+        AnomalyResultResponse readResponse = new AnomalyResultResponse(streamInput);
+        assertEquals(readResponse.getAnomalyGrade(), adResultResponse1_1.getAnomalyGrade(), 0.001);
+        assertEquals(readResponse.getConfidence(), adResultResponse1_1.getConfidence(), 0.001);
+        assertEquals(readResponse.getAnomalyScore(), adResultResponse1_1.getAnomalyScore(), 0.001);
+        assertEquals(1, readResponse.getFeatures().size());
+        assertEquals(readResponse.getFeatures().get(0), adResultResponse1_1.getFeatures().get(0));
+        assertEquals(readResponse.getError(), adResultResponse1_1.getError());
+        assertEquals(readResponse.getRcfTotalUpdates(), adResultResponse1_1.getRcfTotalUpdates(), 0.001);
+        assertEquals(readResponse.getDetectorIntervalInMinutes(), adResultResponse1_1.getDetectorIntervalInMinutes());
+        assertEquals(readResponse.isHCDetector(), adResultResponse1_1.isHCDetector());
+    }
+
+    public void testDeserializeAnomalyResultResponse1_0() throws IOException {
+        setUpAnomalyResultResponse();
+
+        adResultResponse1_0.writeTo(output1_0);
+
+        StreamInput streamInput = output1_0.bytes().streamInput();
+        streamInput.setVersion(Version.V_1_0_0);
+        AnomalyResultResponse readResponse = new AnomalyResultResponse(streamInput);
+        assertEquals(readResponse.getAnomalyGrade(), adResultResponse1_1.getAnomalyGrade(), 0.001);
+        assertEquals(readResponse.getConfidence(), adResultResponse1_1.getConfidence(), 0.001);
+        assertEquals(readResponse.getAnomalyScore(), adResultResponse1_1.getAnomalyScore(), 0.001);
+        assertEquals(1, readResponse.getFeatures().size());
+        assertEquals(readResponse.getFeatures().get(0), adResultResponse1_1.getFeatures().get(0));
+        assertEquals(readResponse.getError(), adResultResponse1_1.getError());
+    }
+
+    public void testSerializeAnomalyResultResponse1_0() throws IOException {
+        setUpAnomalyResultResponse();
+
+        adResultResponse1_1.writeTo(output1_0);
+
+        StreamInput streamInput = output1_0.bytes().streamInput();
+        streamInput.setVersion(Version.V_1_0_0);
+        AnomalyResultResponse1_0 readResponse = new AnomalyResultResponse1_0(streamInput);
+        assertEquals(readResponse.getAnomalyGrade(), adResultResponse1_1.getAnomalyGrade(), 0.001);
+        assertEquals(readResponse.getConfidence(), adResultResponse1_1.getConfidence(), 0.001);
+        assertEquals(readResponse.getAnomalyScore(), adResultResponse1_1.getAnomalyScore(), 0.001);
+        assertEquals(1, readResponse.getFeatures().size());
+        assertEquals(readResponse.getFeatures().get(0), adResultResponse1_1.getFeatures().get(0));
+        assertEquals(readResponse.getError(), adResultResponse1_1.getError());
     }
 }

--- a/src/test/java/org/opensearch/CronNodeRequest1_0.java
+++ b/src/test/java/org/opensearch/CronNodeRequest1_0.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch;
+
+import java.io.IOException;
+
+import org.opensearch.action.support.nodes.BaseNodeRequest;
+import org.opensearch.common.io.stream.StreamInput;
+
+/**
+ *  Delete model represents the request to an individual node
+ */
+public class CronNodeRequest1_0 extends BaseNodeRequest {
+
+    public CronNodeRequest1_0() {}
+
+    public CronNodeRequest1_0(StreamInput in) throws IOException {
+        super(in);
+    }
+
+}

--- a/src/test/java/org/opensearch/CronRequest1_0.java
+++ b/src/test/java/org/opensearch/CronRequest1_0.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch;
+
+import java.io.IOException;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.StreamInput;
+
+/**
+ * Request should be sent from the handler logic of transport delete detector API
+ *
+ */
+public class CronRequest1_0 extends BaseNodesRequest<CronRequest1_0> {
+
+    public CronRequest1_0() {
+        super((String[]) null);
+    }
+
+    public CronRequest1_0(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public CronRequest1_0(DiscoveryNode... nodes) {
+        super(nodes);
+    }
+}

--- a/src/test/java/org/opensearch/ad/AbstractADTest.java
+++ b/src/test/java/org/opensearch/ad/AbstractADTest.java
@@ -62,6 +62,7 @@ import org.opensearch.ad.model.DetectorInternalState;
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -177,10 +178,10 @@ public class AbstractADTest extends OpenSearchTestCase {
     protected void setUpLog4jForJUnit(Class<?> cls) {
         String loggerName = toLoggerName(callerClass(cls));
         logger = (Logger) LogManager.getLogger(loggerName);
+        Loggers.setLevel(logger, Level.DEBUG);
         testAppender = new TestAppender(loggerName);
         testAppender.start();
         logger.addAppender(testAppender);
-        logger.setLevel(Level.DEBUG);
     }
 
     private static String toLoggerName(final Class<?> cls) {

--- a/src/test/java/org/opensearch/ad/indices/UpdateMappingTests.java
+++ b/src/test/java/org/opensearch/ad/indices/UpdateMappingTests.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.indices;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
+import org.opensearch.ad.AbstractADTest;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.util.DiscoveryNodeFilterer;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.collect.ImmutableOpenMap;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+
+public class UpdateMappingTests extends AbstractADTest {
+    private static String resultIndexName;
+
+    private AnomalyDetectionIndices adIndices;
+    private ClusterService clusterService;
+    private int numberOfNodes;
+    private AdminClient adminClient;
+    private ClusterState clusterState;
+    private IndicesAdminClient indicesAdminClient;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        resultIndexName = ".opendistro-anomaly-results-history-2020.06.24-000003";
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Client client = mock(Client.class);
+        adminClient = mock(AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        indicesAdminClient = mock(IndicesAdminClient.class);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+        doAnswer(invocation -> {
+            ActionListener<GetAliasesResponse> listener = (ActionListener<GetAliasesResponse>) invocation.getArgument(1);
+
+            ImmutableOpenMap.Builder<String, List<AliasMetadata>> builder = ImmutableOpenMap.builder();
+            List<AliasMetadata> aliasMetadata = new ArrayList<>();
+            aliasMetadata.add(AliasMetadata.builder(ADIndex.RESULT.name()).build());
+            builder.put(resultIndexName, aliasMetadata);
+
+            listener.onResponse(new GetAliasesResponse(builder.build()));
+            return null;
+        }).when(indicesAdminClient).getAliases(any(GetAliasesRequest.class), any());
+
+        clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections
+                .unmodifiableSet(
+                    new HashSet<>(
+                        Arrays
+                            .asList(
+                                AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS_PER_SHARD,
+                                AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD,
+                                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
+                                AnomalyDetectorSettings.MAX_PRIMARY_SHARDS
+                            )
+                    )
+                )
+        );
+
+        clusterState = mock(ClusterState.class);
+
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        IndexMetadata indexMetadata = IndexMetadata
+            .builder(resultIndexName)
+            .putAlias(AliasMetadata.builder(ADIndex.RESULT.getIndexName()))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ImmutableOpenMap.Builder<String, IndexMetadata> openMapBuilder = ImmutableOpenMap.builder();
+        openMapBuilder.put(resultIndexName, indexMetadata);
+        Metadata metadata = Metadata.builder().indices(openMapBuilder.build()).build();
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(clusterState.metadata()).thenReturn(metadata);
+
+        RoutingTable routingTable = mock(RoutingTable.class);
+        when(clusterState.getRoutingTable()).thenReturn(routingTable);
+        when(routingTable.hasIndex(anyString())).thenReturn(true);
+
+        Settings settings = Settings.EMPTY;
+        DiscoveryNodeFilterer nodeFilter = mock(DiscoveryNodeFilterer.class);
+        numberOfNodes = 2;
+        when(nodeFilter.getNumberOfEligibleDataNodes()).thenReturn(numberOfNodes);
+        adIndices = new AnomalyDetectionIndices(client, clusterService, threadPool, settings, nodeFilter);
+    }
+
+    public void testNoIndexToUpdate() {
+        adIndices.updateMappingIfNecessary();
+        verify(indicesAdminClient, never()).putMapping(any(), any());
+        // for each index, we check doesAliasExists/doesIndexExists and shouldUpdateConcreteIndex
+        verify(clusterService, times(10)).state();
+        adIndices.updateMappingIfNecessary();
+        // we will not trigger new check since we have checked all indices before
+        verify(clusterService, times(10)).state();
+    }
+
+    @SuppressWarnings("serial")
+    public void testUpdate() throws IOException {
+        IndexMetadata indexMetadata = IndexMetadata
+            .builder(resultIndexName)
+            .putAlias(AliasMetadata.builder(ADIndex.RESULT.getIndexName()))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping(new MappingMetadata("type", new HashMap<String, Object>() {
+                {
+                    put(AnomalyDetectionIndices.META, new HashMap<String, Object>() {
+                        {
+                            // version 1 will cause update
+                            put(CommonName.SCHEMA_VERSION_FIELD, 1);
+                        }
+                    });
+                }
+            }))
+            .build();
+        ImmutableOpenMap.Builder<String, IndexMetadata> openMapBuilder = ImmutableOpenMap.builder();
+        openMapBuilder.put(resultIndexName, indexMetadata);
+        Metadata metadata = Metadata.builder().indices(openMapBuilder.build()).build();
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(clusterState.metadata()).thenReturn(metadata);
+        adIndices.updateMappingIfNecessary();
+        verify(indicesAdminClient, times(1)).putMapping(any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/ad/transport/ADResultBulkResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADResultBulkResponseTests.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ADResultBulkResponseTests extends OpenSearchTestCase {
+    public void testSerialization() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        List<IndexRequest> retryRequests = new ArrayList<>();
+        retryRequests.add(new IndexRequest("index").id("blah").source(Collections.singletonMap("foo", "bar")));
+        ADResultBulkResponse response = new ADResultBulkResponse(retryRequests);
+        response.writeTo(output);
+        StreamInput streamInput = output.bytes().streamInput();
+        ADResultBulkResponse readResponse = new ADResultBulkResponse(streamInput);
+        assertTrue(readResponse.hasFailures());
+    }
+}

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -407,7 +407,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             threadPool
         );
 
-        when(normalModelManager.getAnomalyResultForEntity(any(), any(), any(), any(), any())).thenReturn(new ThresholdingResult(0, 1, 1));
+        when(normalModelManager.getAnomalyResultForEntity(any(), any(), any(), any())).thenReturn(new ThresholdingResult(0, 1, 1));
     }
 
     private void setUpEntityResult(int nodeIndex) {

--- a/src/test/java/org/opensearch/ad/transport/handler/AbstractIndexHandlerTest.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/AbstractIndexHandlerTest.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.transport.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ad.TestHelpers.createIndexBlockedState;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ResourceAlreadyExistsException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.ad.AbstractADTest;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.indices.AnomalyDetectionIndices;
+import org.opensearch.ad.transport.AnomalyResultTests;
+import org.opensearch.ad.util.ClientUtil;
+import org.opensearch.ad.util.IndexUtils;
+import org.opensearch.ad.util.Throttler;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.threadpool.ThreadPool;
+
+public abstract class AbstractIndexHandlerTest extends AbstractADTest {
+    enum IndexCreation {
+        RUNTIME_EXCEPTION,
+        RESOURCE_EXISTS_EXCEPTION,
+        ACKED,
+        NOT_ACKED
+    }
+
+    protected static Settings settings;
+    protected ClientUtil clientUtil;
+    protected ThreadPool context;
+    protected IndexUtils indexUtil;
+    protected String detectorId = "123";
+
+    @Mock
+    protected Client client;
+
+    @Mock
+    protected AnomalyDetectionIndices anomalyDetectionIndices;
+
+    @Mock
+    protected Throttler throttler;
+
+    @Mock
+    protected ClusterService clusterService;
+
+    @Mock
+    protected IndexNameExpressionResolver indexNameResolver;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        setUpThreadPool(AnomalyResultTests.class.getSimpleName());
+        settings = Settings
+            .builder()
+            .put("plugins.anomaly_detection.max_retry_for_backoff", 2)
+            .put("plugins.anomaly_detection.backoff_initial_delay", TimeValue.timeValueMillis(1))
+            .build();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        tearDownThreadPool();
+        settings = null;
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.initMocks(this);
+        setWriteBlockAdResultIndex(false);
+        context = TestHelpers.createThreadPool();
+        clientUtil = new ClientUtil(settings, client, throttler, context);
+        indexUtil = new IndexUtils(client, clientUtil, clusterService, indexNameResolver);
+    }
+
+    protected void setWriteBlockAdResultIndex(boolean blocked) {
+        String indexName = randomAlphaOfLength(10);
+        Settings settings = blocked
+            ? Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build()
+            : Settings.EMPTY;
+        ClusterState blockedClusterState = createIndexBlockedState(indexName, settings, CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        when(clusterService.state()).thenReturn(blockedClusterState);
+        when(indexNameResolver.concreteIndexNames(any(), any(), any(String.class))).thenReturn(new String[] { indexName });
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void setUpSavingAnomalyResultIndex(boolean anomalyResultIndexExists, IndexCreation creationResult) throws IOException {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 1);
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            assertTrue(listener != null);
+            switch (creationResult) {
+                case RUNTIME_EXCEPTION:
+                    listener.onFailure(new RuntimeException());
+                    break;
+                case RESOURCE_EXISTS_EXCEPTION:
+                    listener.onFailure(new ResourceAlreadyExistsException(CommonName.ANOMALY_RESULT_INDEX_ALIAS));
+                    break;
+                case ACKED:
+                    listener.onResponse(new CreateIndexResponse(true, true, CommonName.ANOMALY_RESULT_INDEX_ALIAS));
+                    break;
+                case NOT_ACKED:
+                    listener.onResponse(new CreateIndexResponse(false, false, CommonName.ANOMALY_RESULT_INDEX_ALIAS));
+                    break;
+                default:
+                    assertTrue("should not reach here", false);
+                    break;
+            }
+            return null;
+        }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
+        when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(anomalyResultIndexExists);
+    }
+
+    protected void setUpSavingAnomalyResultIndex(boolean anomalyResultIndexExists) throws IOException {
+        setUpSavingAnomalyResultIndex(anomalyResultIndexExists, IndexCreation.ACKED);
+    }
+}

--- a/src/test/java/org/opensearch/ad/transport/handler/MultiEntityResultHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/MultiEntityResultHandlerTests.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.transport.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.opensearch.action.ActionListener;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
+import org.opensearch.ad.transport.ADResultBulkAction;
+import org.opensearch.ad.transport.ADResultBulkRequest;
+import org.opensearch.ad.transport.ADResultBulkResponse;
+
+public class MultiEntityResultHandlerTests extends AbstractIndexHandlerTest {
+    private MultiEntityResultHandler handler;
+    private ADResultBulkRequest request;
+    private ADResultBulkResponse response;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        handler = new MultiEntityResultHandler(
+            client,
+            settings,
+            threadPool,
+            anomalyDetectionIndices,
+            clientUtil,
+            indexUtil,
+            clusterService
+        );
+
+        request = new ADResultBulkRequest();
+        request.add(TestHelpers.randomAnomalyDetectResult());
+
+        response = new ADResultBulkResponse();
+
+        super.setUpLog4jForJUnit(MultiEntityResultHandler.class);
+
+        doAnswer(invocation -> {
+            ActionListener<ADResultBulkResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(ADResultBulkAction.INSTANCE), any(), ArgumentMatchers.<ActionListener<ADResultBulkResponse>>any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        super.tearDownLog4jForJUnit();
+    }
+
+    @Test
+    public void testIndexWriteBlock() throws InterruptedException {
+        setWriteBlockAdResultIndex(true);
+
+        CountDownLatch verified = new CountDownLatch(1);
+
+        handler.flush(request, ActionListener.wrap(response -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }, exception -> {
+            assertTrue(exception instanceof AnomalyDetectionException);
+            assertTrue(
+                "actual: " + exception.getMessage(),
+                exception.getMessage().contains(MultiEntityResultHandler.CANNOT_SAVE_RESULT_ERR_MSG)
+            );
+            verified.countDown();
+        }));
+
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testSavingAdResult() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(false);
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(request, ActionListener.wrap(response -> { verified.countDown(); }, exception -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+        assertEquals(1, testAppender.countMessage(MultiEntityResultHandler.SUCCESS_SAVING_RESULT_MSG, false));
+    }
+
+    @Test
+    public void testSavingFailure() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(false);
+        doAnswer(invocation -> {
+            ActionListener<ADResultBulkResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new RuntimeException());
+            return null;
+        }).when(client).execute(eq(ADResultBulkAction.INSTANCE), any(), ArgumentMatchers.<ActionListener<ADResultBulkResponse>>any());
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(request, ActionListener.wrap(response -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }, exception -> {
+            assertTrue(exception instanceof RuntimeException);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testAdResultIndexExists() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(true);
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(request, ActionListener.wrap(response -> { verified.countDown(); }, exception -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+        assertEquals(1, testAppender.countMessage(MultiEntityResultHandler.SUCCESS_SAVING_RESULT_MSG, false));
+    }
+
+    @Test
+    public void testNothingToSave() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(false);
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(new ADResultBulkRequest(), ActionListener.wrap(response -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }, exception -> {
+            assertTrue(exception instanceof AnomalyDetectionException);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testCreateUnAcked() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(false, IndexCreation.NOT_ACKED);
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(request, ActionListener.wrap(response -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }, exception -> {
+            assertTrue(exception instanceof AnomalyDetectionException);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testCreateRuntimeException() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(false, IndexCreation.RUNTIME_EXCEPTION);
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(request, ActionListener.wrap(response -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }, exception -> {
+            assertTrue(exception instanceof RuntimeException);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testCreateResourcExistsException() throws IOException, InterruptedException {
+        setUpSavingAnomalyResultIndex(false, IndexCreation.RESOURCE_EXISTS_EXCEPTION);
+
+        CountDownLatch verified = new CountDownLatch(1);
+        handler.flush(request, ActionListener.wrap(response -> { verified.countDown(); }, exception -> {
+            assertTrue("Should not reach here ", false);
+            verified.countDown();
+        }));
+        assertTrue(verified.await(100, TimeUnit.SECONDS));
+        assertEquals(1, testAppender.countMessage(MultiEntityResultHandler.SUCCESS_SAVING_RESULT_MSG, false));
+    }
+}

--- a/src/test/java/org/opensearch/ad/util/BulkUtilTests.java
+++ b/src/test/java/org/opensearch/ad/util/BulkUtilTests.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.util;
+
+import java.util.List;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkItemResponse.Failure;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.Index;
+import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class BulkUtilTests extends OpenSearchTestCase {
+    public void testGetFailedIndexRequest() {
+        BulkItemResponse[] itemResponses = new BulkItemResponse[2];
+        String indexName = "index";
+        String type = "_doc";
+        String idPrefix = "id";
+        String uuid = "uuid";
+        int shardIntId = 0;
+        ShardId shardId = new ShardId(new Index(indexName, uuid), shardIntId);
+        itemResponses[0] = new BulkItemResponse(
+            0,
+            randomFrom(DocWriteRequest.OpType.values()),
+            new Failure(indexName, type, idPrefix + 0, new VersionConflictEngineException(shardId, "", "blah"))
+        );
+        itemResponses[1] = new BulkItemResponse(
+            1,
+            randomFrom(DocWriteRequest.OpType.values()),
+            new IndexResponse(shardId, "type", idPrefix + 1, 1, 1, randomInt(), true)
+        );
+        BulkResponse response = new BulkResponse(itemResponses, 0);
+
+        BulkRequest request = new BulkRequest();
+        for (int i = 0; i < 2; i++) {
+            request.add(new IndexRequest(indexName).id(idPrefix + i).source(XContentType.JSON, "field", "value"));
+        }
+
+        List<IndexRequest> retry = BulkUtil.getFailedIndexRequest(request, response);
+        assertEquals(1, retry.size());
+        assertEquals(idPrefix + 0, retry.get(0).id());
+    }
+}

--- a/src/test/java/org/opensearch/ad/util/ThrowingSupplierWrapperTests.java
+++ b/src/test/java/org/opensearch/ad/util/ThrowingSupplierWrapperTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.util;
+
+import java.io.IOException;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ThrowingSupplierWrapperTests extends OpenSearchTestCase {
+    private static String foo() throws IOException {
+        throw new IOException("blah");
+    }
+
+    public void testExceptionThrown() {
+        expectThrows(
+            RuntimeException.class,
+            () -> ThrowingSupplierWrapper.throwingSupplierWrapper(ThrowingSupplierWrapperTests::foo).get()
+        );
+    }
+}


### PR DESCRIPTION
### Description
First, this PR adds an empty string check in PriorityCache.
Second, in EntityColdStarter, this PR clears samples after using them for training.
Third, this PR removes unused fields and local variables in ModelManager and BulkUtil.
Fourth, this PR decreases the concurrent preview from 5 to 2, with a conservative purpose to reduce potential GC.
Fifth, this PR finishes unit tests owed due to my previous PRs. 99% code of the PR is about tests.

Testing done:
1. Added unit tests.
2. made sure the basic e2e workflow still works.

 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
