### PR TITLE
Add bwc tests to run with CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,26 @@ jobs:
           cp ./build/distributions/*.zip ../src/test/resources/job-scheduler
           echo "Copied ./build/distributions/*.zip to ../src/test/resources/job-scheduler ..."
           ls ../src/test/resources/job-scheduler
+          echo "Creating ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
+          mkdir -p ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
+          pwd
+          echo "Copying ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
+          ls ./build/distributions/
+          cp ./build/distributions/*.zip ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
+          echo "Copied ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
+          ls ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
+
+      - name: Assemble anomaly-detection
+        run: |
+          ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT
+          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
+          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT
+          pwd
+          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
+          ls ./build/distributions/
+          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT
+          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
+          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT    
 
       - name: Build and Run Tests
         run: |
@@ -123,6 +143,21 @@ jobs:
             echo "Security plugin is NOT available"
             ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster"
           fi
+
+      - name: Mixed cluster backwards compatibility tests
+        run: |
+          echo "Running mixed cluster backwards compatibility tests ..."
+          ./gradlew adBwcCluster#mixedClusterTask -DmixedCluster=123 -Dtests.security.manager=false
+
+      - name: Rolling upgrade backwards compatibility tests
+        run: |    
+          echo "Running rolling upgrade backwards compatibility tests ..."
+          ./gradlew adBwcCluster#rollingUpgradeClusterTask -DrollingUpgradeCluster=123 -Dtests.security.manager=false
+
+      - name: Full cluster restart backwards compatibility tests
+        run: |     
+          echo "Running full restart cluster backwards compatibility tests ..."
+          ./gradlew adBwcCluster#fullRestartClusterTask -DfullRestartCluster=123 -Dtests.security.manager=false
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,6 @@ jobs:
           ls ../src/test/resources/job-scheduler
           echo "Creating ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
           mkdir -p ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
-          pwd
           echo "Copying ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
           ls ./build/distributions/
           cp ./build/distributions/*.zip ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
@@ -86,7 +85,6 @@ jobs:
           ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT
           echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
           mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT
-          pwd
           echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
           ls ./build/distributions/
           cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT
@@ -147,17 +145,17 @@ jobs:
       - name: Mixed cluster backwards compatibility tests
         run: |
           echo "Running mixed cluster backwards compatibility tests ..."
-          ./gradlew adBwcCluster#mixedClusterTask -DmixedCluster=123 -Dtests.security.manager=false
+          ./gradlew adBwcCluster#mixedClusterTask -DmixedCluster=true -Dtests.security.manager=false
 
       - name: Rolling upgrade backwards compatibility tests
         run: |    
           echo "Running rolling upgrade backwards compatibility tests ..."
-          ./gradlew adBwcCluster#rollingUpgradeClusterTask -DrollingUpgradeCluster=123 -Dtests.security.manager=false
+          ./gradlew adBwcCluster#rollingUpgradeClusterTask -DrollingUpgradeCluster=true -Dtests.security.manager=false
 
       - name: Full cluster restart backwards compatibility tests
         run: |     
           echo "Running full restart cluster backwards compatibility tests ..."
-          ./gradlew adBwcCluster#fullRestartClusterTask -DfullRestartCluster=123 -Dtests.security.manager=false
+          ./gradlew adBwcCluster#fullRestartClusterTask -DfullRestartCluster=true -Dtests.security.manager=false
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -41,6 +41,9 @@ Currently we just put RCF jar in lib as dependency. Plan to publish to Maven and
 4. ` ./gradlew :integTest --tests="**.test execute foo"` runs a single integration test class or method
 5. `./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin` launches integration tests against a local cluster and run tests with security
 6. `./gradlew spotlessApply` formats code. And/or import formatting rules in `.eclipseformat.xml` with IDE.
+7. `./gradlew adBwcCluster#mixedClusterTask -DmixedCluster=true -Dtests.security.manager=false` launches a cluster with three nodes of bwc version of OpenSearch with anomaly-detection and job-scheduler and tests backwards compatibility by upgrading one of the nodes with the current version of OpenSearch with anomaly-detection and job-scheduler creating a mixed cluster.
+8. `./gradlew adBwcCluster#rollingUpgradeClusterTask -DrollingUpgradeCluster=true -Dtests.security.manager=false` launches a cluster with three nodes of bwc version of OpenSearch with anomaly-detection and job-scheduler and tests backwards compatibility by performing rolling upgrade of each node with the current version of OpenSearch with anomaly-detection and job-scheduler.
+9. `./gradlew adBwcCluster#fullRestartClusterTask -DfullRestartCluster=true -Dtests.security.manager=false` launches a cluster with three nodes of bwc version of OpenSearch with anomaly-detection and job-scheduler and tests backwards compatibility by performing a full restart on the cluster upgrading all the nodes with the current version of OpenSearch with anomaly-detection and job-scheduler.
 
 When launching a cluster using one of the above commands logs are placed in `/build/cluster/run node0/opensearch-<version>/logs`. Though the logs are teed to the console, in practices it's best to check the actual log file.
 


### PR DESCRIPTION
### Description
Adding bwc tests introduced in #158 to run with CI for `anomaly-detection`. Also adding the test run commands in the developer guide.
 
### Issues Resolved
[opensearch-build#222](https://github.com/opensearch-project/opensearch-build/issues/222)
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
