### PR TITLE
Limit the max models shown on the stats and profile API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -517,6 +517,9 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.transport.GetAnomalyDetectorResponse',
         'org.opensearch.ad.transport.ADBatchAnomalyResultRequest',
         'org.opensearch.ad.transport.ADBatchTaskRemoteExecutionTransportAction',
+
+        // TODO: to be fixed by kaituo
+        'org.opensearch.ad.indices.AnomalyDetectionIndices',
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -99,6 +99,7 @@ import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.stats.StatNames;
 import org.opensearch.ad.stats.suppliers.CounterSupplier;
 import org.opensearch.ad.stats.suppliers.IndexStatusSupplier;
+import org.opensearch.ad.stats.suppliers.ModelsOnNodeCountSupplier;
 import org.opensearch.ad.stats.suppliers.ModelsOnNodeSupplier;
 import org.opensearch.ad.stats.suppliers.SettableSupplier;
 import org.opensearch.ad.task.ADBatchTaskRunner;
@@ -649,7 +650,10 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             .put(StatNames.AD_EXECUTE_FAIL_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_HC_EXECUTE_REQUEST_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_HC_EXECUTE_FAIL_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
-            .put(StatNames.MODEL_INFORMATION.getName(), new ADStat<>(false, new ModelsOnNodeSupplier(modelManager, cacheProvider)))
+            .put(
+                StatNames.MODEL_INFORMATION.getName(),
+                new ADStat<>(false, new ModelsOnNodeSupplier(modelManager, cacheProvider, settings, clusterService))
+            )
             .put(
                 StatNames.ANOMALY_DETECTORS_INDEX_STATUS.getName(),
                 new ADStat<>(true, new IndexStatusSupplier(indexUtils, AnomalyDetector.ANOMALY_DETECTORS_INDEX))
@@ -677,6 +681,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             .put(StatNames.AD_CANCELED_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_TOTAL_BATCH_TASK_EXECUTION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_BATCH_TASK_FAILURE_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
+            .put(StatNames.MODEL_COUNT.getName(), new ADStat<>(false, new ModelsOnNodeCountSupplier(modelManager, cacheProvider)))
             .build();
 
         adStats = new ADStats(stats);
@@ -877,7 +882,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 AnomalyDetectorSettings.MAX_CONCURRENT_PREVIEW,
                 AnomalyDetectorSettings.PAGE_SIZE,
                 // clean resource
-                AnomalyDetectorSettings.DELETE_AD_RESULT_WHEN_DELETE_DETECTOR
+                AnomalyDetectorSettings.DELETE_AD_RESULT_WHEN_DELETE_DETECTOR,
+                // stats/profile API
+                AnomalyDetectorSettings.MAX_MODEL_SZIE
             );
         return unmodifiableList(
             Stream

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -884,7 +884,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 // clean resource
                 AnomalyDetectorSettings.DELETE_AD_RESULT_WHEN_DELETE_DETECTOR,
                 // stats/profile API
-                AnomalyDetectorSettings.MAX_MODEL_SZIE
+                AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE
             );
         return unmodifiableList(
             Stream

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -300,7 +300,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
 
     private void profileEntityStats(MultiResponsesDelegateActionListener<DetectorProfile> listener, AnomalyDetector detector) {
         List<String> categoryField = detector.getCategoryField();
-        if (categoryField == null || categoryField.size() == 0 || categoryField.size() > NumericSetting.maxCategoricalFields()) {
+        if (!detector.isMultientityDetector() || categoryField.size() > NumericSetting.maxCategoricalFields()) {
             listener.onResponse(new DetectorProfile.Builder().build());
         } else {
             if (categoryField.size() == 1) {

--- a/src/main/java/org/opensearch/ad/constant/CommonName.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonName.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.constant;
 
+import org.opensearch.ad.stats.StatNames;
+
 public class CommonName {
     // ======================================
     // Index name
@@ -80,7 +82,7 @@ public class CommonName {
     public static final String ACTIVE_ENTITIES = "active_entities";
     public static final String ENTITY_INFO = "entity_info";
     public static final String TOTAL_UPDATES = "total_updates";
-
+    public static final String MODEL_COUNT = StatNames.MODEL_COUNT.getName();
     // ======================================
     // Historical detectors
     // ======================================

--- a/src/main/java/org/opensearch/ad/model/DetectorProfile.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorProfile.java
@@ -51,6 +51,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
     private Long totalEntities;
     private Long activeEntities;
     private Map<String, ADTaskProfile> adTaskProfiles;
+    private long modelCount;
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
         return toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -74,6 +75,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         if (in.readBoolean()) {
             this.adTaskProfiles = in.readMap(StreamInput::readString, ADTaskProfile::new);
         }
+        this.modelCount = in.readVLong();
     }
 
     private DetectorProfile() {}
@@ -89,6 +91,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         private Long totalEntities;
         private Long activeEntities;
         private Map<String, ADTaskProfile> adTaskProfiles;
+        private long modelCount = 0;
 
         public Builder() {}
 
@@ -104,6 +107,11 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
 
         public Builder modelProfile(ModelProfileOnNode[] modelProfile) {
             this.modelProfile = modelProfile;
+            return this;
+        }
+
+        public Builder modelCount(long modelCount) {
+            this.modelCount = modelCount;
             return this;
         }
 
@@ -147,6 +155,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             profile.state = this.state;
             profile.error = this.error;
             profile.modelProfile = modelProfile;
+            profile.modelCount = modelCount;
             profile.shingleSize = shingleSize;
             profile.coordinatingNode = coordinatingNode;
             profile.totalSizeInBytes = totalSizeInBytes;
@@ -187,6 +196,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             out.writeBoolean(true);
             out.writeMap(adTaskProfiles, StreamOutput::writeString, (o, s) -> s.writeTo(o));
         }
+        out.writeVLong(modelCount);
     }
 
     @Override
@@ -226,6 +236,9 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
         if (adTaskProfiles != null) {
             xContentBuilder.field(CommonName.HISTORICAL_ANALYSIS, adTaskProfiles);
+        }
+        if (modelCount > 0) {
+            xContentBuilder.field(CommonName.MODEL_COUNT, modelCount);
         }
         return xContentBuilder.endObject();
     }
@@ -310,6 +323,14 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         this.adTaskProfiles = adTaskProfiles;
     }
 
+    public long getModelCount() {
+        return modelCount;
+    }
+
+    public void setModelCount(long modelCount) {
+        this.modelCount = modelCount;
+    }
+
     @Override
     public void merge(Mergeable other) {
         if (this == other || other == null || getClass() != other.getClass()) {
@@ -349,6 +370,9 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             } else {
                 this.adTaskProfiles.putAll(otherProfile.getAdTaskProfiles());
             }
+        }
+        if (otherProfile.getModelCount() > 0) {
+            this.modelCount = otherProfile.getModelCount();
         }
     }
 
@@ -394,6 +418,9 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             if (adTaskProfiles != null) {
                 equalsBuilder.append(adTaskProfiles, other.adTaskProfiles);
             }
+            if (modelCount > 0) {
+                equalsBuilder.append(modelCount, other.modelCount);
+            }
             return equalsBuilder.isEquals();
         }
         return false;
@@ -412,6 +439,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             .append(totalEntities)
             .append(activeEntities)
             .append(adTaskProfiles)
+            .append(modelCount)
             .toHashCode();
     }
 
@@ -448,6 +476,9 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
         if (adTaskProfiles != null) {
             toStringBuilder.append(CommonName.AD_TASK, adTaskProfiles);
+        }
+        if (modelCount > 0) {
+            toStringBuilder.append(CommonName.MODEL_COUNT, modelCount);
         }
         return toStringBuilder.toString();
     }

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -290,9 +290,6 @@ public final class AnomalyDetectorSettings {
     // minute. Since these states' life time is hour, we keep its size 10 * 1000 = 10000.
     public static final int MAX_SMALL_STATES = 10000;
 
-    // how many categorical fields we support
-    public static final int CATEGORY_FIELD_LIMIT = 1;
-
     public static final int MULTI_ENTITY_NUM_TREES = 30;
 
     // ======================================
@@ -772,4 +769,28 @@ public final class AnomalyDetectorSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
+
+    // ======================================
+    // stats/profile API setting
+    // ======================================
+    // the max number of models to return per node.
+    // the setting is used to limit resource usage due to showing models
+    public static final Setting<Integer> MAX_MODEL_SZIE = Setting
+        .intSetting(
+            "plugins.anomaly_detection.max_model_size_per_node",
+            100,
+            1,
+            10_000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    // profile API needs to report total entities. We can use cardinality aggregation for a single-category field.
+    // But we cannot do that for multi-category fields as it requires scripting to generate run time fields,
+    // which is expensive. We work around the problem by using a composite query to find the first 10_000 buckets.
+    // Generally, traversing all buckets/combinations can't be done without visiting all matches, which is costly
+    // for data with many entities. Given that it is often enough to have a lower bound of the number of entities,
+    // such as "there are at least 10000 entities", the default is set to 10,000. That is, requests will count the
+    // total entities up to 10,000.
+    public static final int MAX_TOTAL_ENTITIES_TO_TRACK = 10_000;
 }

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -775,7 +775,7 @@ public final class AnomalyDetectorSettings {
     // ======================================
     // the max number of models to return per node.
     // the setting is used to limit resource usage due to showing models
-    public static final Setting<Integer> MAX_MODEL_SZIE = Setting
+    public static final Setting<Integer> MAX_MODEL_SIZE_PER_NODE = Setting
         .intSetting(
             "plugins.anomaly_detection.max_model_size_per_node",
             100,

--- a/src/main/java/org/opensearch/ad/stats/StatNames.java
+++ b/src/main/java/org/opensearch/ad/stats/StatNames.java
@@ -50,7 +50,8 @@ public enum StatNames {
     AD_EXECUTING_BATCH_TASK_COUNT("ad_executing_batch_task_count"),
     AD_CANCELED_BATCH_TASK_COUNT("ad_canceled_batch_task_count"),
     AD_TOTAL_BATCH_TASK_EXECUTION_COUNT("ad_total_batch_task_execution_count"),
-    AD_BATCH_TASK_FAILURE_COUNT("ad_batch_task_failure_count");
+    AD_BATCH_TASK_FAILURE_COUNT("ad_batch_task_failure_count"),
+    MODEL_COUNT("model_count");
 
     private String name;
 

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeCountSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeCountSupplier.java
@@ -9,21 +9,6 @@
  * GitHub history for details.
  */
 
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package org.opensearch.ad.stats.suppliers;
 
 import java.util.function.Supplier;

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeCountSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeCountSupplier.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.ad.stats.suppliers;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.opensearch.ad.caching.CacheProvider;
+import org.opensearch.ad.ml.ModelManager;
+
+/**
+ * ModelsOnNodeSupplier provides a List of ModelStates info for the models the nodes contains
+ */
+public class ModelsOnNodeCountSupplier implements Supplier<Long> {
+    private ModelManager modelManager;
+    private CacheProvider cache;
+
+    /**
+     * Constructor
+     *
+     * @param modelManager object that manages the model partitions hosted on the node
+     * @param cache object that manages multi-entity detectors' models
+     */
+    public ModelsOnNodeCountSupplier(ModelManager modelManager, CacheProvider cache) {
+        this.modelManager = modelManager;
+        this.cache = cache;
+    }
+
+    @Override
+    public Long get() {
+        return Stream.concat(modelManager.getAllModels().stream(), cache.get().getAllModels().stream()).count();
+    }
+}

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeCountSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeCountSupplier.java
@@ -18,7 +18,7 @@ import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.ml.ModelManager;
 
 /**
- * ModelsOnNodeSupplier provides a List of ModelStates info for the models the nodes contains
+ * ModelsOnNodeCountSupplier provides the number of models a node contains
  */
 public class ModelsOnNodeCountSupplier implements Supplier<Long> {
     private ModelManager modelManager;

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
@@ -29,6 +29,7 @@ package org.opensearch.ad.stats.suppliers;
 import static org.opensearch.ad.ml.ModelState.LAST_CHECKPOINT_TIME_KEY;
 import static org.opensearch.ad.ml.ModelState.LAST_USED_TIME_KEY;
 import static org.opensearch.ad.ml.ModelState.MODEL_TYPE_KEY;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SZIE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +44,8 @@ import java.util.stream.Stream;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.ml.ModelManager;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 
 /**
  * ModelsOnNodeSupplier provides a List of ModelStates info for the models the nodes contains
@@ -50,6 +53,8 @@ import org.opensearch.ad.ml.ModelManager;
 public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>> {
     private ModelManager modelManager;
     private CacheProvider cache;
+    // the max number of models to return per node. Defaults to 10.
+    private volatile int modelToReturn;
 
     /**
      * Set that contains the model stats that should be exposed.
@@ -71,10 +76,14 @@ public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>>
      *
      * @param modelManager object that manages the model partitions hosted on the node
      * @param cache object that manages multi-entity detectors' models
+     * @param settings node settings accessor
+     * @param clusterService Cluster service accessor
      */
-    public ModelsOnNodeSupplier(ModelManager modelManager, CacheProvider cache) {
+    public ModelsOnNodeSupplier(ModelManager modelManager, CacheProvider cache, Settings settings, ClusterService clusterService) {
         this.modelManager = modelManager;
         this.cache = cache;
+        this.modelToReturn = MAX_MODEL_SZIE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_MODEL_SZIE, it -> this.modelToReturn = it);
     }
 
     @Override
@@ -82,6 +91,7 @@ public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>>
         List<Map<String, Object>> values = new ArrayList<>();
         Stream
             .concat(modelManager.getAllModels().stream(), cache.get().getAllModels().stream())
+            .limit(modelToReturn)
             .forEach(
                 modelState -> values
                     .add(

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -2087,6 +2087,7 @@ public class ADTaskManager {
     public boolean skipUpdateHCRealtimeTask(String detectorId, String error) {
         ADRealtimeTaskCache realtimeTaskCache = adTaskCacheManager.getRealtimeTaskCache(detectorId);
         return realtimeTaskCache != null
+            && realtimeTaskCache.getInitProgress() != null
             && realtimeTaskCache.getInitProgress() == 1.0
             && Objects.equals(error, realtimeTaskCache.getError());
     }

--- a/src/main/java/org/opensearch/ad/transport/ProfileNodeResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/ProfileNodeResponse.java
@@ -50,6 +50,7 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
     private long totalUpdates;
     // added after OpenSearch 1.0
     private List<ModelProfile> modelProfiles;
+    private long modelCount;
 
     /**
      * Constructor
@@ -68,6 +69,7 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         if (Bwc.supportMultiCategoryFields(in.getVersion()) && in.readBoolean()) {
             // added after OpenSearch 1.0
             modelProfiles = in.readList(ModelProfile::new);
+            modelCount = in.readVLong();
         }
     }
 
@@ -80,6 +82,7 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
      * @param activeEntity active entity count
      * @param totalUpdates RCF model total updates
      * @param modelProfiles a collection of model profiles like model size
+     * @param modelCount the number of models on the node
      */
     public ProfileNodeResponse(
         DiscoveryNode node,
@@ -87,7 +90,8 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         int shingleSize,
         long activeEntity,
         long totalUpdates,
-        List<ModelProfile> modelProfiles
+        List<ModelProfile> modelProfiles,
+        long modelCount
     ) {
         super(node);
         this.modelSize = modelSize;
@@ -95,6 +99,7 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         this.activeEntities = activeEntity;
         this.totalUpdates = totalUpdates;
         this.modelProfiles = modelProfiles;
+        this.modelCount = modelCount;
     }
 
     /**
@@ -126,6 +131,7 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
             if (modelProfiles != null) {
                 out.writeBoolean(true);
                 out.writeList(modelProfiles);
+                out.writeVLong(modelCount);
             } else {
                 out.writeBoolean(false);
             }
@@ -152,6 +158,7 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         builder.field(CommonName.ACTIVE_ENTITIES, activeEntities);
         builder.field(CommonName.TOTAL_UPDATES, totalUpdates);
 
+        builder.field(CommonName.MODEL_COUNT, modelCount);
         builder.startArray(CommonName.MODELS);
         for (ModelProfile modelProfile : modelProfiles) {
             builder.startObject();
@@ -181,5 +188,9 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
 
     public List<ModelProfile> getModelProfiles() {
         return modelProfiles;
+    }
+
+    public long getModelCount() {
+        return modelCount;
     }
 }

--- a/src/test/java/org/opensearch/BwcTests.java
+++ b/src/test/java/org/opensearch/BwcTests.java
@@ -379,9 +379,18 @@ public class BwcTests extends AbstractADTest {
             shingleSize,
             0,
             0,
-            Arrays.asList(modelProfile, modelProfile2)
+            Arrays.asList(modelProfile, modelProfile2),
+            modelSizeMap1.size()
         );
-        ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, -1, 0, 0, new ArrayList<>());
+        ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(
+            discoveryNode2,
+            modelSizeMap2,
+            -1,
+            0,
+            0,
+            new ArrayList<>(),
+            modelSizeMap2.size()
+        );
         List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
         List<FailedNodeException> failures = Collections.emptyList();
 
@@ -423,6 +432,7 @@ public class BwcTests extends AbstractADTest {
         assertThat(readResponse.getTotalUpdates(), equalTo(profileResponse1_1.getTotalUpdates()));
         assertThat(readResponse.getCoordinatingNode(), equalTo(profileResponse1_1.getCoordinatingNode()));
         assertThat(readResponse.getTotalSizeInBytes(), equalTo(profileResponse1_1.getTotalSizeInBytes()));
+        assertThat(readResponse.getModelCount(), equalTo(profileResponse1_1.getModelCount()));
     }
 
     /**
@@ -455,6 +465,7 @@ public class BwcTests extends AbstractADTest {
         assertThat(readResponse.getTotalUpdates(), equalTo(profileResponse1_1.getTotalUpdates()));
         assertThat(readResponse.getCoordinatingNode(), equalTo(profileResponse1_1.getCoordinatingNode()));
         assertThat(readResponse.getTotalSizeInBytes(), equalTo(profileResponse1_1.getTotalSizeInBytes()));
+        assertThat(readResponse.getModelCount(), equalTo(0L));
     }
 
     /**

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -434,7 +434,8 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
                 shingleSize,
                 0L,
                 0L,
-                new ArrayList<>()
+                new ArrayList<>(),
+                modelSizeMap1.size()
             );
             ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(
                 discoveryNode2,
@@ -442,7 +443,8 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
                 -1,
                 0L,
                 0L,
-                new ArrayList<>()
+                new ArrayList<>(),
+                modelSizeMap2.size()
             );
             List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
             List<FailedNodeException> failures = Collections.emptyList();

--- a/src/test/java/org/opensearch/ad/MultiEntityProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/MultiEntityProfileRunnerTests.java
@@ -218,7 +218,8 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
                 shingleSize,
                 1L,
                 updates,
-                new ArrayList<>()
+                new ArrayList<>(),
+                modelSizeMap1.size()
             );
             ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(
                 discoveryNode2,
@@ -226,7 +227,8 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
                 shingleSize,
                 1L,
                 updates,
-                new ArrayList<>()
+                new ArrayList<>(),
+                modelSizeMap2.size()
             );
             List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
             List<FailedNodeException> failures = Collections.emptyList();

--- a/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
+++ b/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
@@ -29,7 +29,7 @@ package org.opensearch.ad.stats;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SZIE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -122,11 +122,11 @@ public class ADStatsTests extends OpenSearchTestCase {
         nodeStatName1 = "nodeStat1";
         nodeStatName2 = "nodeStat2";
 
-        Settings settings = Settings.builder().put(MAX_MODEL_SZIE.getKey(), 10).build();
+        Settings settings = Settings.builder().put(MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SZIE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SIZE_PER_NODE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
+++ b/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
@@ -29,10 +29,12 @@ package org.opensearch.ad.stats;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SZIE;
 
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +55,9 @@ import org.opensearch.ad.stats.suppliers.CounterSupplier;
 import org.opensearch.ad.stats.suppliers.IndexStatusSupplier;
 import org.opensearch.ad.stats.suppliers.ModelsOnNodeSupplier;
 import org.opensearch.ad.util.IndexUtils;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import test.org.opensearch.ad.util.MLUtil;
@@ -117,10 +122,18 @@ public class ADStatsTests extends OpenSearchTestCase {
         nodeStatName1 = "nodeStat1";
         nodeStatName2 = "nodeStat2";
 
+        Settings settings = Settings.builder().put(MAX_MODEL_SZIE.getKey(), 10).build();
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SZIE)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
         statsMap = new HashMap<String, ADStat<?>>() {
             {
                 put(nodeStatName1, new ADStat<>(false, new CounterSupplier()));
-                put(nodeStatName2, new ADStat<>(false, new ModelsOnNodeSupplier(modelManager, cacheProvider)));
+                put(nodeStatName2, new ADStat<>(false, new ModelsOnNodeSupplier(modelManager, cacheProvider, settings, clusterService)));
                 put(clusterStatName1, new ADStat<>(true, new IndexStatusSupplier(indexUtils, "index1")));
                 put(clusterStatName2, new ADStat<>(true, new IndexStatusSupplier(indexUtils, "index2")));
             }

--- a/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
+++ b/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
@@ -28,7 +28,7 @@ package org.opensearch.ad.stats.suppliers;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SZIE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
 import static org.opensearch.ad.stats.suppliers.ModelsOnNodeSupplier.MODEL_STATE_STAT_KEYS;
 
 import java.time.Clock;
@@ -105,11 +105,11 @@ public class ModelsOnNodeSupplierTests extends OpenSearchTestCase {
 
     @Test
     public void testGet() {
-        Settings settings = Settings.builder().put(MAX_MODEL_SZIE.getKey(), 10).build();
+        Settings settings = Settings.builder().put(MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SZIE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SIZE_PER_NODE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
+++ b/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
@@ -28,11 +28,14 @@ package org.opensearch.ad.stats.suppliers;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SZIE;
 import static org.opensearch.ad.stats.suppliers.ModelsOnNodeSupplier.MODEL_STATE_STAT_KEYS;
 
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,6 +51,9 @@ import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.HybridThresholdingModel;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.ml.ModelState;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import test.org.opensearch.ad.util.MLUtil;
@@ -99,7 +105,15 @@ public class ModelsOnNodeSupplierTests extends OpenSearchTestCase {
 
     @Test
     public void testGet() {
-        ModelsOnNodeSupplier modelsOnNodeSupplier = new ModelsOnNodeSupplier(modelManager, cacheProvider);
+        Settings settings = Settings.builder().put(MAX_MODEL_SZIE.getKey(), 10).build();
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SZIE)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        ModelsOnNodeSupplier modelsOnNodeSupplier = new ModelsOnNodeSupplier(modelManager, cacheProvider, settings, clusterService);
         List<Map<String, Object>> results = modelsOnNodeSupplier.get();
         assertEquals(
             "get fails to return correct result",
@@ -116,5 +130,11 @@ public class ModelsOnNodeSupplierTests extends OpenSearchTestCase {
                 .collect(Collectors.toList()),
             results
         );
+    }
+
+    @Test
+    public void testGetModelCount() {
+        ModelsOnNodeCountSupplier modelsOnNodeSupplier = new ModelsOnNodeCountSupplier(modelManager, cacheProvider);
+        assertEquals(6L, modelsOnNodeSupplier.get().longValue());
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
@@ -28,7 +28,7 @@ package org.opensearch.ad.transport;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SZIE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
 
 import java.time.Clock;
 import java.util.Arrays;
@@ -99,11 +99,11 @@ public class ADStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         nodeStatName1 = "nodeStat1";
         nodeStatName2 = "nodeStat2";
 
-        Settings settings = Settings.builder().put(MAX_MODEL_SZIE.getKey(), 10).build();
+        Settings settings = Settings.builder().put(MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SZIE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SIZE_PER_NODE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/transport/ProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ProfileTests.java
@@ -154,7 +154,8 @@ public class ProfileTests extends OpenSearchTestCase {
             shingleSize,
             0,
             0,
-            new ArrayList<>()
+            new ArrayList<>(),
+            modelSizeMap1.size()
         );
         BytesStreamOutput output = new BytesStreamOutput();
         profileNodeResponse.writeTo(output);
@@ -208,9 +209,18 @@ public class ProfileTests extends OpenSearchTestCase {
             shingleSize,
             0,
             0,
-            new ArrayList<>()
+            new ArrayList<>(),
+            modelSizeMap1.size()
         );
-        ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, -1, 0, 0, new ArrayList<>());
+        ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(
+            discoveryNode2,
+            modelSizeMap2,
+            -1,
+            0,
+            0,
+            new ArrayList<>(),
+            modelSizeMap2.size()
+        );
         List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
         List<FailedNodeException> failures = Collections.emptyList();
         ProfileResponse profileResponse = new ProfileResponse(new ClusterName(clusterName), profileNodeResponses, failures);

--- a/src/test/java/org/opensearch/ad/transport/ProfileTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ProfileTransportActionTests.java
@@ -129,7 +129,7 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
     }
 
     private void setUpModelSize(int maxModel) {
-        Settings nodeSettings = Settings.builder().put(AnomalyDetectorSettings.MAX_MODEL_SZIE.getKey(), maxModel).build();
+        Settings nodeSettings = Settings.builder().put(AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE.getKey(), maxModel).build();
         internalCluster().startNode(nodeSettings);
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ProfileTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ProfileTransportActionTests.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.feature.FeatureManager;
@@ -50,7 +52,10 @@ import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.ModelProfile;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.transport.TransportService;
 
@@ -67,14 +72,16 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
     private int activeEntities = 10;
     private long totalUpdates = 127;
     private long multiEntityModelSize = 712480L;
+    private ModelManager modelManager;
+    private FeatureManager featureManager;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
 
-        ModelManager modelManager = mock(ModelManager.class);
-        FeatureManager featureManager = mock(FeatureManager.class);
+        modelManager = mock(ModelManager.class);
+        featureManager = mock(FeatureManager.class);
 
         when(featureManager.getShingleSize(any(String.class))).thenReturn(shingleSize);
 
@@ -104,6 +111,8 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
         modelSizes.put(modelId, modelSize);
         when(modelManager.getModelSize(any(String.class))).thenReturn(modelSizes);
 
+        Settings settings = Settings.builder().put("plugins.anomaly_detection.max_model_size_per_node", 100).build();
+
         action = new ProfileTransportAction(
             client().threadPool(),
             clusterService(),
@@ -111,19 +120,31 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
             mock(ActionFilters.class),
             modelManager,
             featureManager,
-            cacheProvider
+            cacheProvider,
+            settings
         );
 
         profilesToRetrieve = new HashSet<DetectorProfileName>();
         profilesToRetrieve.add(DetectorProfileName.COORDINATING_NODE);
     }
 
+    private void setUpModelSize(int maxModel) {
+        Settings nodeSettings = Settings.builder().put(AnomalyDetectorSettings.MAX_MODEL_SZIE.getKey(), maxModel).build();
+        internalCluster().startNode(nodeSettings);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(AnomalyDetectorPlugin.class);
+    }
+
     @Test
     public void testNewResponse() {
+        setUpModelSize(100);
         DiscoveryNode node = clusterService().localNode();
         ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve, false, node);
 
-        ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(node, new HashMap<>(), shingleSize, 0, 0, new ArrayList<>());
+        ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(node, new HashMap<>(), shingleSize, 0, 0, new ArrayList<>(), 0);
         List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1);
         List<FailedNodeException> failures = new ArrayList<>();
 
@@ -133,7 +154,7 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
 
     @Test
     public void testNewNodeRequest() {
-
+        setUpModelSize(100);
         ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve, false);
 
         ProfileNodeRequest profileNodeRequest1 = new ProfileNodeRequest(profileRequest);
@@ -145,7 +166,7 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
 
     @Test
     public void testNodeOperation() {
-
+        setUpModelSize(100);
         DiscoveryNode nodeId = clusterService().localNode();
         ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve, false, nodeId);
 
@@ -167,7 +188,7 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
 
     @Test
     public void testMultiEntityNodeOperation() {
-
+        setUpModelSize(100);
         DiscoveryNode nodeId = clusterService().localNode();
         profilesToRetrieve = new HashSet<DetectorProfileName>();
         profilesToRetrieve.add(DetectorProfileName.ACTIVE_ENTITIES);
@@ -195,5 +216,32 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
         assertEquals(null, response.getModelSize());
         assertEquals(2, response.getModelProfiles().size());
         assertEquals(totalUpdates, response.getTotalUpdates());
+        assertEquals(2, response.getModelCount());
+    }
+
+    @Test
+    public void testModelCount() {
+        setUpModelSize(1);
+
+        Settings settings = Settings.builder().put("plugins.anomaly_detection.max_model_size_per_node", 1).build();
+
+        action = new ProfileTransportAction(
+            client().threadPool(),
+            clusterService(),
+            mock(TransportService.class),
+            mock(ActionFilters.class),
+            modelManager,
+            featureManager,
+            cacheProvider,
+            settings
+        );
+
+        DiscoveryNode nodeId = clusterService().localNode();
+        profilesToRetrieve = new HashSet<DetectorProfileName>();
+        profilesToRetrieve.add(DetectorProfileName.MODELS);
+        ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve, true, nodeId);
+        ProfileNodeResponse response = action.nodeOperation(new ProfileNodeRequest(profileRequest));
+        assertEquals(2, response.getModelCount());
+        assertEquals(1, response.getModelProfiles().size());
     }
 }

--- a/src/test/java/org/opensearch/search/aggregations/metrics/CardinalityProfileTests.java
+++ b/src/test/java/org/opensearch/search/aggregations/metrics/CardinalityProfileTests.java
@@ -203,7 +203,8 @@ public class CardinalityProfileTests extends AbstractProfileRunnerTests {
                 shingleSize,
                 0,
                 0,
-                new ArrayList<>()
+                new ArrayList<>(),
+                0
             );
             List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1);
             listener.onResponse(new ProfileResponse(new ClusterName(clusterName), profileNodeResponses, Collections.emptyList()));


### PR DESCRIPTION
### Description
Previously, the number of models we show on the stats/profile API is unbounded. The unbounded models can cause potential memory/network issues if a vast number of models exist. This PR sets an upper bound and makes the bound a dynamic setting. Due to the above change, the models may not be complete, and thus I added a model_count to the stats/profile API to show the actual models present.

This PR also fixed bugs:
First, AnomalyDetectorProfileRunner used a listener instead of delegateListener, which can cause the profile API to return early before collecting all outputs.
Second, I forgot to support the multi-category fields in AnomalyDetectorProfileRunner.profileEntityStats. This PR adds support there. In detail, profile API needs to report total entities. We can use cardinality aggregation for a single-category field. But we cannot do that for multi-category fields as it requires scripting to generate run time fields, which is expensive. We work around the problem by using a composite query to find the first 10_000 buckets. Generally, traversing all buckets/combinations can't be done without visiting all matches, which is costly for data with many entities. Given that it is often enough to have a lower bound of the number of entities, such as "there are at least 10000 entities", the default is set to 10,000. That is, requests will count the total entities up to 10,000.
Third, I fixed a potential null pointer exception in ADTaskManager.

Testing done:
1. e2e workflow tests by verifying profile/stats API shows correct output, and the limit is in effect.
2. backward compatibility tests to make sure the newly added model_count does not cause issues.
3. added unit tests.

Example:

stats API

```
{
	"anomaly_detectors_index_status": "green",
	"anomaly_detection_state_status": "green",
	"single_entity_detector_count": 0,
	"detector_count": 2,
	"multi_entity_detector_count": 0,
	"anomaly_detection_job_index_status": "green",
	"models_checkpoint_index_status": "green",
	"anomaly_results_index_status": "green",
	"nodes": {
		"-rjw2JaoQ5WNrMdWnbd7nA": {
			"ad_execute_request_count": 0,
			"models": [{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319564,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_3S8k6q_DLFhw3hboko3dfw",
					"last_checkpoint_time": 1629222140992,
					"entity": [{
							"name": "host",
							"value": "server_1"
						},
						{
							"name": "service",
							"value": "app_3"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319563,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_oTdcenY1L5bqa6chUxg7xw",
					"last_checkpoint_time": 1629222141596,
					"entity": [{
							"name": "host",
							"value": "server_1"
						},
						{
							"name": "service",
							"value": "app_1"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319563,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_E_uWreoeJpGrAMMaitg8BA",
					"last_checkpoint_time": 1629222141932,
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_4"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319564,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_xm_gKBMKlgymKcoqZyXT8A",
					"last_checkpoint_time": 1629222142183,
					"entity": [{
							"name": "host",
							"value": "server_2"
						},
						{
							"name": "service",
							"value": "app_0"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319562,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_FuqXh0HBXlPhKepOc6JADQ",
					"last_checkpoint_time": 1629222140346,
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_6"
						}
					]
				}
			],
			"ad_canceled_batch_task_count": 0,
			"ad_hc_execute_request_count": 0,
			"ad_hc_execute_failure_count": 0,
			"model_count": 5,
			"ad_execute_failure_count": 0,
			"ad_batch_task_failure_count": 0,
			"ad_total_batch_task_execution_count": 0,
			"ad_executing_batch_task_count": 0
		},
		"T7_YAgWnTIywUdE0OZLVWw": {
			"ad_execute_request_count": 0,
			"models": [{
					"detector_id": "3_cxVXsBPFUfO-zDp2oF",
					"model_type": "rcf",
					"last_used_time": 1629222299971,
					"model_id": "3_cxVXsBPFUfO-zDp2oF_model_rcf_0"
				},
				{
					"detector_id": "3_cxVXsBPFUfO-zDp2oF",
					"model_type": "threshold",
					"last_used_time": 1629222299976,
					"model_id": "3_cxVXsBPFUfO-zDp2oF_model_threshold"
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319564,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_zxSqAWv5Iz19v-Hnqhrwrw",
					"last_checkpoint_time": 1629222141186,
					"entity": [{
							"name": "host",
							"value": "server_1"
						},
						{
							"name": "service",
							"value": "app_5"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319564,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_OnZ4CP-yJF5llO57gUjM6w",
					"last_checkpoint_time": 1629222142119,
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_1"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319563,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_6SvF11RCqf7HYbY56BnFKA",
					"last_checkpoint_time": 1629222140637,
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_2"
						}
					]
				}
			],
			"ad_canceled_batch_task_count": 0,
			"ad_hc_execute_request_count": 0,
			"ad_hc_execute_failure_count": 0,
			"model_count": 6,
			"ad_execute_failure_count": 0,
			"ad_batch_task_failure_count": 0,
			"ad_total_batch_task_execution_count": 0,
			"ad_executing_batch_task_count": 0
		},
		"M7FJpR-uT0u-gdXfu4np3Q": {
			"ad_execute_request_count": 12,
			"models": [{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319570,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_93DEK2PooWlHF6gkh-0hIA",
					"last_checkpoint_time": 1629222143829,
					"entity": [{
							"name": "host",
							"value": "server_2"
						},
						{
							"name": "service",
							"value": "app_4"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319563,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_I0L8K8ktyVnyL59CVFCLVQ",
					"last_checkpoint_time": 1629222141104,
					"entity": [{
							"name": "host",
							"value": "server_1"
						},
						{
							"name": "service",
							"value": "app_4"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319563,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_0uafBokvEYuncGbjP3D2qA",
					"last_checkpoint_time": 1629222141649,
					"entity": [{
							"name": "host",
							"value": "server_2"
						},
						{
							"name": "service",
							"value": "app_5"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319582,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_qo2ANH_NS7Bg8iV4AJpHOw",
					"last_checkpoint_time": 1629222144092,
					"entity": [{
							"name": "host",
							"value": "server_3"
						},
						{
							"name": "service",
							"value": "app_0"
						}
					]
				},
				{
					"detector_id": "4_cyVXsBPFUfO-zDBGpR",
					"model_type": "entity",
					"last_used_time": 1629222319565,
					"model_id": "4_cyVXsBPFUfO-zDBGpR_entity_DOze7d0HnK3K54g3Emk1XA",
					"last_checkpoint_time": 1629222142921,
					"entity": [{
							"name": "host",
							"value": "server_2"
						},
						{
							"name": "service",
							"value": "app_3"
						}
					]
				}
			],
			"ad_canceled_batch_task_count": 0,
			"ad_hc_execute_request_count": 6,
			"ad_hc_execute_failure_count": 2,
			"model_count": 12, <== added
			"ad_execute_failure_count": 3,
			"ad_batch_task_failure_count": 0,
			"ad_total_batch_task_execution_count": 0,
			"ad_executing_batch_task_count": 0
		}
	}
}
```
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
