### PR TITLE
get model id for single entity

### DIFF
--- a/src/main/java/org/opensearch/ad/model/Entity.java
+++ b/src/main/java/org/opensearch/ad/model/Entity.java
@@ -284,7 +284,7 @@ public class Entity implements ToXContentObject, Writeable {
     */
     public static Optional<String> getModelId(String detectorId, SortedMap<String, String> attributes) {
         if (attributes.isEmpty()) {
-            return Optional.empty();
+            return Optional.of(detectorId);
         } else if (attributes.size() == 1) {
             for (Map.Entry<String, String> categoryValuePair : attributes.entrySet()) {
                 // For OpenSearch, the limit of the document ID is 512 bytes.

--- a/src/test/java/org/opensearch/ad/model/EntityTests.java
+++ b/src/test/java/org/opensearch/ad/model/EntityTests.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.ad.model;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import org.opensearch.ad.AbstractADTest;
@@ -30,5 +32,15 @@ public class EntityTests extends AbstractADTest {
         String detectorId = "detectorId";
         Entity entity = Entity.createEntityFromOrderedMap(detectorId, attributes);
         assertEquals("host=server_2,service=app_4", entity.toString());
+    }
+
+    public void test_getModelId_returnId_withNoAttributes() {
+        String detectorId = "id";
+        Entity entity = Entity.createEntityByReordering(detectorId, Collections.emptyMap());
+
+        Optional<String> modelId = entity.getModelId(detectorId);
+
+        assertTrue(modelId.isPresent());
+        assertEquals(detectorId, modelId.get());
     }
 }


### PR DESCRIPTION
Signed-off-by: lai <laijiang@amazon.com>

### Description
This pr returns a model id for a single entity. A single entity has only an id and no additional attributes. The model id is therefore the id itself.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
