### PR TITLE
block updating detector category field

### DIFF
--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -38,6 +38,7 @@ public class CommonErrorMessages {
     public static final String FEATURE_NOT_AVAILABLE_ERR_MSG = "No Feature in current detection window.";
     public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
     public static final String DISABLED_ERR_MSG = "AD plugin is disabled. To enable update plugins.anomaly_detection.enabled to true";
+    public static final String CAN_NOT_CHANGE_CATEGORY_FIELD = "Can't change detector category field";
     // We need this invalid query tag to show proper error message on frontend
     // refer to AD Dashboard code: https://tinyurl.com/8b5n8hat
     public static final String INVALID_SEARCH_QUERY_MSG = "Invalid search query.";

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -694,11 +694,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return categoryFields != null && categoryFields.size() > 0;
     }
 
-    // TODO: remove this
-    public boolean isRealTimeDetector() {
-        return false;
-    }
-
     public boolean invalidShingleSizeRange(Integer shingleSizeToTest) {
         return shingleSizeToTest != null && (shingleSizeToTest < 1 || shingleSizeToTest > AnomalyDetectorSettings.MAX_SHINGLE_SIZE);
     }

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -29,6 +29,7 @@ package org.opensearch.ad.rest.handler;
 import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.opensearch.ad.util.ParseUtils.listEqualsWithoutConsideringOrder;
 import static org.opensearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -38,7 +39,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
@@ -243,7 +243,7 @@ public class IndexAnomalyDetectorActionHandler {
             // If single-category HC changed category field from IP to error type, the AD result page may show both IP and error type
             // in top N entities list. That's confusing.
             // So we decide to block updating detector category field.
-            if (!Objects.equals(existingDetector.getCategoryField(), anomalyDetector.getCategoryField())) {
+            if (!listEqualsWithoutConsideringOrder(existingDetector.getCategoryField(), anomalyDetector.getCategoryField())) {
                 listener
                     .onFailure(new OpenSearchStatusException(CommonErrorMessages.CAN_NOT_CHANGE_CATEGORY_FIELD, RestStatus.BAD_REQUEST));
                 return;

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
@@ -236,32 +237,26 @@ public class IndexAnomalyDetectorActionHandler {
         try (XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             AnomalyDetector existingDetector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
-            // We have separate flows for realtime and historical detector currently. User
-            // can't change detector from realtime to historical, vice versa.
-            if (existingDetector.isRealTimeDetector() != anomalyDetector.isRealTimeDetector()) {
+            // If detector category field changed, frontend may not be able to render AD result for different detector types correctly.
+            // For example, if detector changed from HC to single entity detector, AD result page may show multiple anomaly
+            // result points on the same time point if there are multiple entities have anomaly results.
+            // If single-category HC changed category field from IP to error type, the AD result page may show both IP and error type
+            // in top N entities list. That's confusing.
+            // So we decide to block updating detector category field.
+            if (!Objects.equals(existingDetector.getCategoryField(), anomalyDetector.getCategoryField())) {
                 listener
-                    .onFailure(
-                        new OpenSearchStatusException(
-                            "Can't change detector type between realtime and historical detector",
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
+                    .onFailure(new OpenSearchStatusException(CommonErrorMessages.CAN_NOT_CHANGE_CATEGORY_FIELD, RestStatus.BAD_REQUEST));
                 return;
             }
 
-            if (existingDetector.isRealTimeDetector()) {
-                validateDetector(existingDetector);
-            } else {
-                adTaskManager.getAndExecuteOnLatestDetectorLevelTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, (adTask) -> {
-                    if (adTask.isPresent() && !adTaskManager.isADTaskEnded(adTask.get())) {
-                        // can't update detector if there is AD task running
-                        listener.onFailure(new OpenSearchStatusException("Detector is running", RestStatus.INTERNAL_SERVER_ERROR));
-                    } else {
-                        // TODO: change to validateDetector method when we support HC historical detector
-                        searchAdInputIndices(detectorId);
-                    }
-                }, transportService, true, listener);
-            }
+            adTaskManager.getAndExecuteOnLatestDetectorLevelTask(detectorId, HISTORICAL_DETECTOR_TASK_TYPES, (adTask) -> {
+                if (adTask.isPresent() && !adTaskManager.isADTaskEnded(adTask.get())) {
+                    // can't update detector if there is AD task running
+                    listener.onFailure(new OpenSearchStatusException("Detector is running", RestStatus.INTERNAL_SERVER_ERROR));
+                } else {
+                    validateDetector(existingDetector);
+                }
+            }, transportService, true, listener);
         } catch (IOException e) {
             String message = "Failed to parse anomaly detector " + detectorId;
             logger.error(message, e);

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -879,36 +879,8 @@ public class ADTaskManager {
         }, exception -> listener.onFailure(exception)));
     }
 
-    // TODO: delete this one later
-    public <T> void getDetector(
-        String detectorId,
-        Consumer<AnomalyDetector> realTimeDetectorConsumer,
-        Consumer<AnomalyDetector> historicalDetectorConsumer,
-        ActionListener<T> listener
-    ) {
-        GetRequest getRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
-        client.get(getRequest, ActionListener.wrap(response -> {
-            if (!response.isExists()) {
-                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG, RestStatus.NOT_FOUND));
-                return;
-            }
-            try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-                AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
-
-                if (detector.isRealTimeDetector()) {
-                    // run realtime detector
-                    realTimeDetectorConsumer.accept(detector);
-                } else {
-                    // run historical detector
-                    historicalDetectorConsumer.accept(detector);
-                }
-            } catch (Exception e) {
-                String message = "Failed to start anomaly detector " + detectorId;
-                logger.error(message, e);
-                listener.onFailure(new OpenSearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        }, exception -> listener.onFailure(exception)));
+    private List<String> taskTypeToString(List<ADTaskType> adTaskTypes) {
+        return adTaskTypes.stream().map(type -> type.name()).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -43,10 +43,13 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 
@@ -701,5 +704,25 @@ public final class ParseUtils {
 
     public static <T> boolean isNullOrEmpty(Collection<T> collection) {
         return collection == null || collection.size() == 0;
+    }
+
+    /**
+     * Check if two lists of string equals or not without considering the order.
+     * If the list is null, will consider it equals to empty list.
+     *
+     * @param list1 first list
+     * @param list2 second list
+     * @return true if two list of string equals
+     */
+    public static boolean listEqualsWithoutConsideringOrder(List<String> list1, List<String> list2) {
+        Set<String> set1 = new HashSet<>();
+        Set<String> set2 = new HashSet<>();
+        if (list1 != null) {
+            set1.addAll(list1);
+        }
+        if (list2 != null) {
+            set2.addAll(list2);
+        }
+        return Objects.equals(set1, set2);
     }
 }

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -191,7 +191,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         Map<String, Object> responseMap = entityAsMap(response);
         String id = (String) responseMap.get("_id");
         System.out.println(id);
-        // long version = (long) responseMap.get("_version");
         AnomalyDetector newDetector = new AnomalyDetector(
             id,
             null,

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -181,6 +181,50 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         assertTrue("incorrect version", version > 0);
     }
 
+    public void testUpdateAnomalyDetectorCategoryField() throws Exception {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null);
+        String indexName = detector.getIndices().get(0);
+        TestHelpers.createIndex(client(), indexName, TestHelpers.toHttpEntity("{\"name\": \"test\"}"));
+        Response response = TestHelpers
+            .makeRequest(client(), "POST", TestHelpers.AD_BASE_DETECTORS_URI, ImmutableMap.of(), TestHelpers.toHttpEntity(detector), null);
+        assertEquals("Create anomaly detector failed", RestStatus.CREATED, TestHelpers.restStatus(response));
+        Map<String, Object> responseMap = entityAsMap(response);
+        String id = (String) responseMap.get("_id");
+        System.out.println(id);
+        // long version = (long) responseMap.get("_version");
+        AnomalyDetector newDetector = new AnomalyDetector(
+            id,
+            null,
+            detector.getName(),
+            detector.getDescription(),
+            detector.getTimeField(),
+            detector.getIndices(),
+            detector.getFeatureAttributes(),
+            detector.getFilterQuery(),
+            detector.getDetectionInterval(),
+            detector.getWindowDelay(),
+            detector.getShingleSize(),
+            detector.getUiMetadata(),
+            detector.getSchemaVersion(),
+            detector.getLastUpdateTime(),
+            ImmutableList.of(randomAlphaOfLength(5)),
+            detector.getUser()
+        );
+        Exception ex = expectThrows(
+            ResponseException.class,
+            () -> TestHelpers
+                .makeRequest(
+                    client(),
+                    "PUT",
+                    TestHelpers.AD_BASE_DETECTORS_URI + "/" + id + "?refresh=true",
+                    ImmutableMap.of(),
+                    TestHelpers.toHttpEntity(newDetector),
+                    null
+                )
+        );
+        assertThat(ex.getMessage(), containsString(CommonErrorMessages.CAN_NOT_CHANGE_CATEGORY_FIELD));
+    }
+
     public void testGetAnomalyDetector() throws Exception {
         AnomalyDetector detector = createRandomAnomalyDetector(true, true, client());
 

--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -280,4 +280,19 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         );
         assertEquals("No enabled feature configured", exception.getMessage());
     }
+
+    public void testListEqualsWithoutConsideringOrder() {
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(null, null));
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(null, ImmutableList.of()));
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of(), null));
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of(), ImmutableList.of()));
+
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of("a"), ImmutableList.of("a")));
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of("a", "b"), ImmutableList.of("a", "b")));
+        assertTrue(ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of("b", "a"), ImmutableList.of("a", "b")));
+        assertFalse(ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of("a"), ImmutableList.of("a", "b")));
+        assertFalse(
+            ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5)))
+        );
+    }
 }


### PR DESCRIPTION
### Description
If detector category field changed, frontend may not be able to render AD result for different detector types correctly. For example, if detector changed from HC to single entity detector, AD result page may show multiple anomaly result points on the same time point if there are multiple entities have anomaly results. If single-category HC changed category field from IP to error type, the AD result page may show both IP and error type in top entities list. That's confusing. So we decide to block updating detector category field.
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
