### PR TITLE
Fix flaky test and log level/msgs and enable auto-expand replication

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.x'
+          ref: '1.1'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal

--- a/build.gradle
+++ b/build.gradle
@@ -526,9 +526,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.common.exception.ResourceNotFoundException',
         'org.opensearch.ad.task.ADTaskSlotLimit',
         'org.opensearch.ad.task.ADTaskCacheManager',
-
-        // TODO: to be fixed by kaituo
-        'org.opensearch.ad.indices.AnomalyDetectionIndices'
 ]
 
 jacocoTestCoverageVerification {

--- a/docs/ml-rfc.md
+++ b/docs/ml-rfc.md
@@ -16,7 +16,6 @@ In the meanwhile, we observe more and more machine learning features required to
 * **Machine Learning in SIEM**: SIEM(Security Information and Event Management) is another domain in OpenSearch. Machine learning is also very useful in SIEM to help facilitate security analytics, and it can reduce the effort on sophisticated tasks, enable real time threat analysis and uncover anomalies.
 
 ## Solution
-![](./images/ml-arch.png)
 The solution is to introduce a new Machine Learning Framework inside the OpenSearch cluster, and all ML jobs only run and are managed in it. Existing functionalities: security, node communication, node management, can be leveraged.  The major functionalities in this solution include:
 
 * **Unified Client Interfaces:** clients can use common interfaces for training and inference tasks, and then follow the algorithm interface to give right input parameters, such as input data, hyperparameters.  A client library will be built for easy use.

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
@@ -643,10 +643,11 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
         Long detectorIntervalInMinutes,
         String error
     ) {
+        // Don't need info as this will be printed repeatedly in each interval
         adTaskManager
             .updateLatestRealtimeTask(detectorId, taskState, rcfTotalUpdates, detectorIntervalInMinutes, error, ActionListener.wrap(r -> {
                 log
-                    .info(
+                    .debug(
                         "Updated latest realtime task successfully for detector {}, taskState: {},"
                             + " RCF total update: {}, detectorIntervalInMinutes: {}",
                         detectorId,

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
@@ -230,7 +230,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
             );
             return;
         }
-        indexUtil.updateMappingIfNecessary();
+        indexUtil.update();
         /*
          * We need to handle 3 cases:
          * 1. Detectors created by older versions and never updated. These detectors wont have User details in the

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -346,7 +346,14 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         this.clientUtil = new ClientUtil(settings, client, throttler, threadPool);
         this.indexUtils = new IndexUtils(client, clientUtil, clusterService, indexNameExpressionResolver);
         this.nodeFilter = new DiscoveryNodeFilterer(clusterService);
-        this.anomalyDetectionIndices = new AnomalyDetectionIndices(client, clusterService, threadPool, settings, nodeFilter);
+        this.anomalyDetectionIndices = new AnomalyDetectionIndices(
+            client,
+            clusterService,
+            threadPool,
+            settings,
+            nodeFilter,
+            AnomalyDetectorSettings.MAX_UPDATE_RETRY_TIMES
+        );
         this.clusterService = clusterService;
 
         SingleFeatureLinearUniformInterpolator singleFeatureLinearUniformInterpolator =

--- a/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
@@ -191,7 +191,8 @@ public class CompositeRetriever extends AbstractRetriever {
 
             try {
                 Page page = analyzePage(response);
-                if (totalResults < maxEntities && afterKey != null) {
+                // we can process at most maxEntities entities
+                if (totalResults <= maxEntities && afterKey != null) {
                     updateCompositeAfterKey(response, source);
                     listener.onResponse(page);
                 } else {

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -892,16 +892,6 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
         return indexState.schemaVersion;
     }
 
-    /**
-     *
-     * @param index Index metadata
-     * @return Whether the given index's mapping is up-to-date
-     */
-    public Boolean isMappingUpdated(ADIndex index) {
-        IndexState indexState = this.indexStates.computeIfAbsent(index, IndexState::new);
-        return indexState.mappingUpToDate;
-    }
-
     private void updateJobIndexSettingIfNecessary(IndexState jobIndexState, ActionListener<Void> listener) {
         GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
             .indices(ADIndex.JOB.getIndexName())

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -788,4 +788,9 @@ public final class AnomalyDetectorSettings {
     // such as "there are at least 10000 entities", the default is set to 10,000. That is, requests will count the
     // total entities up to 10,000.
     public static final int MAX_TOTAL_ENTITIES_TO_TRACK = 10_000;
+
+    // ======================================
+    // AD Index setting
+    // ======================================
+    public static int MAX_UPDATE_RETRY_TIMES = 10_000;
 }

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -149,7 +149,7 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         ThreadContext.StoredContext storedContext,
         ActionListener<IndexAnomalyDetectorResponse> listener
     ) {
-        anomalyDetectionIndices.updateMappingIfNecessary();
+        anomalyDetectionIndices.update();
         String detectorId = request.getDetectorID();
         long seqNo = request.getSeqNo();
         long primaryTerm = request.getPrimaryTerm();

--- a/src/test/java/org/opensearch/ad/indices/AnomalyDetectionIndicesTests.java
+++ b/src/test/java/org/opensearch/ad/indices/AnomalyDetectionIndicesTests.java
@@ -37,6 +37,7 @@ import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
 import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.common.settings.Settings;
@@ -72,7 +73,14 @@ public class AnomalyDetectionIndicesTests extends OpenSearchIntegTestCase {
 
         nodeFilter = new DiscoveryNodeFilterer(clusterService());
 
-        indices = new AnomalyDetectionIndices(client(), clusterService(), client().threadPool(), settings, nodeFilter);
+        indices = new AnomalyDetectionIndices(
+            client(),
+            clusterService(),
+            client().threadPool(),
+            settings,
+            nodeFilter,
+            AnomalyDetectorSettings.MAX_UPDATE_RETRY_TIMES
+        );
     }
 
     public void testAnomalyDetectorIndexNotExists() {

--- a/src/test/java/org/opensearch/ad/indices/InitAnomalyDetectionIndicesTests.java
+++ b/src/test/java/org/opensearch/ad/indices/InitAnomalyDetectionIndicesTests.java
@@ -113,7 +113,14 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
         clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().build()).build();
         when(clusterService.state()).thenReturn(clusterState);
 
-        adIndices = new AnomalyDetectionIndices(client, clusterService, threadPool, settings, nodeFilter);
+        adIndices = new AnomalyDetectionIndices(
+            client,
+            clusterService,
+            threadPool,
+            settings,
+            nodeFilter,
+            AnomalyDetectorSettings.MAX_UPDATE_RETRY_TIMES
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/ad/indices/InitAnomalyDetectionIndicesTests.java
+++ b/src/test/java/org/opensearch/ad/indices/InitAnomalyDetectionIndicesTests.java
@@ -175,7 +175,11 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
             }
 
             Settings settings = request.settings();
-            assertThat(settings.get("index.number_of_shards"), equalTo(Integer.toString(numberOfHotNodes)));
+            if (index.equals(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)) {
+                assertThat(settings.get("index.number_of_shards"), equalTo(Integer.toString(1)));
+            } else {
+                assertThat(settings.get("index.number_of_shards"), equalTo(Integer.toString(numberOfHotNodes)));
+            }
 
             ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocation.getArgument(1);
 

--- a/src/test/java/org/opensearch/ad/indices/RolloverTests.java
+++ b/src/test/java/org/opensearch/ad/indices/RolloverTests.java
@@ -111,7 +111,14 @@ public class RolloverTests extends AbstractADTest {
         numberOfNodes = 2;
         when(nodeFilter.getNumberOfEligibleDataNodes()).thenReturn(numberOfNodes);
 
-        adIndices = new AnomalyDetectionIndices(client, clusterService, threadPool, settings, nodeFilter);
+        adIndices = new AnomalyDetectionIndices(
+            client,
+            clusterService,
+            threadPool,
+            settings,
+            nodeFilter,
+            AnomalyDetectorSettings.MAX_UPDATE_RETRY_TIMES
+        );
 
         clusterAdminClient = mock(ClusterAdminClient.class);
         when(adminClient.cluster()).thenReturn(clusterAdminClient);

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -626,8 +626,11 @@ public class MultiEntityResultTests extends AbstractADTest {
                 listener.onResponse(createEmptyResponse());
                 inProgress.countDown();
             } else {
-                listener.onResponse(response);
+                // set firstCalled to be true before returning in case that listener return
+                // and the 2nd call comes in before firstCalled is set to true. Then we
+                // have the 2nd response.
                 firstCalled.set(true);
+                listener.onResponse(response);
                 inProgress.countDown();
             }
             return null;


### PR DESCRIPTION
### Description
This PR (hopefully, as I cannot reproduce the failure locally) fixed flaky tests in MultiEntityResultTests. The tests are flaky, maybe because we expect two pages in our pagination, but we may create more than two pages due to a race condition. Please read comments in MultiEntityResultTests for detail.

This PR also changes the log level of the updating real-time task log from info to debug. We don't need info as Opensearch prints the log repeatedly in each interval. Also, I changed the log message in ADTaskManager to match what the relevant code does.

This PR also enables auto-expand replication for AD job indexes. The job scheduler puts both primary and replica shards in the hash ring. Enabling auto-expand the number of replicas based on the number of data nodes (up to 20) in the cluster so that each node can become a coordinating node. Enabling auto-expanding is useful when customers scale out their cluster so that we can do adaptive scaling accordingly. Also, this PR changed the primary number of shards of the AD job index to 1 as the AD job index is small.

Testing done:
1. Checked that the AD job index setting change is effective and won't negatively impact normal e2e workflow.
 
### Issues Resolved
Flaky test run: https://github.com/opensearch-project/anomaly-detection/pull/196/checks?check_run_id=3487905317
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
