### PR TITLE
[1.1] Bump OpenSearch core to 1.1 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.x'
+          ref: '1.1'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal

--- a/release-notes/opensearch-anomaly-detection.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-anomaly-detection.release-notes-1.1.0.0.md
@@ -23,6 +23,7 @@ Compatible with OpenSearch 1.1.0
 
 ### Infrastructure
 * add deprecated detector type for bwc; add more test cases for historical analysis ([#197](https://github.com/opensearch-project/anomaly-detection/pull/197))
+* Bump OpenSearch core to 1.1 in CI ([#212](https://github.com/opensearch-project/anomaly-detection/pull/212))
 
 ### Documentation
 * Add themed logo to README ([#134](https://github.com/opensearch-project/anomaly-detection/pull/134))


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Bumps the OpenSearch core branch from `1.x` to `1.0` in the CI workflow.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
