### PR TITLE
Update versions for build dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Run AD Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests ..."
-          ./gradlew bwcTestSuite -Dtests.security.manager=false
+          ./gradlew bwcTestSuite -Dtests.security.manager=false -Dbuild.snapshot=false
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: 'main'
+          ref: '1.1'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout job-scheduler
         uses: actions/checkout@v2
         with:
-          ref: 'main'
+          ref: '1.1'
           repository: 'opensearch-project/job-scheduler'
           path: job-scheduler
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
           ref: '1.1'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils
@@ -47,7 +47,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
 
       # dependencies: job-scheduler
       - name: Checkout job-scheduler
@@ -59,11 +59,11 @@ jobs:
 
       - name: Build job-scheduler
         working-directory: ./job-scheduler
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT
+          ./gradlew assemble -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd
@@ -72,32 +72,32 @@ jobs:
           cp ./build/distributions/*.zip ../src/test/resources/job-scheduler
           echo "Copied ./build/distributions/*.zip to ../src/test/resources/job-scheduler ..."
           ls ../src/test/resources/job-scheduler
-          echo "Creating ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
-          mkdir -p ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
-          echo "Copying ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
+          echo "Creating ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0 ..."
+          mkdir -p ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0
+          echo "Copying ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0 ..."
           ls ./build/distributions/
-          cp ./build/distributions/*.zip ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
-          echo "Copied ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT ..."
-          ls ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0-SNAPSHOT
+          cp ./build/distributions/*.zip ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0
+          echo "Copied ./build/distributions/*.zip to ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0 ..."
+          ls ../src/test/resources/org/opensearch/ad/bwc/job-scheduler/1.1.0.0
 
       - name: Assemble anomaly-detection
         run: |
-          ./gradlew assemble -Dopensearch.version=1.1.0-SNAPSHOT
-          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
-          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT
-          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
+          ./gradlew assemble -Dbuild.snapshot=false
+          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0 ..."
+          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0
+          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0 ..."
           ls ./build/distributions/
-          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT
-          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT ..."
-          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0-SNAPSHOT    
+          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0
+          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0 ..."
+          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.1.0.0
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
+          ./gradlew build
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
+          ./gradlew publishToMavenLocal
 
       - name: Multi Nodes Integration Testing
         run: |
@@ -106,8 +106,8 @@ jobs:
       - name: Pull and Run Docker
         run: |
           plugin=`ls build/distributions/*.zip`
-          version=1.1.0-SNAPSHOT
-          plugin_version=1.1.0.0-SNAPSHOT
+          version=1.1.0
+          plugin_version=1.1.0.0
           echo Using OpenSearch $version with AD $plugin_version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Assemble job-scheduler
         working-directory: ./job-scheduler
         run: |
-          ./gradlew assemble -Dbuild.snapshot=false
+          ./gradlew assemble -Dopensearch.version=1.1.0 -Dbuild.snapshot=false
           echo "Creating ../src/test/resources/job-scheduler ..."
           mkdir -p ../src/test/resources/job-scheduler
           pwd

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
         // 1.1.0 -> 1.1.0.0, and 1.1.0-SNAPSHOT -> 1.1.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)

--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,7 @@ String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2","1.1.0-SNAPSHOT"]
+            versions = ["7.10.2","1.1.0"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Now that core OpenSearch has `1.1` branch cut, we should switch from using the snapshot artifacts (with version `1.1.0-SNAPSHOT`) to regular artifacts (with version `1.1.0`), for both core and other dependencies (job-scheduler, common-utils). We add the `build.snapshots=false` arg for all locally published artifacts, so that we have version consistency in `build.gradle`, where all dependency versions are now `1.1.0`.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
