### PR TITLE
Deal with backward-compatibility in Checkpoint

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/HybridThresholdingModel.java
+++ b/src/main/java/org/opensearch/ad/ml/HybridThresholdingModel.java
@@ -26,12 +26,16 @@
 
 package org.opensearch.ad.ml;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.math3.special.Erf;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.JsonAdapter;
 import com.yahoo.sketches.kll.KllFloatsSketch;
+import com.yahoo.sketches.kll.KllFloatsSketchIterator;
 
 /**
  * A model for converting raw anomaly scores into anomaly grades.
@@ -255,7 +259,7 @@ public class HybridThresholdingModel implements ThresholdingModel {
           raw anomaly scores are positive and non-zero.
         */
         final double maxScorePvalue = computeLogNormalCdf(maxScore, mu, sigma);
-        final double pvalueStep = maxScorePvalue / ((double) numLogNormalQuantiles + 1.0);
+        final double pvalueStep = maxScorePvalue / (numLogNormalQuantiles + 1.0);
         for (double pvalue = pvalueStep; pvalue < maxScorePvalue; pvalue += pvalueStep) {
             double currentScore = computeLogNormalQuantile(pvalue, mu, sigma);
             update(currentScore);
@@ -363,12 +367,22 @@ public class HybridThresholdingModel implements ThresholdingModel {
      */
     private void downsample() {
         KllFloatsSketch downsampledQuantileSketch = new KllFloatsSketch(quantileSketch.getK());
-        double pvalueStep = 1.0 / ((double) downsampleNumSamples - 1.0);
+        double pvalueStep = 1.0 / (downsampleNumSamples - 1.0);
         for (double pvalue = 0.0; pvalue < 1.0; pvalue += pvalueStep) {
             float score = quantileSketch.getQuantile(pvalue);
             downsampledQuantileSketch.update(score);
         }
         downsampledQuantileSketch.update((float) maxScore);
         this.quantileSketch = downsampledQuantileSketch;
+    }
+
+    @Override
+    public List<Double> extractScores() {
+        KllFloatsSketchIterator iter = quantileSketch.iterator();
+        List<Double> scores = new ArrayList<>();
+        while (iter.next()) {
+            scores.add((double) iter.getValue());
+        }
+        return scores;
     }
 }

--- a/src/main/java/org/opensearch/ad/ml/ThresholdingModel.java
+++ b/src/main/java/org/opensearch/ad/ml/ThresholdingModel.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.ad.ml;
 
+import java.util.List;
+
 /**
  * A model for converting raw anomaly scores into anomaly grades.
  *
@@ -72,4 +74,10 @@ public interface ThresholdingModel {
      * @return  the model confidence
      */
     double confidence();
+
+    /**
+     * Extract scores
+     * @return the extract scores
+     */
+    List<Double> extractScores();
 }

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -1,4 +1,5 @@
 grant {
+  // required by Jackson/Gson to (se)deserializing checkpoints
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";


### PR DESCRIPTION
Note: since there are inter-file references, I split a big PR into multiple smaller PRs based on files to save time (1.1 cut off is due this Friday). The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big PR in the end and merge once after all review PRs get approved. For the complete code, check https://github.com/kaituo/anomaly-detection-1/tree/thresholdRCF2

### Description
As part of integrating with ThresholdedRandomCutForest, this PR deals with backward-compatibility in Checkpoint.  Specifically, if ThresholdedRandomCutForest is present at the checkpoint, we load it directly.  Otherwise, we need to look for RandomCutForest and Kll threshold models and convert them to ThresholdedRandomCutForest. The model id is still the same so that we can still find previous checkpoints. For single-stream detectors, the model is detector_id _model_rcf_0.  For HCAD, the model id is detector_id _model_entity_value.

Testing done:
1. Manual BWC testing.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
