### PR TITLE
tune AD batch task and HC running entity setting based on performance test result

### DIFF
--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -464,7 +464,7 @@ public final class AnomalyDetectorSettings {
     public static final Setting<Integer> MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS = Setting
         .intSetting(
             "plugins.anomaly_detection.max_running_entities_per_detector_for_historical_analysis",
-            2,
+            10,
             1,
             1000,
             Setting.Property.NodeScope,

--- a/src/main/java/org/opensearch/ad/settings/LegacyOpenDistroAnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/LegacyOpenDistroAnomalyDetectorSettings.java
@@ -281,7 +281,7 @@ public class LegacyOpenDistroAnomalyDetectorSettings {
     public static final Setting<Integer> MAX_BATCH_TASK_PER_NODE = Setting
         .intSetting(
             "opendistro.anomaly_detection.max_batch_task_per_node",
-            2,
+            10,
             1,
             100,
             Setting.Property.NodeScope,


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Current batch task setting and HC max running entities settings are too conservative as we set these quite small numbers before performance testing. 
After performance testing, we tune these settings to a general number which can speed up historical analysis and will not cause too much load.
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
