### PR TITLE
[Backport to 1.1]fix failed UT caused by dynamic setting update (#234)

### DIFF
--- a/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
+++ b/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
@@ -320,7 +320,7 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_batch_task_per_node", 78).build();
         assertEquals(AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE.get(settings), Integer.valueOf(78));
-        assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE.get(settings), Integer.valueOf(2));
+        assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE.get(settings), Integer.valueOf(10));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_old_ad_task_docs_per_detector", 77).build();
         assertEquals(AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.get(settings), Integer.valueOf(77));

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -173,6 +173,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
     private DiscoveryNode node2;
 
     private int maxRunningEntities;
+    private int maxBatchTaskPerNode;
 
     private String historicalTaskId = "test_historical_task_id";
     private String realtimeTaskId = "test_realtime_task_id";
@@ -236,6 +237,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
             MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS
         );
 
+        maxBatchTaskPerNode = MAX_BATCH_TASK_PER_NODE.get(settings);
         clusterService = spy(new ClusterService(settings, clusterSettings, null));
 
         client = mock(Client.class);
@@ -459,7 +461,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         );
         setupHashRingWithSameLocalADVersionNodes();
 
-        setupTaskSlots(0, 2, 2, 2);
+        setupTaskSlots(0, maxBatchTaskPerNode, maxBatchTaskPerNode, maxBatchTaskPerNode);
 
         adTaskManager
             .checkTaskSlots(adTask, adTask.getDetector(), detectionDateRange, randomUser(), ADTaskAction.START, transportService, listener);
@@ -485,7 +487,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         setupSearchTopEntities(4);
         setupHashRingWithSameLocalADVersionNodes();
 
-        setupTaskSlots(0, 2, 2, 1);
+        setupTaskSlots(0, maxBatchTaskPerNode, maxBatchTaskPerNode, maxBatchTaskPerNode - 1);
 
         adTaskManager
             .checkTaskSlots(adTask, adTask.getDetector(), detectionDateRange, randomUser(), ADTaskAction.START, transportService, listener);
@@ -540,7 +542,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         setupSearchTopEntities(4);
         setupHashRingWithSameLocalADVersionNodes();
 
-        setupTaskSlots(0, 2, 2, 1);
+        setupTaskSlots(0, maxBatchTaskPerNode, maxBatchTaskPerNode, maxBatchTaskPerNode - 1);
 
         adTaskManager
             .checkTaskSlots(


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Backport #234 to 1.1

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
