### PR TITLE
Add javadoc utf8 encoding support in AD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,13 @@ plugins {
 }
 
 tasks.withType(JavaCompile) {
-	options.encoding = "UTF-8"
+    options.encoding = "UTF-8"
 }
 tasks.withType(Test) {
-	systemProperty "file.encoding", "UTF-8"
+    systemProperty "file.encoding", "UTF-8"
+}
+tasks.withType(Javadoc) {
+    options.encoding = 'UTF-8'
 }
 
 repositories {


### PR DESCRIPTION
### Description
Add javadoc utf8 encoding support in AD0
 
### Issues Resolved
#244
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
