### PR TITLE
Fix flaky test  CheckpointDaoTests.testMapperFailure

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
@@ -541,6 +541,9 @@ public class CheckpointDao {
                     }
 
                     Optional<ThresholdedRandomCutForest> convertedTRCF = convertToTRCF(rcf, threshold);
+                    // if checkpoint is corrupted (e.g., some unexpected checkpoint when we missed
+                    // the mark in backward compatibility), we are not gonna load the model part
+                    // the model will have to use live data to initialize
                     if (convertedTRCF.isPresent()) {
                         trcf = convertedTRCF.get();
                     }

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
@@ -234,7 +234,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
                     Map<String, Object> source = checkpoint.toIndexSource(state);
                     String modelId = state.getModelId();
 
-                    // the model state is bloated, skip
+                    // the model state is bloated or empty (empty samples and models), skip
                     if (source == null || source.isEmpty() || Strings.isEmpty(modelId)) {
                         continue;
                     }

--- a/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
+++ b/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
@@ -766,7 +766,8 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             anomalyRate
         );
 
-        ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
+        // make sure sample size is not 0 otherwise sample size won't be written to checkpoint
+        ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).sampleSize(1).build());
         String json = checkpointDao.toCheckpoint(state.getModel(), modelId).get();
         assertEquals(null, JsonDeserializer.getChildNode(json, CheckpointDao.ENTITY_TRCF));
         assertTrue(null != JsonDeserializer.getChildNode(json, CheckpointDao.ENTITY_SAMPLE));


### PR DESCRIPTION
### Description
The following failure happens because the sample size is randomly generated.  If the size is 0, the assertion about a non-empty sample checkpoint would be false. This PR (hopefully) fixed the test by using a non-zero sample size.

CI: https://tinyurl.com/6fbf7nae

org.opensearch.ad.ml.CheckpointDaoTests > testMapperFailure FAILED
    java.lang.AssertionError
        at __randomizedtesting.SeedInfo.seed([3870AE3C6CD8C213:61F4DC7F9D698B03]:0)
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at org.opensearch.ad.ml.CheckpointDaoTests.testMapperFailure(CheckpointDaoTests.java:772)

Testing done:
1. gradle build
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
