### PR TITLE
[Backport to 1.x] fix null AD version of non-data-type node (#253)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -508,6 +508,9 @@ List<String> jacocoExclusions = [
 
         // TODO: unified flow caused coverage drop
         'org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction',
+        // TODO: fix unstable code coverage caused by null NodeClient issue
+        // https://github.com/opensearch-project/anomaly-detection/issues/241
+        'org.opensearch.ad.task.ADBatchTaskRunner'
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -735,7 +735,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 featureManager,
                 modelManager,
                 stateManager,
-                new ADClusterEventListener(clusterService, hashRing, nodeFilter),
+                new ADClusterEventListener(clusterService, hashRing),
                 adCircuitBreakerService,
                 adStats,
                 new MasterEventListener(clusterService, threadPool, client, getClock(), clientUtil, nodeFilter),

--- a/src/main/java/org/opensearch/ad/cluster/ADNodeInfo.java
+++ b/src/main/java/org/opensearch/ad/cluster/ADNodeInfo.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.cluster;
+
+import org.opensearch.Version;
+
+/**
+ * This class records AD version of nodes and whether node is eligible data node to run AD.
+ */
+public class ADNodeInfo {
+    // AD plugin version
+    private Version adVersion;
+    // Is node eligible to run AD.
+    private boolean isEligibleDataNode;
+
+    public ADNodeInfo(Version version, boolean isEligibleDataNode) {
+        this.adVersion = version;
+        this.isEligibleDataNode = isEligibleDataNode;
+    }
+
+    public Version getAdVersion() {
+        return adVersion;
+    }
+
+    public boolean isEligibleDataNode() {
+        return isEligibleDataNode;
+    }
+
+    @Override
+    public String toString() {
+        return "ADNodeInfo{" + "version=" + adVersion + ", isEligibleDataNode=" + isEligibleDataNode + '}';
+    }
+}

--- a/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
@@ -573,4 +573,47 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
                 latestHCTaskRunTime
             );
     }
+
+    @Override
+    public String toString() {
+        return "ADTaskProfile{"
+            + "adTask="
+            + adTask
+            + ", shingleSize="
+            + shingleSize
+            + ", rcfTotalUpdates="
+            + rcfTotalUpdates
+            + ", thresholdModelTrained="
+            + thresholdModelTrained
+            + ", thresholdModelTrainingDataSize="
+            + thresholdModelTrainingDataSize
+            + ", modelSizeInBytes="
+            + modelSizeInBytes
+            + ", nodeId='"
+            + nodeId
+            + '\''
+            + ", taskId='"
+            + taskId
+            + '\''
+            + ", adTaskType='"
+            + adTaskType
+            + '\''
+            + ", detectorTaskSlots="
+            + detectorTaskSlots
+            + ", totalEntitiesInited="
+            + totalEntitiesInited
+            + ", totalEntitiesCount="
+            + totalEntitiesCount
+            + ", pendingEntitiesCount="
+            + pendingEntitiesCount
+            + ", runningEntitiesCount="
+            + runningEntitiesCount
+            + ", runningEntities="
+            + runningEntities
+            + ", latestHCTaskRunTime="
+            + latestHCTaskRunTime
+            + ", entityTaskProfiles="
+            + entityTaskProfiles
+            + '}';
+    }
 }

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -2695,7 +2695,7 @@ public class ADTaskManager {
                     adTaskCacheManager.cleanExpiredHCBatchTaskRunStates();
                 }
             );
-
+        logger.debug("Local AD task profile of detector {}: {}", detectorId, detectorTaskProfile);
         return detectorTaskProfile;
     }
 

--- a/src/main/java/org/opensearch/ad/util/DiscoveryNodeFilterer.java
+++ b/src/main/java/org/opensearch/ad/util/DiscoveryNodeFilterer.java
@@ -71,6 +71,15 @@ public class DiscoveryNodeFilterer {
         return eligibleNodes.toArray(new DiscoveryNode[0]);
     }
 
+    public DiscoveryNode[] getAllNodes() {
+        ClusterState state = this.clusterService.state();
+        final List<DiscoveryNode> nodes = new ArrayList<>();
+        for (DiscoveryNode node : state.nodes()) {
+            nodes.add(node);
+        }
+        return nodes.toArray(new DiscoveryNode[0]);
+    }
+
     public boolean isEligibleDataNode(DiscoveryNode node) {
         return eligibleNodeFilter.test(node);
     }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -331,6 +331,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
         request.setJsonEntity(Strings.toString(builder));
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        Thread.sleep(2000); // sleep some time to resolve flaky test
     }
 
     public Response getDetectorProfile(String detectorId, boolean all, String customizedProfile, RestClient client) throws IOException {

--- a/src/test/java/org/opensearch/ad/cluster/HashRingTests.java
+++ b/src/test/java/org/opensearch/ad/cluster/HashRingTests.java
@@ -240,6 +240,7 @@ public class HashRingTests extends ADUnitTestCase {
         setupClusterAdminClient(localNode, newNode, warmNode);
 
         doReturn(new DiscoveryNode[] { localNode, newNode }).when(nodeFilter).getEligibleDataNodes();
+        doReturn(new DiscoveryNode[] { localNode, newNode, warmNode }).when(nodeFilter).getAllNodes();
         return addedNodes;
     }
 

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -67,6 +67,7 @@ import com.google.gson.JsonParser;
 public class DetectionResultEvalutationIT extends ODFERestTestCase {
     protected static final Logger LOG = (Logger) LogManager.getLogger(DetectionResultEvalutationIT.class);
 
+    // TODO: fix flaky test, sometimes this assert will fail "assertTrue(precision >= minPrecision);"
     public void testDataset() throws Exception {
         // TODO: this test case will run for a much longer time and timeout with security enabled
         if (!isHttps()) {

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -366,6 +366,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getUser()
         );
 
+        Thread.sleep(2000); // sleep some time before updating to avoid flaky test
         TestHelpers
             .makeRequest(
                 client(),


### PR DESCRIPTION
* fix null AD version of non-data-type node
* fix flaky test

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Backport PR #253 to 1.x
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
