### PR TITLE
Fixed a bug when door keepers unnecessarily reset their states

### DIFF
--- a/src/main/java/org/opensearch/ad/caching/DoorKeeper.java
+++ b/src/main/java/org/opensearch/ad/caching/DoorKeeper.java
@@ -72,6 +72,7 @@ public class DoorKeeper implements MaintenanceState, ExpiringState {
 
     @Override
     public boolean expired(Duration stateTtl) {
-        return expired(lastAccessTime, stateTtl, clock.instant());
+        // ignore stateTtl since we have customized resetInterval
+        return expired(lastAccessTime, resetInterval, clock.instant());
     }
 }

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -156,7 +156,12 @@ public class PriorityCache implements EntityCache {
                 );
 
             // first hit, ignore
-            if (doorKeeper.mightContain(modelId) == false) {
+            // since door keeper may get reset during maintenance, it is possible
+            // the entity is still active even though door keeper has no record of
+            // this model Id. We have to call isActive method to make sure. Otherwise,
+            // the entity might miss an anomaly result every 60 intervals due to door keeper
+            // reset.
+            if (!doorKeeper.mightContain(modelId) && !isActive(detectorId, modelId)) {
                 doorKeeper.put(modelId);
                 return null;
             }
@@ -627,7 +632,8 @@ public class PriorityCache implements EntityCache {
             doorKeepers.entrySet().stream().forEach(doorKeeperEntry -> {
                 String detectorId = doorKeeperEntry.getKey();
                 DoorKeeper doorKeeper = doorKeeperEntry.getValue();
-                if (doorKeeper.expired(modelTtl)) {
+                // doorKeeper has its own state ttl
+                if (doorKeeper.expired(null)) {
                     doorKeepers.remove(detectorId);
                 } else {
                     doorKeeper.maintenance();
@@ -771,14 +777,18 @@ public class PriorityCache implements EntityCache {
     @Override
     public long getLastActiveMs(String detectorId, String entityModelId) {
         CacheBuffer cacheBuffer = activeEnities.get(detectorId);
+        long lastUsedMs = -1;
         if (cacheBuffer != null) {
-            return cacheBuffer.getLastUsedTime(entityModelId);
+            lastUsedMs = cacheBuffer.getLastUsedTime(entityModelId);
+            if (lastUsedMs != -1) {
+                return lastUsedMs;
+            }
         }
         ModelState<EntityModel> stateInActive = inActiveEntities.getIfPresent(entityModelId);
         if (stateInActive != null) {
-            return stateInActive.getLastUsedTime().getEpochSecond();
+            lastUsedMs = stateInActive.getLastUsedTime().toEpochMilli();
         }
-        return -1L;
+        return lastUsedMs;
     }
 
     @Override

--- a/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -77,7 +78,6 @@ public class PriorityCacheTests extends AbstractCacheTest {
     double[] point;
     int dedicatedCacheSize;
 
-    @SuppressWarnings("unchecked")
     @Override
     @Before
     public void setUp() throws Exception {
@@ -631,5 +631,25 @@ public class PriorityCacheTests extends AbstractCacheTest {
         Pair<List<Entity>, List<Entity>> selectedAndOther = cacheProvider.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
         assertEquals(0, selectedAndOther.getLeft().size());
         assertEquals(0, selectedAndOther.getRight().size());
+    }
+
+    // test that detector interval is more than 1 hour that maintenance is called before
+    // the next get method
+    public void testLongDetectorInterval() {
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(1000));
+        when(detector.getDetectionIntervalDuration()).thenReturn(Duration.ofHours(12));
+        String modelId = entity1.getModelId(detectorId).get();
+        // record last access time 1000
+        cacheProvider.get(modelId, detector);
+        assertEquals(-1, cacheProvider.getLastActiveMs(detectorId, modelId));
+        // 2 hour = 7200 seconds have passed
+        long currentTimeEpoch = 8200;
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(currentTimeEpoch));
+        // door keeper should not be expired since we reclaim space every 60 intervals
+        cacheProvider.maintenance();
+        // door keeper still has the record and won't blocks entity state being created
+        cacheProvider.get(modelId, detector);
+        // * 1000 to convert to milliseconds
+        assertEquals(currentTimeEpoch * 1000, cacheProvider.getLastActiveMs(detectorId, modelId));
     }
 }


### PR DESCRIPTION
### Description
In many workloads, and especially in heavy tailed workloads, unpopular items account for a considerable portion of all accesses. This phenomenon implies that if we model each entity appearing, the majority of the models are assigned to items that are not likely to appear
more than once. Hence, to further reduce the size of model memory usage and reduce the number of unnecessary cold starts, we have used the Doorkeeper mechanism that enables us to avoid allocating models to most tail objects.

Door keepers reset their states every hour in the maintenance window.  It is fine to do so when a detector's interval is less than an hour.  But when a detector's interval is more than one hour, door keepers will keep forgetting that it has seen the detector' entities and refrained from admitting these entities into the cache memory.

This PR fixed the bug by resetting door keepers' states every 60 detector intervals instead of every hour. If an entity does not arrive in the past 60 detector intervals and it is not already in the cache, the detector's door keeper treats it as a first timer and does not include the entity in the cache.

Testing done:
1. added a unit test to reproduce the issue.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
