### PR TITLE
Fix task cache expiration bug

### DIFF
--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -2120,12 +2120,12 @@ public class ADTaskManager {
                                 oldCoordinatingNode,
                                 detectorId
                             );
-                        adTaskCacheManager.initRealtimeTaskCache(detectorId, detector.getDetectorIntervalInMinutes());
+                        adTaskCacheManager.initRealtimeTaskCache(detectorId, detector.getDetectorIntervalInMilliseconds());
                         listener.onResponse(true);
                     }, listener);
                 } else {
                     logger.info("Init realtime task cache for detector {}", detectorId);
-                    adTaskCacheManager.initRealtimeTaskCache(detectorId, detector.getDetectorIntervalInMinutes());
+                    adTaskCacheManager.initRealtimeTaskCache(detectorId, detector.getDetectorIntervalInMilliseconds());
                     listener.onResponse(true);
                 }
             }, transportService, false, listener);


### PR DESCRIPTION
### Description
ADTaskCacheManager.initRealtimeTaskCache expects an interval in milliseconds.  But we passed an interval in minutes in a couple of places.  This PR fixed the bug.

Testing done:
1. Manually tested the scenario: before the fix, hourly cron clears the cache no matter what; after the fix, the expiration time is honored.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
