### PR TITLE
Support custom result indices in multi-category filtering API

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Strings;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -40,6 +39,7 @@ import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.AnomalyResultBucket;
 import org.opensearch.ad.transport.handler.ADSearchHandler;
 import org.opensearch.client.Client;
+import org.opensearch.common.Strings;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
@@ -309,8 +309,9 @@ public class SearchTopAnomalyResultTransportAction extends
             SearchRequest searchRequest = generateSearchRequest(request);
 
             // Adding search over any custom result indices
-            String customResultIndex = Strings.trimToNull(getAdResponse.getDetector().getResultIndex());
-            if (customResultIndex != null) {
+            String rawCustomResultIndex = getAdResponse.getDetector().getResultIndex();
+            String customResultIndex = rawCustomResultIndex == null ? null : rawCustomResultIndex.trim();
+            if (!Strings.isNullOrEmpty(customResultIndex)) {
                 searchRequest.indices(defaultIndex, customResultIndex);
             }
 

--- a/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
@@ -437,7 +437,7 @@ public class SearchTopAnomalyResultTransportAction extends
                     aggBuilder.aggregateAfter(afterKey);
 
                     // Searching more, using an updated source with an after_key
-                    SearchRequest searchRequest = customResultIndex == null
+                    SearchRequest searchRequest = Strings.isNullOrEmpty(customResultIndex)
                         ? new SearchRequest().indices(defaultIndex)
                         : new SearchRequest().indices(defaultIndex, customResultIndex);
                     searchHandler.search(searchRequest.source(searchSourceBuilder), this);


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Adds support for searching over detectors that have a specified custom result index (see #276). When retrieving detector info, checks for any set custom result index, and adds it to the list of indices to search over. 

Confirmed it works for custom & non-custom-result-index detectors, confirmed pagination works
 
### Issues Resolved
closes #280 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
