### PR TITLE
fixed unit test by changing name of method to most up to date

### DIFF
--- a/src/test/java/org/opensearch/ad/indices/CustomIndexTests.java
+++ b/src/test/java/org/opensearch/ad/indices/CustomIndexTests.java
@@ -236,7 +236,7 @@ public class CustomIndexTests extends AbstractADTest {
         when(clusterService.state())
             .thenReturn(ClusterState.builder(clusterName).metadata(Metadata.builder().put(indexMetadata1, true).build()).build());
 
-        assertTrue(adIndices.isValidResultIndex(customIndexName));
+        assertTrue(adIndices.isValidResultIndexMapping(customIndexName));
     }
 
     /**
@@ -269,7 +269,7 @@ public class CustomIndexTests extends AbstractADTest {
         when(clusterService.state())
             .thenReturn(ClusterState.builder(clusterName).metadata(Metadata.builder().put(indexMetadata1, true).build()).build());
 
-        assertTrue(adIndices.isValidResultIndex(customIndexName));
+        assertTrue(adIndices.isValidResultIndexMapping(customIndexName));
     }
 
     /**
@@ -301,7 +301,7 @@ public class CustomIndexTests extends AbstractADTest {
         when(clusterService.state())
             .thenReturn(ClusterState.builder(clusterName).metadata(Metadata.builder().put(indexMetadata1, true).build()).build());
 
-        assertTrue(adIndices.isValidResultIndex(customIndexName));
+        assertTrue(adIndices.isValidResultIndexMapping(customIndexName));
     }
 
     public void testInCorrectMapping() throws IOException {
@@ -336,7 +336,7 @@ public class CustomIndexTests extends AbstractADTest {
         when(clusterService.state())
             .thenReturn(ClusterState.builder(clusterName).metadata(Metadata.builder().put(indexMetadata1, true).build()).build());
 
-        assertTrue(!adIndices.isValidResultIndex(customIndexName));
+        assertTrue(!adIndices.isValidResultIndexMapping(customIndexName));
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
 * Latest commit was merged before rebasing with main which led to merging issues. On latest commit the name of method `AnomalyDetectionIndices.isValidResultIndex` changed to `AnomalyDetectionIndices.isValidResultIndexMapping` inorder to more accuretly reflect what function was doing. However since it wasn't rebased with main before merging new unit tests were added with the old name and they were never changed.
 * This PR changes these unit test naming 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
