### PR TITLE
Fix bug of not parsing Instant in multi-category API

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
@@ -487,8 +487,8 @@ public class SearchTopAnomalyResultTransportAction extends
         // Adding the date range and anomaly grade filters (needed regardless of real-time or historical)
         RangeQueryBuilder dateRangeFilter = QueryBuilders
             .rangeQuery(AnomalyResult.DATA_END_TIME_FIELD)
-            .gte(request.getStartTime())
-            .lte(request.getEndTime());
+            .gte(request.getStartTime().toEpochMilli())
+            .lte(request.getEndTime().toEpochMilli());
         RangeQueryBuilder anomalyGradeFilter = QueryBuilders.rangeQuery(AnomalyResult.ANOMALY_GRADE_FIELD).gt(0);
         query.filter(dateRangeFilter).filter(anomalyGradeFilter);
 

--- a/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
@@ -179,7 +179,7 @@ public class SearchTopAnomalyResultTransportAction extends
     private static final OrderType DEFAULT_ORDER_TYPE = OrderType.SEVERITY;
     private static final int DEFAULT_SIZE = 10;
     private static final int MAX_SIZE = 1000;
-    private static final String index = ALL_AD_RESULTS_INDEX_PATTERN;
+    private static final String defaultIndex = ALL_AD_RESULTS_INDEX_PATTERN;
     private static final String COUNT_FIELD = "_count";
     private static final String BUCKET_SORT_FIELD = "bucket_sort";
     private static final String MULTI_BUCKETS_FIELD = "multi_buckets";
@@ -308,6 +308,13 @@ public class SearchTopAnomalyResultTransportAction extends
             // Generating the search request which will contain the generated query
             SearchRequest searchRequest = generateSearchRequest(request);
 
+            // Adding search over any custom result indices
+            String rawCustomResultIndex = getAdResponse.getDetector().getResultIndex();
+            String customResultIndex = rawCustomResultIndex == null ? null : rawCustomResultIndex.trim();
+            if (!Strings.isNullOrEmpty(customResultIndex)) {
+                searchRequest.indices(defaultIndex, customResultIndex);
+            }
+
             // Utilizing the existing search() from SearchHandler to handle security permissions. Both user role
             // and backend role filtering is handled in there, and any error will be propagated up and
             // returned as a failure in this Listener.
@@ -321,7 +328,8 @@ public class SearchTopAnomalyResultTransportAction extends
                         searchRequest.source(),
                         clock.millis() + TOP_ANOMALY_RESULT_TIMEOUT_IN_MILLIS,
                         request.getSize(),
-                        orderType
+                        orderType,
+                        customResultIndex
                     )
                 );
 
@@ -347,13 +355,15 @@ public class SearchTopAnomalyResultTransportAction extends
         private long expirationEpochMs;
         private int maxResults;
         private PriorityQueue<AnomalyResultBucket> topResultsHeap;
+        private String customResultIndex;
 
         TopAnomalyResultListener(
             ActionListener<SearchTopAnomalyResultResponse> listener,
             SearchSourceBuilder searchSourceBuilder,
             long expirationEpochMs,
             int maxResults,
-            OrderType orderType
+            OrderType orderType,
+            String customResultIndex
         ) {
             this.listener = listener;
             this.searchSourceBuilder = searchSourceBuilder;
@@ -370,6 +380,7 @@ public class SearchTopAnomalyResultTransportAction extends
                     }
                 }
             });
+            this.customResultIndex = customResultIndex;
         }
 
         @Override
@@ -426,7 +437,10 @@ public class SearchTopAnomalyResultTransportAction extends
                     aggBuilder.aggregateAfter(afterKey);
 
                     // Searching more, using an updated source with an after_key
-                    searchHandler.search(new SearchRequest().indices(index).source(searchSourceBuilder), this);
+                    SearchRequest searchRequest = Strings.isNullOrEmpty(customResultIndex)
+                        ? new SearchRequest().indices(defaultIndex)
+                        : new SearchRequest().indices(defaultIndex, customResultIndex);
+                    searchHandler.search(searchRequest.source(searchSourceBuilder), this);
                 }
 
             } catch (Exception e) {
@@ -448,7 +462,7 @@ public class SearchTopAnomalyResultTransportAction extends
      * @return the SearchRequest to pass to the SearchHandler
      */
     private SearchRequest generateSearchRequest(SearchTopAnomalyResultRequest request) {
-        SearchRequest searchRequest = new SearchRequest().indices(index);
+        SearchRequest searchRequest = new SearchRequest().indices(defaultIndex);
         QueryBuilder query = generateQuery(request);
         AggregationBuilder aggregation = generateAggregation(request);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query).aggregation(aggregation);


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen ohltyler@amazon.com

### Description
Fixes a bug where the range query can fail when parsing `java.time.Instant`s in OpenSearch's `RangeQueryBuilder`, when constructing the internal query used to fetch anomaly results.

Error seen: `can not write type [class java.time.Instant]`

The class can't be parsed properly. To fix, we convert the Instant to a `long` using `toEpochMilli()`.

Similar issue: https://github.com/opendistro-for-elasticsearch/index-management/pull/373
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
