### PR TITLE
Fix Instant parsing bug in multi category filtering API

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchTopAnomalyResultTransportAction.java
@@ -473,8 +473,8 @@ public class SearchTopAnomalyResultTransportAction extends
         // Adding the date range and anomaly grade filters (needed regardless of real-time or historical)
         RangeQueryBuilder dateRangeFilter = QueryBuilders
             .rangeQuery(AnomalyResult.DATA_END_TIME_FIELD)
-            .gte(request.getStartTime())
-            .lte(request.getEndTime());
+            .gte(request.getStartTime().toEpochMilli())
+            .lte(request.getEndTime().toEpochMilli());
         RangeQueryBuilder anomalyGradeFilter = QueryBuilders.rangeQuery(AnomalyResult.ANOMALY_GRADE_FIELD).gt(0);
         query.filter(dateRangeFilter).filter(anomalyGradeFilter);
 


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen ohltyler@amazon.com

### Description
Fixes a bug where the range query can fail when parsing `java.time.Instant`s in OpenSearch's `RangeQueryBuilder`, when constructing the internal query used to fetch anomaly results.

Error seen: `can not write type [class java.time.Instant]`

The class can't be parsed properly. To fix, we convert the Instant to a `long` using `toEpochMilli()`.

Similar issue: https://github.com/opendistro-for-elasticsearch/index-management/pull/373
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

