### PR TITLE
support only searching results in custom result index

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
@@ -91,7 +91,7 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
         String[] concreteIndices = indexNameExpressionResolver
             .concreteIndexNames(clusterService.state(), IndicesOptions.lenientExpandOpen(), indices);
         if (concreteIndices == null || concreteIndices.length == 0) {
-            // No custom result indices found, just search default result index
+            // No result indices found, will throw exception
             listener.onFailure(new IllegalArgumentException("No indices found"));
             return;
         }
@@ -120,6 +120,8 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
             try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
                 // Search result indices of all detectors. User may create index with same prefix of custom result index
                 // which not used for AD, so we should avoid searching extra indices which not used by anomaly detectors.
+                // Variable used in lambda expression should be final or effectively final, so copy to a final boolean and
+                // use the final boolean in lambda below.
                 boolean finalOnlyQueryCustomResultIndex = onlyQueryCustomResultIndex;
                 client.search(searchResultIndex, ActionListener.wrap(allResultIndicesResponse -> {
                     Aggregations aggregations = allResultIndicesResponse.getAggregations();

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -297,7 +297,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getLastUpdateTime(),
                 null,
                 detector.getUser(),
-                null
+                detector.getResultIndex()
             ),
             detectorJob,
             historicalAdTask,
@@ -448,6 +448,40 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             );
     }
 
+    public Response createSearchRole(String role, String index) throws IOException {
+        return TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/_opendistro/_security/api/roles/" + role,
+                null,
+                TestHelpers
+                    .toHttpEntity(
+                        "{\n"
+                            + "\"cluster_permissions\": [\n"
+                            + "],\n"
+                            + "\"index_permissions\": [\n"
+                            + "{\n"
+                            + "\"index_patterns\": [\n"
+                            + "\""
+                            + index
+                            + "\"\n"
+                            + "],\n"
+                            + "\"dls\": \"\",\n"
+                            + "\"fls\": [],\n"
+                            + "\"masked_fields\": [],\n"
+                            + "\"allowed_actions\": [\n"
+                            + "\"indices:data/read/search\"\n"
+                            + "]\n"
+                            + "}\n"
+                            + "],\n"
+                            + "\"tenant_permissions\": []\n"
+                            + "}"
+                    ),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
+    }
+
     public Response deleteUser(String user) throws IOException {
         return TestHelpers
             .makeRequest(
@@ -508,6 +542,29 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                     ),
                 ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
             );
+    }
+
+    protected AnomalyDetector cloneDetector(AnomalyDetector anomalyDetector, String resultIndex) {
+        AnomalyDetector detector = new AnomalyDetector(
+            null,
+            null,
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(10),
+            anomalyDetector.getTimeField(),
+            anomalyDetector.getIndices(),
+            anomalyDetector.getFeatureAttributes(),
+            anomalyDetector.getFilterQuery(),
+            anomalyDetector.getDetectionInterval(),
+            anomalyDetector.getWindowDelay(),
+            anomalyDetector.getShingleSize(),
+            anomalyDetector.getUiMetadata(),
+            anomalyDetector.getSchemaVersion(),
+            Instant.now(),
+            anomalyDetector.getCategoryField(),
+            null,
+            resultIndex
+        );
+        return detector;
     }
 
 }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.common.exception.ADValidationException;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.ToXContent;
@@ -43,6 +44,26 @@ public class AnomalyDetectorTests extends AbstractADTest {
         detectorString = detectorString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
+    }
+
+    public void testParseAnomalyDetectorWithCustomIndex() throws IOException {
+        String resultIndex = CommonName.CUSTOM_RESULT_INDEX_PREFIX + "test";
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(
+                ImmutableList.of(TestHelpers.randomFeature()),
+                randomAlphaOfLength(5),
+                randomIntBetween(1, 5),
+                randomAlphaOfLength(5),
+                ImmutableList.of(randomAlphaOfLength(5)),
+                resultIndex
+            );
+        String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        LOG.info(detectorString);
+        detectorString = detectorString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals("Parsing result index doesn't work", resultIndex, parsedDetector.getResultIndex());
         assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
     }
 

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.TestHelpers.matchAllRequest;
+import static org.opensearch.ad.indices.AnomalyDetectionIndices.ALL_AD_RESULTS_INDEX_PATTERN;
 
 import java.io.IOException;
 
@@ -28,7 +29,9 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
         createADResultIndex();
         String adResultId = createADResult(TestHelpers.randomAnomalyDetectResult());
 
-        SearchResponse searchResponse = client().execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest()).actionGet(10000);
+        SearchResponse searchResponse = client()
+            .execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest().indices(ALL_AD_RESULTS_INDEX_PATTERN))
+            .actionGet(10000);
         assertEquals(1, searchResponse.getInternalResponse().hits().getTotalHits().value);
 
         assertEquals(adResultId, searchResponse.getInternalResponse().hits().getAt(0).getId());
@@ -37,8 +40,12 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
     @Test
     public void testNoIndex() {
         deleteIndexIfExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
-        SearchResponse searchResponse = client().execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest()).actionGet(10000);
-        assertEquals(0, searchResponse.getInternalResponse().hits().getTotalHits().value);
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> client()
+                .execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest().indices(ALL_AD_RESULTS_INDEX_PATTERN))
+                .actionGet(10000)
+        );
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
In current implementation, we always query AD results from default index. Actually detector result page doesn't need to query default index if detector is using custom result index. And for API users, they may need to query AD results from custom result index only as well.

This PR supports searching AD result from custom result index only if user specify "?only_query_custom_result_index=true" when call search result API.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
