### PR TITLE
[Backport to 1.x] wait for some time to get semaphore when set HC detector task as done (#300)

### DIFF
--- a/src/main/java/org/opensearch/ad/task/ADHCBatchTaskCache.java
+++ b/src/main/java/org/opensearch/ad/task/ADHCBatchTaskCache.java
@@ -18,6 +18,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -104,8 +105,8 @@ public class ADHCBatchTaskCache {
         return topEntityCount;
     }
 
-    public boolean tryAcquireTaskUpdatingSemaphore() {
-        return detectorTaskUpdatingSemaphore.tryAcquire();
+    public boolean tryAcquireTaskUpdatingSemaphore(long timeoutInMillis) throws InterruptedException {
+        return detectorTaskUpdatingSemaphore.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS);
     }
 
     public void releaseTaskUpdatingSemaphore() {

--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -970,13 +970,21 @@ public class ADTaskCacheManager {
 
     /**
      * Try to get semaphore to update detector task.
+     *
+     * If the timeout is less than or equal to zero, will not wait at all to get 1 permit.
+     * If permit is available, will acquire 1 permit and return true immediately. If no permit,
+     * will wait for other thread release. If no permit available until timeout elapses, will
+     * return false.
+     *
      * @param detectorId detector id
+     * @param timeoutInMillis timeout in milliseconds to wait for a permit, zero or negative means don't wait at all
      * @return true if can get semaphore
+     * @throws InterruptedException if the current thread is interrupted
      */
-    public boolean tryAcquireTaskUpdatingSemaphore(String detectorId) {
+    public boolean tryAcquireTaskUpdatingSemaphore(String detectorId, long timeoutInMillis) throws InterruptedException {
         ADHCBatchTaskCache taskCache = hcBatchTaskCaches.get(detectorId);
         if (taskCache != null) {
-            return taskCache.tryAcquireTaskUpdatingSemaphore();
+            return taskCache.tryAcquireTaskUpdatingSemaphore(timeoutInMillis);
         }
         return false;
     }

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultResponse.java
@@ -62,7 +62,13 @@ public class AnomalyResultResponse extends ActionResponse implements ToXContentO
     private Double threshold;
 
     // used when returning an error/exception or empty result
-    public AnomalyResultResponse(List<FeatureData> features, String error, Long rcfTotalUpdates, Long detectorIntervalInMinutes) {
+    public AnomalyResultResponse(
+        List<FeatureData> features,
+        String error,
+        Long rcfTotalUpdates,
+        Long detectorIntervalInMinutes,
+        Boolean isHCDetector
+    ) {
         this(
             Double.NaN,
             Double.NaN,
@@ -71,7 +77,7 @@ public class AnomalyResultResponse extends ActionResponse implements ToXContentO
             error,
             rcfTotalUpdates,
             detectorIntervalInMinutes,
-            null,
+            isHCDetector,
             null,
             null,
             null,

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -507,7 +507,13 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
             } else {
                 listener
                     .onResponse(
-                        new AnomalyResultResponse(new ArrayList<FeatureData>(), null, null, anomalyDetector.getDetectorIntervalInMinutes())
+                        new AnomalyResultResponse(
+                            new ArrayList<FeatureData>(),
+                            null,
+                            null,
+                            anomalyDetector.getDetectorIntervalInMinutes(),
+                            true
+                        )
                     );
             }
             return;
@@ -568,13 +574,19 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                     LOG.debug("No data in current detection window between {} and {} for {}", dataStartTime, dataEndTime, adID);
                     listener
                         .onResponse(
-                            new AnomalyResultResponse(new ArrayList<FeatureData>(), "No data in current detection window", null, null)
+                            new AnomalyResultResponse(
+                                new ArrayList<FeatureData>(),
+                                "No data in current detection window",
+                                null,
+                                null,
+                                false
+                            )
                         );
                 } else {
                     LOG.debug("Return at least current feature value between {} and {} for {}", dataStartTime, dataEndTime, adID);
                     listener
                         .onResponse(
-                            new AnomalyResultResponse(featureInResponse, "No full shingle in current detection window", null, null)
+                            new AnomalyResultResponse(featureInResponse, "No full shingle in current detection window", null, null, false)
                         );
                 }
                 return;

--- a/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
@@ -385,12 +385,12 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
         assertFalse(adTaskCacheManager.hasDeletedDetectorTask());
     }
 
-    public void testAcquireTaskUpdatingSemaphore() throws IOException {
+    public void testAcquireTaskUpdatingSemaphore() throws IOException, InterruptedException {
         String detectorId = randomAlphaOfLength(10);
         ADTask adTask = TestHelpers.randomAdTask(ADTaskType.HISTORICAL_HC_DETECTOR);
         adTaskCacheManager.add(detectorId, adTask);
-        assertTrue(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
-        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
+        assertTrue(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
+        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
     }
 
     public void testGetTasksOfDetectorWithNonExistingDetectorId() throws IOException {
@@ -653,18 +653,18 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
         assertEquals(newState, adTaskCacheManager.getDetectorTaskState(detectorId, detectorTaskId));
     }
 
-    public void testReleaseTaskUpdatingSemaphore() throws IOException {
+    public void testReleaseTaskUpdatingSemaphore() throws IOException, InterruptedException {
         String detectorId = randomAlphaOfLength(5);
         ADTask adTask = TestHelpers.randomAdTask(ADTaskType.HISTORICAL_HC_DETECTOR);
-        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
+        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
         adTaskCacheManager.releaseTaskUpdatingSemaphore(detectorId);
-        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
+        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
 
         adTaskCacheManager.add(detectorId, adTask);
-        assertTrue(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
-        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
+        assertTrue(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
+        assertFalse(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
         adTaskCacheManager.releaseTaskUpdatingSemaphore(detectorId);
-        assertTrue(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId));
+        assertTrue(adTaskCacheManager.tryAcquireTaskUpdatingSemaphore(detectorId, 0));
     }
 
     public void testCleanExpiredHCBatchTaskRunStates() {

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -792,6 +792,13 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         ActionListener<AnomalyDetectorJobResponse> actionListener = mock(ActionListener.class);
         ADTask adTask = randomAdTask();
         String entity = randomAlphaOfLength(5);
+        ExecutorService executeService = mock(ExecutorService.class);
+        when(threadPool.executor(anyString())).thenReturn(executeService);
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executeService).execute(any());
         when(adTaskCacheManager.removeRunningEntity(anyString(), anyString())).thenReturn(true);
         when(adTaskCacheManager.getPendingEntityCount(anyString())).thenReturn(randomIntBetween(1, 10));
         adTaskManager.removeStaleRunningEntity(adTask, entity, transportService, actionListener);


### PR DESCRIPTION
… (#300)

* wait for some time to get semaphore when set HC detector task as done

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

* fix HC detector stay on initializing forever bug

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
