### PR TITLE
added switch case for general settings issues

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -191,6 +191,7 @@ public class ValidateAnomalyDetectorTransportAction extends
             case SHINGLE_SIZE_FIELD:
             case WINDOW_DELAY:
             case RESULT_INDEX:
+            case GENERAL_SETTINGS:
             case INDICES:
                 errorMessage = originalErrorMessage;
                 break;


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Added General Settings switch case in `ValidateAnomalyDetectorTransportAction`. This case not existing led to a bug where message for max number of HC or single entity detectors weren't shown. 
![image](https://user-images.githubusercontent.com/67072393/141200758-63d26836-38d1-4f63-b2b8-51854714af3c.png)

Error message on frontend now displays correct message instead of blank. 

![Screen Shot 2021-11-10 at 2 02 26 PM](https://user-images.githubusercontent.com/67072393/141200978-f3d4a88b-f42e-4c7d-b4eb-96d207b23728.png)

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
