### PR TITLE
don't throw exception if no result indices found when search both default and custom result index

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
@@ -99,7 +99,7 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
         // return an empty SearchResponse. This search looks unnecessary, but this can make sure the
         // detector list page show all detectors correctly. The other solution is to catch errors from
         // frontend when search anomaly results to make sure frontend won't crash. Check this Github issue:
-        // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/153
+        // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/154
 
         Set<String> customResultIndices = new HashSet<>();
         if (concreteIndices != null) {

--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
@@ -93,6 +93,13 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
         // If concreteIndices is null or empty, don't throw exception. Detector list page will search both
         // default and custom result indices to get anomaly of last 24 hours. If throw exception, detector
         // list page will throw error and won't show any detector.
+        // If a cluster has no custom result indices, and some new non-custom-result-detector that hasn't
+        // finished one interval (where no default result index exists), then no result indices found. We
+        // will still search ".opendistro-anomaly-results*" (even these default indices don't exist) to
+        // return an empty SearchResponse. This search looks unnecessary, but this can make sure the
+        // detector list page show all detectors correctly. The other solution is to catch errors from
+        // frontend when search anomaly results to make sure frontend won't crash. Check this Github issue:
+        // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/153
 
         Set<String> customResultIndices = new HashSet<>();
         if (concreteIndices != null) {

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -40,12 +40,10 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
     @Test
     public void testNoIndex() {
         deleteIndexIfExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> client()
-                .execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest().indices(ALL_AD_RESULTS_INDEX_PATTERN))
-                .actionGet(10000)
-        );
+        SearchResponse searchResponse = client()
+            .execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest().indices(ALL_AD_RESULTS_INDEX_PATTERN))
+            .actionGet(10000);
+        assertEquals(0, searchResponse.getHits().getTotalHits().value);
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Detector list page will search both default and custom result indices. For a new cluster, if no default/custom result created yet, the detector list page will not show any detector as the backend will throw "No indices found" exception.

This PR removed that exception, just search all default result indices and will return empty SearchResponse to frontend. 


 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
