### PR TITLE
[Backport to 1.2] don't throw exception if no result indices found when search both def…

### DIFF
--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -40,12 +40,10 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
     @Test
     public void testNoIndex() {
         deleteIndexIfExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> client()
-                .execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest().indices(ALL_AD_RESULTS_INDEX_PATTERN))
-                .actionGet(10000)
-        );
+        SearchResponse searchResponse = client()
+            .execute(SearchAnomalyResultAction.INSTANCE, matchAllRequest().indices(ALL_AD_RESULTS_INDEX_PATTERN))
+            .actionGet(10000);
+        assertEquals(0, searchResponse.getHits().getTotalHits().value);
     }
 
 }


### PR DESCRIPTION
…ault and custom result index (#322)

* don't throw exception if no result indices found when search both default and custom result index

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

* add more comments

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

* fix issue link

Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
