### PR TITLE
[Backport 1.x] Dropping securemock depedency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,6 @@ configurations.all {
 
 configurations {
     testCompile {
-        exclude group: 'org.elasticsearch', module: 'securemock'
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 }


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Backporting #331 to 1.x
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
