### PR TITLE
Adding more unit tests for validation API and some model classes

### DIFF
--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -73,8 +73,10 @@ public class CommonErrorMessages {
     public static String HISTORICAL_ANALYSIS_CANCELLED = "Historical analysis cancelled by user";
     public static String HC_DETECTOR_TASK_IS_UPDATING = "HC detector task is updating";
     public static String NEGATIVE_TIME_CONFIGURATION = "should be non-negative";
+    public static String INVALID_TIME_CONFIGURATION_UNITS = "Timezone %s is not supported";
     public static String INVALID_DETECTOR_NAME =
         "Valid characters for detector name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
+    public static String DUPLICATE_FEATURE_AGGREGATION_NAMES = "Detector has duplicate feature aggregation query names: ";
 
     public static String FAIL_TO_GET_DETECTOR = "Fail to get detector";
     public static String FAIL_TO_GET_DETECTOR_INFO = "Fail to get detector info";

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -13,6 +13,7 @@ package org.opensearch.ad.constant;
 
 import static org.opensearch.ad.constant.CommonName.CUSTOM_RESULT_INDEX_PREFIX;
 import static org.opensearch.ad.model.AnomalyDetector.MAX_RESULT_INDEX_NAME_SIZE;
+import static org.opensearch.ad.rest.handler.AbstractAnomalyDetectorActionHandler.MAX_DETECTOR_NAME_SIZE;
 
 import java.util.Locale;
 
@@ -98,4 +99,7 @@ public class CommonErrorMessages {
     public static String INVALID_CHAR_IN_RESULT_INDEX_NAME =
         "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";
     public static String INVALID_RESULT_INDEX_MAPPING = "Result index mapping is not correct for index: ";
+    public static String INVALID_DETECTOR_NAME_SIZE = "Name should be shortened. The maximum limit is "
+        + MAX_DETECTOR_NAME_SIZE
+        + " characters.";
 }

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -52,7 +52,7 @@ public class CommonErrorMessages {
     public static final String BUG_RESPONSE = "We might have bugs.";
     public static final String INDEX_NOT_FOUND = "index does not exist";
     public static final String NOT_EXISTENT_VALIDATION_TYPE = "The given validation type doesn't exist";
-    public static final String NON_SUPPORTED_PROFILE_TYPE = "Unsupported profile types";
+    public static final String UNSUPPORTED_PROFILE_TYPE = "Unsupported profile types";
 
     private static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT = "We can have only %d categorical field/s.";
 

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -75,7 +75,7 @@ public class CommonErrorMessages {
     public static String HISTORICAL_ANALYSIS_CANCELLED = "Historical analysis cancelled by user";
     public static String HC_DETECTOR_TASK_IS_UPDATING = "HC detector task is updating";
     public static String NEGATIVE_TIME_CONFIGURATION = "should be non-negative";
-    public static String INVALID_TIME_CONFIGURATION_UNITS = "Timezone %s is not supported";
+    public static String INVALID_TIME_CONFIGURATION_UNITS = "Time unit %s is not supported";
     public static String INVALID_DETECTOR_NAME =
         "Valid characters for detector name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
     public static String DUPLICATE_FEATURE_AGGREGATION_NAMES = "Detector has duplicate feature aggregation query names: ";

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -52,6 +52,7 @@ public class CommonErrorMessages {
     public static final String BUG_RESPONSE = "We might have bugs.";
     public static final String INDEX_NOT_FOUND = "index does not exist";
     public static final String NOT_EXISTENT_VALIDATION_TYPE = "The given validation type doesn't exist";
+    public static final String NON_SUPPORTED_PROFILE_TYPE = "Unsupported profile types";
 
     private static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT = "We can have only %d categorical field/s.";
 

--- a/src/main/java/org/opensearch/ad/model/ADEntityTaskProfile.java
+++ b/src/main/java/org/opensearch/ad/model/ADEntityTaskProfile.java
@@ -14,6 +14,7 @@ package org.opensearch.ad.model;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -268,5 +269,39 @@ public class ADEntityTaskProfile implements ToXContentObject, Writeable {
 
     public void setAdTaskType(String adTaskType) {
         this.adTaskType = adTaskType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ADEntityTaskProfile that = (ADEntityTaskProfile) o;
+        return Objects.equals(shingleSize, that.shingleSize)
+            && Objects.equals(rcfTotalUpdates, that.rcfTotalUpdates)
+            && Objects.equals(thresholdModelTrained, that.thresholdModelTrained)
+            && Objects.equals(thresholdModelTrainingDataSize, that.thresholdModelTrainingDataSize)
+            && Objects.equals(modelSizeInBytes, that.modelSizeInBytes)
+            && Objects.equals(nodeId, that.nodeId)
+            && Objects.equals(taskId, that.taskId)
+            && Objects.equals(adTaskType, that.adTaskType)
+            && Objects.equals(entity, that.entity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects
+            .hash(
+                shingleSize,
+                rcfTotalUpdates,
+                thresholdModelTrained,
+                thresholdModelTrainingDataSize,
+                modelSizeInBytes,
+                nodeId,
+                entity,
+                taskId,
+                adTaskType
+            );
     }
 }

--- a/src/main/java/org/opensearch/ad/model/DetectorProfileName.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorProfileName.java
@@ -69,7 +69,7 @@ public enum DetectorProfileName implements Name {
             case CommonName.AD_TASK:
                 return AD_TASK;
             default:
-                throw new IllegalArgumentException(CommonErrorMessages.NON_SUPPORTED_PROFILE_TYPE);
+                throw new IllegalArgumentException(CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/model/DetectorProfileName.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorProfileName.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.opensearch.ad.Name;
+import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 
 public enum DetectorProfileName implements Name {
@@ -68,7 +69,7 @@ public enum DetectorProfileName implements Name {
             case CommonName.AD_TASK:
                 return AD_TASK;
             default:
-                throw new IllegalArgumentException("Unsupported profile types");
+                throw new IllegalArgumentException(CommonErrorMessages.NON_SUPPORTED_PROFILE_TYPE);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
+++ b/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
@@ -46,7 +46,7 @@ public class IntervalTimeConfiguration extends TimeConfiguration {
             );
         }
         if (!SUPPORTED_UNITS.contains(unit)) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Timezone %s is not supported", unit));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIME_CONFIGURATION_UNITS, unit));
         }
         this.interval = interval;
         this.unit = unit;

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -119,7 +119,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
     public static final String FEATURE_WITH_INVALID_QUERY_MSG = FEATURE_INVALID_MSG_PREFIX + " causing a runtime exception: ";
     public static final String UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG =
         "Feature has an unknown exception caught while executing the feature query: ";
-
+    public static final String VALIDATION_FEATURE_FAILURE = "Validation failed for feature(s) of detector %s";
     public static final String NAME_REGEX = "[a-zA-Z0-9._-]+";
     public static final Integer MAX_DETECTOR_NAME_SIZE = 64;
 
@@ -303,7 +303,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             listener
                 .onFailure(
                     new ADValidationException(
-                        "Name should be shortened. The maximum limit is " + MAX_DETECTOR_NAME_SIZE + " characters.",
+                        CommonErrorMessages.INVALID_DETECTOR_NAME_SIZE,
                         DetectorValidationIssueType.NAME,
                         ValidationAspect.DETECTOR
                     )
@@ -816,7 +816,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             new MultiResponsesDelegateActionListener<MergeableList<Optional<double[]>>>(
                 validateFeatureQueriesListener,
                 anomalyDetector.getFeatureAttributes().size(),
-                String.format(Locale.ROOT, "Validation failed for feature(s) of detector %s", anomalyDetector.getName()),
+                String.format(Locale.ROOT, VALIDATION_FEATURE_FAILURE, anomalyDetector.getName()),
                 false
             );
 

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -405,7 +405,6 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query).size(0).timeout(requestTimeout);
 
             SearchRequest searchRequest = new SearchRequest(ANOMALY_DETECTORS_INDEX).source(searchSourceBuilder);
-
             client
                 .search(
                     searchRequest,

--- a/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
@@ -27,6 +27,7 @@ import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
+import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.common.Strings;
@@ -151,7 +152,7 @@ public final class RestHandlerUtils {
             errorMsgBuilder.append(". ");
         }
         if (duplicateFeatureAggNames.size() > 0) {
-            errorMsgBuilder.append("Detector has duplicate feature aggregation query names: ");
+            errorMsgBuilder.append(CommonErrorMessages.DUPLICATE_FEATURE_AGGREGATION_NAMES);
             errorMsgBuilder.append(String.join(", ", duplicateFeatureAggNames));
         }
         return errorMsgBuilder.toString();

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -710,7 +710,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void testValidateAnomalyDetectorWithDuplicateFeatureAggregationNames() throws IOException {
+    public void testCreateAnomalyDetectorWithDuplicateFeatureAggregationNames() throws IOException {
         Feature featureOne = TestHelpers.randomFeature("featureName", "test-1");
         Feature featureTwo = TestHelpers.randomFeature("featureNameTwo", "test-1");
         AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(ImmutableList.of(featureOne, featureTwo));

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -728,16 +728,8 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
                 ActionListener<Response> listener
             ) {
                 try {
-                    if (action.equals(SearchAction.INSTANCE)) {
-                        listener.onResponse((Response) detectorResponse);
-                    } else {
-                        // we need to put the test in the same package of GetFieldMappingsResponse since its constructor is package private
-                        GetFieldMappingsResponse response = new GetFieldMappingsResponse(
-                            TestHelpers.createFieldMappings(detector.getIndices().get(0), "A", TEXT_FIELD_TYPE)
-                        );
-                        listener.onResponse((Response) response);
-                    }
-                } catch (IOException e) {
+                    listener.onResponse((Response) detectorResponse);
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
@@ -121,7 +121,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     @SuppressWarnings("unchecked")
     public void testValidateMoreThanThousandSingleEntityDetectorLimit() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
-        int totalHits = 1001;
+        int totalHits = maxSingleEntityAnomalyDetectors + 1;
         when(mockResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
@@ -152,7 +152,6 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
             searchFeatureDao,
             ValidationAspect.DETECTOR.getName()
         );
-
         handler.start();
         ArgumentCaptor<Exception> response = ArgumentCaptor.forClass(Exception.class);
         verify(clientMock, never()).execute(eq(GetMappingsAction.INSTANCE), any(), any());
@@ -172,7 +171,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     public void testValidateMoreThanTenMultiEntityDetectorsLimit() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
 
-        int totalHits = 11;
+        int totalHits = maxMultiEntityAnomalyDetectors + 1;
 
         when(mockResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
 
@@ -204,7 +203,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
             xContentRegistry(),
             null,
             searchFeatureDao,
-            ValidationAspect.DETECTOR.getName()
+            ""
         );
         handler.start();
 

--- a/src/test/java/org/opensearch/ad/ADIntegTestCase.java
+++ b/src/test/java/org/opensearch/ad/ADIntegTestCase.java
@@ -136,6 +136,10 @@ public abstract class ADIntegTestCase extends OpenSearchIntegTestCase {
         createIndex(CommonName.ANOMALY_RESULT_INDEX_ALIAS, AnomalyDetectionIndices.getAnomalyResultMappings());
     }
 
+    public void createCustomADResultIndex(String indexName) throws IOException {
+        createIndex(indexName, AnomalyDetectionIndices.getAnomalyResultMappings());
+    }
+
     public void createDetectionStateIndex() throws IOException {
         createIndex(CommonName.DETECTION_STATE_INDEX, AnomalyDetectionIndices.getDetectionStateMappings());
     }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -182,10 +182,6 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
         return TestHelpers.makeRequest(client, "DELETE", TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId, ImmutableMap.of(), "", null);
     }
 
-    // protected Response validateAnomalyDetector(AnomalyDetector detector, RestClient client) {
-    //
-    // }
-
     protected Response previewAnomalyDetector(String detectorId, RestClient client, AnomalyDetectorExecutionInput input)
         throws IOException {
         return TestHelpers

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -182,6 +182,10 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
         return TestHelpers.makeRequest(client, "DELETE", TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId, ImmutableMap.of(), "", null);
     }
 
+    // protected Response validateAnomalyDetector(AnomalyDetector detector, RestClient client) {
+    //
+    // }
+
     protected Response previewAnomalyDetector(String detectorId, RestClient client, AnomalyDetectorExecutionInput input)
         throws IOException {
         return TestHelpers

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -1443,8 +1443,17 @@ public class TestHelpers {
         DetectorValidationIssue issue = new DetectorValidationIssue(
             ValidationAspect.DETECTOR,
             DetectorValidationIssueType.NAME,
+            randomAlphaOfLength(5)
+        );
+        return issue;
+    }
+
+    public static DetectorValidationIssue randomDetectorValidationIssueWithSubIssues(Map<String, String> subIssues) {
+        DetectorValidationIssue issue = new DetectorValidationIssue(
+            ValidationAspect.DETECTOR,
+            DetectorValidationIssueType.NAME,
             randomAlphaOfLength(5),
-            null,
+            subIssues,
             null
         );
         return issue;

--- a/src/test/java/org/opensearch/ad/model/ADEntityTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/ADEntityTaskProfileTests.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.model;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.TreeMap;
+
+import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+public class ADEntityTaskProfileTests extends OpenSearchSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testADEntityTaskProfileSerialization() throws IOException {
+        ADEntityTaskProfile entityTask = new ADEntityTaskProfile(
+            1,
+            23L,
+            false,
+            1,
+            2L,
+            "1234",
+            null,
+            "4321",
+            ADTaskType.HISTORICAL_HC_ENTITY.name()
+        );
+        BytesStreamOutput output = new BytesStreamOutput();
+        entityTask.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ADEntityTaskProfile parsedEntityTask = new ADEntityTaskProfile(input);
+        assertEquals(entityTask, parsedEntityTask);
+    }
+
+    public void testParseADEntityTaskProfile() throws IOException {
+        TreeMap<String, String> attributes = new TreeMap<>();
+        String name1 = "host";
+        String val1 = "server_2";
+        String name2 = "service";
+        String val2 = "app_4";
+        attributes.put(name1, val1);
+        attributes.put(name2, val2);
+        Entity entity = Entity.createEntityFromOrderedMap(attributes);
+        ADEntityTaskProfile entityTask = new ADEntityTaskProfile(
+            1,
+            23L,
+            false,
+            1,
+            2L,
+            "1234",
+            entity,
+            "4321",
+            ADTaskType.HISTORICAL_HC_ENTITY.name()
+        );
+        String adEntityTaskProfileString = TestHelpers
+            .xContentBuilderToString(entityTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADEntityTaskProfile parsedEntityTask = ADEntityTaskProfile.parse(TestHelpers.parser(adEntityTaskProfileString));
+        assertEquals(entityTask, parsedEntityTask);
+    }
+
+    public void testParseADEntityTaskProfileWithNullEntity() throws IOException {
+        ADEntityTaskProfile entityTask = new ADEntityTaskProfile(
+            1,
+            23L,
+            false,
+            1,
+            2L,
+            "1234",
+            null,
+            "4321",
+            ADTaskType.HISTORICAL_HC_ENTITY.name()
+        );
+        String adEntityTaskProfileString = TestHelpers
+            .xContentBuilderToString(entityTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADEntityTaskProfile parsedEntityTask = ADEntityTaskProfile.parse(TestHelpers.parser(adEntityTaskProfileString));
+        assertEquals(entityTask, parsedEntityTask);
+    }
+}

--- a/src/test/java/org/opensearch/ad/model/ADEntityTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/ADEntityTaskProfileTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.ad.model;

--- a/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
@@ -7,6 +7,7 @@ package org.opensearch.ad.model;
 
 import java.io.IOException;
 import java.time.Instant;
+
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;

--- a/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
@@ -1,39 +1,17 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.ad.model;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collection;
-
-import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.TestHelpers;
-import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.xcontent.ToXContent;
-import org.opensearch.plugins.Plugin;
-import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
 public class DetectorInternalStateTests extends OpenSearchSingleNodeTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
-    }
-
-    @Override
-    protected NamedWriteableRegistry writableRegistry() {
-        return getInstanceFromNode(NamedWriteableRegistry.class);
-    }
 
     public void testToXContentDetectorInternalState() throws IOException {
         DetectorInternalState internalState = new DetectorInternalState.Builder()

--- a/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.model;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+
+import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+public class DetectorInternalStateTests extends OpenSearchSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testToXContentDetectorInternalState() throws IOException {
+        DetectorInternalState internalState = new DetectorInternalState.Builder()
+            .lastUpdateTime(Instant.ofEpochMilli(100L))
+            .error("error-test")
+            .build();
+        String internalStateString = TestHelpers
+            .xContentBuilderToString(internalState.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        DetectorInternalState parsedInternalState = DetectorInternalState.parse(TestHelpers.parser(internalStateString));
+        assertEquals(internalState, parsedInternalState);
+    }
+}

--- a/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.xcontent.XContentParser;
@@ -82,5 +84,11 @@ public class DetectorProfileTests extends OpenSearchTestCase {
         assertEquals(detectorProfile.getCoordinatingNode(), parsedMap.get("coordinating_node"));
         assertEquals(detectorProfile.getState().toString(), parsedMap.get("state"));
         assertTrue(parsedMap.get("models").toString().contains(detectorProfile.getModelProfile()[0].getModelId()));
+    }
+
+    public void testDetectorProfileName() throws IllegalArgumentException {
+        DetectorProfileName.getName(CommonName.AD_TASK);
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> DetectorProfileName.getName("abc"));
+        assertEquals(exception.getMessage(), CommonErrorMessages.NON_SUPPORTED_PROFILE_TYPE);
     }
 }

--- a/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
@@ -56,7 +56,6 @@ public class DetectorProfileTests extends OpenSearchTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         detectorProfile.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
-        // StreamInput input = output.bytes().streamInput();
         DetectorProfile parsedDetectorProfile = new DetectorProfile(input);
         assertEquals("Detector profile serialization doesn't work", detectorProfile, parsedDetectorProfile);
     }

--- a/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
@@ -89,6 +89,6 @@ public class DetectorProfileTests extends OpenSearchTestCase {
     public void testDetectorProfileName() throws IllegalArgumentException {
         DetectorProfileName.getName(CommonName.AD_TASK);
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> DetectorProfileName.getName("abc"));
-        assertEquals(exception.getMessage(), CommonErrorMessages.NON_SUPPORTED_PROFILE_TYPE);
+        assertEquals(exception.getMessage(), CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
     }
 }

--- a/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
@@ -32,6 +32,7 @@ public class EntityProfileTests extends AbstractADTest {
 
         profile1.merge(profile2);
         assertEquals(profile1.getState(), EntityState.INIT);
+        assertTrue(profile1.toString().contains(EntityState.INIT.toString()));
     }
 
     public void testToXContent() throws IOException, JsonPathNotFoundException {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -130,12 +130,6 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opendistro/ad/detector/write]"));
     }
 
-    // public void testValidateAnomalyDetectorWithWriteAccess() throws IOException {
-    // // User Alice has AD full access, should be able to validate a detector
-    // AnomalyDetector aliceDetector = createRandomAnomalyDetector(false, false, aliceClient);
-    // Assert.assertNotNull("User alice could not create detector", aliceDetector.getDetectorId());
-    // }
-
     public void testStartDetectorWithReadAccess() throws IOException {
         // User Bob has AD read access, should not be able to modify a detector
         AnomalyDetector aliceDetector = createRandomAnomalyDetector(false, false, aliceClient);

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -130,6 +130,12 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opendistro/ad/detector/write]"));
     }
 
+    // public void testValidateAnomalyDetectorWithWriteAccess() throws IOException {
+    // // User Alice has AD full access, should be able to validate a detector
+    // AnomalyDetector aliceDetector = createRandomAnomalyDetector(false, false, aliceClient);
+    // Assert.assertNotNull("User alice could not create detector", aliceDetector.getDetectorId());
+    // }
+
     public void testStartDetectorWithReadAccess() throws IOException {
         // User Bob has AD read access, should not be able to modify a detector
         AnomalyDetector aliceDetector = createRandomAnomalyDetector(false, false, aliceClient);

--- a/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
@@ -31,6 +31,7 @@ import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
@@ -108,11 +109,28 @@ public class ADTaskProfileTests extends OpenSearchSingleNodeTestCase {
         response.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         ADTaskProfileNodeResponse parsedResponse = ADTaskProfileNodeResponse.readNodeResponse(input);
-        // if (response.getAdTaskProfile() != null) {
-        // assertTrue(response.getAdTaskProfile().equals(parsedResponse.getAdTaskProfile()));
-        // } else {
-        // assertNull(parsedResponse.getAdTaskProfile());
-        // }
+        if (response.getAdTaskProfile() != null) {
+            assertTrue(response.getAdTaskProfile().equals(parsedResponse.getAdTaskProfile()));
+        } else {
+            assertNull(parsedResponse.getAdTaskProfile());
+        }
+    }
+
+    public void testADTaskProfileParse() throws IOException {
+        ADTaskProfile adTaskProfile = new ADTaskProfile(
+            randomAlphaOfLength(5),
+            randomInt(),
+            randomLong(),
+            randomBoolean(),
+            randomInt(),
+            randomLong(),
+            randomAlphaOfLength(5)
+        );
+        String adTaskProfileString = TestHelpers
+            .xContentBuilderToString(adTaskProfile.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTaskProfile parsedADTaskProfile = ADTaskProfile.parse(TestHelpers.parser(adTaskProfileString));
+        assertEquals(adTaskProfile, parsedADTaskProfile);
+        assertEquals(parsedADTaskProfile.toString(), adTaskProfile.toString());
     }
 
     @Ignore

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -233,6 +233,7 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
         Map<String, Object> map = TestHelpers.XContentBuilderToMap(builder);
         Map<String, Object> parsedInitProgress = (Map<String, Object>) (map.get(CommonName.INIT_PROGRESS));
         Assert.assertEquals(initProgress.getPercentage(), parsedInitProgress.get(InitProgressProfile.PERCENTAGE).toString());
+        assertTrue(initProgress.toString().contains("[percentage=99%,estimated_minutes_left=2,needed_shingles=2]"));
         Assert
             .assertEquals(
                 String.valueOf(initProgress.getEstimatedMinutesLeft()),

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorResponseTests.java
@@ -12,6 +12,8 @@
 package org.opensearch.ad.transport;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Test;
 import org.opensearch.ad.AbstractADTest;
@@ -19,20 +21,20 @@ import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.model.DetectorValidationIssue;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.xcontent.ToXContent;
 
 public class ValidateAnomalyDetectorResponseTests extends AbstractADTest {
 
     @Test
     public void testResponseSerialization() throws IOException {
-        DetectorValidationIssue issue = TestHelpers.randomDetectorValidationIssue();
+        Map<String, String> subIssues = new HashMap<>();
+        subIssues.put("a", "b");
+        subIssues.put("c", "d");
+        DetectorValidationIssue issue = TestHelpers.randomDetectorValidationIssueWithSubIssues(subIssues);
         ValidateAnomalyDetectorResponse response = new ValidateAnomalyDetectorResponse(issue);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
-
         StreamInput streamInput = output.bytes().streamInput();
         ValidateAnomalyDetectorResponse readResponse = ValidateAnomalyDetectorAction.INSTANCE.getResponseReader().read(streamInput);
-
         assertEquals("serialization has the wrong issue", issue, readResponse.getIssue());
     }
 
@@ -41,19 +43,36 @@ public class ValidateAnomalyDetectorResponseTests extends AbstractADTest {
         ValidateAnomalyDetectorResponse response = new ValidateAnomalyDetectorResponse((DetectorValidationIssue) null);
         BytesStreamOutput output = new BytesStreamOutput();
         response.writeTo(output);
-
         StreamInput streamInput = output.bytes().streamInput();
         ValidateAnomalyDetectorResponse readResponse = ValidateAnomalyDetectorAction.INSTANCE.getResponseReader().read(streamInput);
-
         assertNull("serialization should have empty issue", readResponse.getIssue());
+    }
+
+    public void testResponseToXContentWithSubIssues() throws IOException {
+        Map<String, String> subIssues = new HashMap<>();
+        subIssues.put("a", "b");
+        subIssues.put("c", "d");
+        DetectorValidationIssue issue = TestHelpers.randomDetectorValidationIssueWithSubIssues(subIssues);
+        ValidateAnomalyDetectorResponse response = new ValidateAnomalyDetectorResponse(issue);
+        String validationResponse = TestHelpers.xContentBuilderToString(response.toXContent(TestHelpers.builder()));
+        String message = issue.getMessage();
+        assertEquals(
+            "{\"detector\":{\"name\":{\"message\":\"" + message + "\",\"sub_issues\":{\"a\":\"b\",\"c\":\"d\"}}}}",
+            validationResponse
+        );
     }
 
     public void testResponseToXContent() throws IOException {
         DetectorValidationIssue issue = TestHelpers.randomDetectorValidationIssue();
         ValidateAnomalyDetectorResponse response = new ValidateAnomalyDetectorResponse(issue);
-        String validationResponse = TestHelpers
-            .xContentBuilderToString(response.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        String validationResponse = TestHelpers.xContentBuilderToString(response.toXContent(TestHelpers.builder()));
         String message = issue.getMessage();
         assertEquals("{\"detector\":{\"name\":{\"message\":\"" + message + "\"}}}", validationResponse);
+    }
+
+    public void testResponseToXContentNull() throws IOException {
+        ValidateAnomalyDetectorResponse response = new ValidateAnomalyDetectorResponse((DetectorValidationIssue) null);
+        String validationResponse = TestHelpers.xContentBuilderToString(response.toXContent(TestHelpers.builder()));
+        assertEquals("{}", validationResponse);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -16,6 +16,7 @@ import static org.opensearch.ad.rest.handler.AbstractAnomalyDetectorActionHandle
 import static org.opensearch.ad.rest.handler.AbstractAnomalyDetectorActionHandler.UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG;
 
 import java.io.IOException;
+import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
@@ -23,15 +24,20 @@ import org.junit.Test;
 import org.opensearch.ad.ADIntegTestCase;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorValidationIssueType;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.ad.model.ValidationAspect;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.search.aggregations.AggregationBuilder;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
 
 public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase {
 
@@ -66,6 +72,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             new TimeValue(5_000L)
         );
         ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        System.out.println("response: " + response.getIssue());
         assertNotNull(response.getIssue());
         assertEquals(DetectorValidationIssueType.INDICES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
@@ -260,5 +267,175 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertTrue(response.getIssue().getMessage().contains(FEATURE_WITH_INVALID_QUERY_MSG));
         assertTrue(response.getIssue().getSubIssues().containsKey(maxFeature.getName()));
         assertTrue(FEATURE_WITH_INVALID_QUERY_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName())));
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithCustomResultIndex() throws IOException {
+        String resultIndex = CommonName.CUSTOM_RESULT_INDEX_PREFIX + "test";
+        createCustomADResultIndex(resultIndex);
+        AnomalyDetector anomalyDetector = TestHelpers
+            .randomDetector(
+                ImmutableList.of(TestHelpers.randomFeature()),
+                randomAlphaOfLength(5).toLowerCase(),
+                randomIntBetween(1, 5),
+                randomAlphaOfLength(5),
+                null,
+                resultIndex
+            );
+        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertNull(response.getIssue());
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithCustomResultIndexCreated() throws IOException {
+        testValidateAnomalyDetectorWithCustomResultIndex(true);
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithCustomResultIndexPresentButNotCreated() throws IOException {
+        testValidateAnomalyDetectorWithCustomResultIndex(false);
+
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithCustomResultIndexWithInvalidMapping() throws IOException {
+        String resultIndex = CommonName.CUSTOM_RESULT_INDEX_PREFIX + "test";
+        URL url = AnomalyDetectionIndices.class.getClassLoader().getResource("mappings/checkpoint.json");
+        createIndex(resultIndex, Resources.toString(url, Charsets.UTF_8));
+        AnomalyDetector anomalyDetector = TestHelpers
+            .randomDetector(
+                ImmutableList.of(TestHelpers.randomFeature()),
+                randomAlphaOfLength(5).toLowerCase(),
+                randomIntBetween(1, 5),
+                randomAlphaOfLength(5),
+                null,
+                resultIndex
+            );
+        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertEquals(DetectorValidationIssueType.RESULT_INDEX, response.getIssue().getType());
+        assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
+        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.INVALID_RESULT_INDEX_MAPPING));
+    }
+
+    private void testValidateAnomalyDetectorWithCustomResultIndex(boolean resultIndexCreated) throws IOException {
+        String resultIndex = CommonName.CUSTOM_RESULT_INDEX_PREFIX + "test";
+        if (resultIndexCreated) {
+            createCustomADResultIndex(resultIndex);
+        }
+        AnomalyDetector anomalyDetector = TestHelpers
+            .randomDetector(
+                ImmutableList.of(TestHelpers.randomFeature()),
+                randomAlphaOfLength(5).toLowerCase(),
+                randomIntBetween(1, 5),
+                randomAlphaOfLength(5),
+                null,
+                resultIndex
+            );
+        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertNull(response.getIssue());
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithInvalidDetectorName() throws IOException {
+        AnomalyDetector anomalyDetector = new AnomalyDetector(
+            randomAlphaOfLength(5),
+            randomLong(),
+            "#$32",
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(5).toLowerCase()),
+            ImmutableList.of(TestHelpers.randomFeature()),
+            TestHelpers.randomQuery(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
+            null,
+            1,
+            Instant.now(),
+            null,
+            TestHelpers.randomUser(),
+            null
+        );
+        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertEquals(DetectorValidationIssueType.NAME, response.getIssue().getType());
+        assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
+        assertEquals(CommonErrorMessages.INVALID_DETECTOR_NAME, response.getIssue().getMessage());
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithDetectorNameTooLong() throws IOException {
+        AnomalyDetector anomalyDetector = new AnomalyDetector(
+            randomAlphaOfLength(5),
+            randomLong(),
+            "abababababababababababababababababababababababababababababababababababababababababababababababab",
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(5).toLowerCase()),
+            ImmutableList.of(TestHelpers.randomFeature()),
+            TestHelpers.randomQuery(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
+            null,
+            1,
+            Instant.now(),
+            null,
+            TestHelpers.randomUser(),
+            null
+        );
+        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertEquals(DetectorValidationIssueType.NAME, response.getIssue().getType());
+        assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
+        assertTrue(response.getIssue().getMessage().contains("Name should be shortened. The maximum limit is"));
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -61,8 +61,6 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
     @Test
     public void testValidateAnomalyDetectorWithNoIndexFound() throws IOException {
         AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now());
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        // ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -70,7 +70,6 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             new TimeValue(5_000L)
         );
         ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
-        System.out.println("response: " + response.getIssue());
         assertNotNull(response.getIssue());
         assertEquals(DetectorValidationIssueType.INDICES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());


### PR DESCRIPTION
### Description
Added more unit testing for validation API as well as for some model classes that either didn't have any tests or were missing a unit test. 

Split PR into two separate ones. This first one has all the additional validation testing, including some additional model testing. Second PR will have more integration tests, more tests in ad.model package and other files. 
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
