### PR TITLE
Do not git ignore job scheduler dir, used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ out/
 .classpath
 .vscode
 bin/
-src/test/resources/job-scheduler


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

The .zip in this folder is used, remove from gitignore.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
