### PR TITLE
Do not git ignore job scheduler dir, used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ out/
 .classpath
 .vscode
 bin/
-src/test/resources/job-scheduler


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

When updating to 1.2.4 a .zip file was not git add-ed, had to do it manually.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
