### PR TITLE
Use admin client for system index updates in integ tests

### DIFF
--- a/src/test/java/org/opensearch/ad/ODFERestTestCase.java
+++ b/src/test/java/org/opensearch/ad/ODFERestTestCase.java
@@ -51,6 +51,7 @@ import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.rest.SecureRestClientBuilder;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 /**
@@ -90,9 +91,19 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
             .build();
     }
 
+    // Utility fn for deleting indices. Should only be used when not allowed in a regular context
+    // (e.g., deleting system indices)
     protected static void deleteIndexWithAdminClient(String name) throws IOException {
         Request request = new Request("DELETE", "/" + name);
         adminClient().performRequest(request);
+    }
+
+    // Utility fn for checking if an index exists. Should only be used when not allowed in a regular context
+    // (e.g., checking existence of system indices)
+    protected static boolean indexExistsWithAdminClient(String indexName) throws IOException {
+        Request request = new Request("HEAD", "/" + indexName);
+        Response response = adminClient().performRequest(request);
+        return RestStatus.OK.getStatus() == response.getStatusLine().getStatusCode();
     }
 
     @Override

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1760,7 +1760,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         );
 
         // Ingest some sample results
-        //deleteIndexWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
         if (!indexExistsWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
             TestHelpers.createEmptyAnomalyResultIndex(adminClient());
         }

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1681,8 +1681,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         );
 
         // Delete any existing result index
-        if (indexExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
-            deleteIndex(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        if (indexExistsWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
+            deleteIndexWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
         }
         Response response = searchTopAnomalyResults(
             detector.getDetectorId(),
@@ -1720,10 +1720,10 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         );
 
         // Clear any existing result index, create an empty one
-        if (indexExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
-            deleteIndex(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        if (indexExistsWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
+            deleteIndexWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
         }
-        TestHelpers.createEmptyAnomalyResultIndex(client());
+        TestHelpers.createEmptyAnomalyResultIndex(adminClient());
         Response response = searchTopAnomalyResults(
             detector.getDetectorId(),
             false,
@@ -1760,8 +1760,9 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         );
 
         // Ingest some sample results
-        if (!indexExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
-            TestHelpers.createEmptyAnomalyResultIndex(client());
+        //deleteIndexWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        if (!indexExistsWithAdminClient(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
+            TestHelpers.createEmptyAnomalyResultIndex(adminClient());
         }
         Map<String, Object> entityAttrs1 = new HashMap<String, Object>() {
             {
@@ -1788,9 +1789,9 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         AnomalyResult anomalyResult3 = TestHelpers
             .randomHCADAnomalyDetectResult(detector.getDetectorId(), null, entityAttrs3, 0.5, 0.2, null, 5L, 5L);
 
-        TestHelpers.ingestDataToIndex(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS, TestHelpers.toHttpEntity(anomalyResult1));
-        TestHelpers.ingestDataToIndex(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS, TestHelpers.toHttpEntity(anomalyResult2));
-        TestHelpers.ingestDataToIndex(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS, TestHelpers.toHttpEntity(anomalyResult3));
+        TestHelpers.ingestDataToIndex(adminClient(), CommonName.ANOMALY_RESULT_INDEX_ALIAS, TestHelpers.toHttpEntity(anomalyResult1));
+        TestHelpers.ingestDataToIndex(adminClient(), CommonName.ANOMALY_RESULT_INDEX_ALIAS, TestHelpers.toHttpEntity(anomalyResult2));
+        TestHelpers.ingestDataToIndex(adminClient(), CommonName.ANOMALY_RESULT_INDEX_ALIAS, TestHelpers.toHttpEntity(anomalyResult3));
 
         // Sorting by severity
         Response severityResponse = searchTopAnomalyResults(


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Fixes 3 tests that were using the default client to perform manual changes to system indices, such as checking if they exist, creating them, deleting them. Note that this is necessary sometimes to put the cluster in a certain state for testing out certain scenarios. To properly perform these actions, we can use the existing admin client.

Advantages of admin client:
- overrides any strict deprecation failures related to direct access to system indices
- overrides any permissions failures related to security-enabled cluster

More context behind these changes:
We were seeing occasional failures when trying to execute these tests against certain cluster configurations, including bundled binary clusters with security enabled. By changing to use the admin client for certain sensitive requests, these failures don't occur. 
### Issues Resolved
Closes #278 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
