### PR TITLE
remove remaining jcenter reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ repositories {
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    jcenter()
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Removing remaining reference to jcenter. This was initially removed from `buildscript` section of `build.gradle` in this PR: #361 but was never removed from repositories list outside of the `buildscript` section.
 
### Issues Resolved
#357 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
