### PR TITLE
Adding Model Type Validation to Validate API ("non-blocker")

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -480,6 +480,7 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.AnomalyDetectorPlugin',
         'org.opensearch.ad.settings.AnomalyDetectorSettings',
 
+        //TODO: Add more cases for model validation API, both UT and IT
         //TODO: add more test cases later for these package
         'org.opensearch.ad.model.*',
         'org.opensearch.ad.rest.*',

--- a/src/main/java/org/opensearch/ad/common/exception/ADValidationException.java
+++ b/src/main/java/org/opensearch/ad/common/exception/ADValidationException.java
@@ -13,11 +13,13 @@ package org.opensearch.ad.common.exception;
 
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorValidationIssueType;
+import org.opensearch.ad.model.IntervalTimeConfiguration;
 import org.opensearch.ad.model.ValidationAspect;
 
 public class ADValidationException extends AnomalyDetectionException {
     private final DetectorValidationIssueType type;
     private final ValidationAspect aspect;
+    private final IntervalTimeConfiguration intervalSuggestion;
 
     public DetectorValidationIssueType getType() {
         return type;
@@ -27,14 +29,34 @@ public class ADValidationException extends AnomalyDetectionException {
         return aspect;
     }
 
-    public ADValidationException(String message, DetectorValidationIssueType type, ValidationAspect aspect) {
-        this(message, null, type, aspect);
+    public IntervalTimeConfiguration getIntervalSuggestion() {
+        return intervalSuggestion;
     }
 
-    public ADValidationException(String message, Throwable cause, DetectorValidationIssueType type, ValidationAspect aspect) {
+    public ADValidationException(String message, DetectorValidationIssueType type, ValidationAspect aspect) {
+        this(message, null, type, aspect, null);
+    }
+
+    public ADValidationException(
+        String message,
+        DetectorValidationIssueType type,
+        ValidationAspect aspect,
+        IntervalTimeConfiguration intervalSuggestion
+    ) {
+        this(message, null, type, aspect, intervalSuggestion);
+    }
+
+    public ADValidationException(
+        String message,
+        Throwable cause,
+        DetectorValidationIssueType type,
+        ValidationAspect aspect,
+        IntervalTimeConfiguration intervalSuggestion
+    ) {
         super(AnomalyDetector.NO_ID, message, cause);
         this.type = type;
         this.aspect = aspect;
+        this.intervalSuggestion = intervalSuggestion;
     }
 
     @Override
@@ -49,6 +71,12 @@ public class ADValidationException extends AnomalyDetectionException {
         if (aspect != null) {
             sb.append(" aspect: ");
             sb.append(aspect.getName());
+        }
+
+        if (intervalSuggestion != null) {
+            sb.append("interval Suggestion: ");
+            sb.append(intervalSuggestion.getInterval());
+            sb.append(intervalSuggestion.getUnit());
         }
 
         return sb.toString();

--- a/src/main/java/org/opensearch/ad/common/exception/ADValidationException.java
+++ b/src/main/java/org/opensearch/ad/common/exception/ADValidationException.java
@@ -74,7 +74,7 @@ public class ADValidationException extends AnomalyDetectionException {
         }
 
         if (intervalSuggestion != null) {
-            sb.append("interval Suggestion: ");
+            sb.append(" interval suggestion: ");
             sb.append(intervalSuggestion.getInterval());
             sb.append(intervalSuggestion.getUnit());
         }

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -115,7 +115,8 @@ public class CommonErrorMessages {
     public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied. Consider changing the data filter";
     public static String CATEGORY_FIELD_TOO_SPARSE = "Data is most likely too sparse with the given category fields.";
     public static String CATEGORY_FIELD_NO_DATA = "No entity was found with the given categorical fields.";
-    public static String FEATURE_QUERY_TOO_SPARSE = "Given data is most likely too sparse when given feature query is applied: ";
+    public static String FEATURE_QUERY_TOO_SPARSE =
+        "Given data is most likely too sparse when given feature queries are applied. Consider revising feature queries.";
 
     // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction
     public static final String FEATURE_INVALID_MSG_PREFIX = "Feature has an invalid query";

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -107,12 +107,13 @@ public class CommonErrorMessages {
         + " characters.";
 
     public static String WINDOW_DELAY_REC = "We suggest using a window delay value of at least: ";
-    public static String NOT_ENOUGH_HISTORICAL_DATA = "There isn't enough historical data found with current configurations";
-    public static String DETECTOR_INTERVAL_REC = "We suggest using a detector interval of : ";
+    public static String NOT_ENOUGH_HISTORICAL_DATA = "There isn't enough historical data found with current configurations.";
+    public static String DETECTOR_INTERVAL_REC = "We suggest using a detector interval of: ";
     public static String RAW_DATA_TOO_SPARSE = "Given index data is potentially too sparse for model training.";
     public static String MODEL_VALIDATION_FAILED_UNEXPECTEDLY = "Model validation experienced issues completing.";
     public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied.";
-    public static String CATEGORY_FIELD_TOO_SPARSE = "Data is most likely too sparse with the given category fields";
+    public static String CATEGORY_FIELD_TOO_SPARSE = "Data is most likely too sparse with the given category fields.";
+    public static String CATEGORY_FIELD_NO_DATA = "No entity was found with the given categorical fields.";
     public static String FEATURE_QUERY_TOO_SPARSE = "Given data is most likely too sparse when given feature query is applied: ";
 
     // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -111,9 +111,9 @@ public class CommonErrorMessages {
     public static String TIME_FIELD_NOT_ENOUGH_HISTORICAL_DATA =
         "There isn't enough historical data found with current timefield selected.";
     public static String DETECTOR_INTERVAL_REC =
-        "The selected detector interval might collect sparse data. Consider increasing interval range too: ";
+        "The selected detector interval might collect sparse data. Consider changing interval length too: ";
     public static String RAW_DATA_TOO_SPARSE =
-        "Given index data is potentially too sparse for model training. Consider changing interval length or ingesting more data";
+        "Source index data is potentially too sparse for model training. Consider changing interval length or ingesting more data";
     public static String MODEL_VALIDATION_FAILED_UNEXPECTEDLY = "Model validation experienced issues completing.";
     public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied. Consider changing the data filter";
     public static String CATEGORY_FIELD_TOO_SPARSE =
@@ -121,7 +121,7 @@ public class CommonErrorMessages {
     public static String CATEGORY_FIELD_NO_DATA =
         "No entity was found with the given categorical fields. Consider revising category field/s or ingesting more data";
     public static String FEATURE_QUERY_TOO_SPARSE =
-        "Given data is most likely too sparse when given feature queries are applied. Consider revising feature queries.";
+        "Data is most likely too sparse when given feature queries are applied. Consider revising feature queries.";
     public static String TIMEOUT_ON_INTERVAL_REC = "Timed out getting interval recommendation";
 
     // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -80,7 +80,7 @@ public class CommonErrorMessages {
         "Valid characters for detector name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
     public static String DUPLICATE_FEATURE_AGGREGATION_NAMES = "Detector has duplicate feature aggregation query names: ";
     public static String INVALID_TIMESTAMP = "Timestamp field: (%s) must be of type date";
-    public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping:";
+    public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping";
 
     public static String FAIL_TO_GET_DETECTOR = "Fail to get detector";
     public static String FAIL_TO_GET_DETECTOR_INFO = "Fail to get detector info";
@@ -106,17 +106,23 @@ public class CommonErrorMessages {
         + MAX_DETECTOR_NAME_SIZE
         + " characters.";
 
-    public static String WINDOW_DELAY_REC = "We suggest using a window delay value of at least: ";
+    public static String WINDOW_DELAY_REC =
+        "Latest seen data point is at least %d minutes ago, consider changing window delay to at least %d minutes.";
     public static String TIME_FIELD_NOT_ENOUGH_HISTORICAL_DATA =
         "There isn't enough historical data found with current timefield selected.";
-    public static String DETECTOR_INTERVAL_REC = "Suggested detector interval: ";
-    public static String RAW_DATA_TOO_SPARSE = "Given index data is potentially too sparse for model training.";
+    public static String DETECTOR_INTERVAL_REC =
+        "The selected detector interval might collect sparse data. Consider increasing interval range too: ";
+    public static String RAW_DATA_TOO_SPARSE =
+        "Given index data is potentially too sparse for model training. Consider changing interval length or ingesting more data";
     public static String MODEL_VALIDATION_FAILED_UNEXPECTEDLY = "Model validation experienced issues completing.";
     public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied. Consider changing the data filter";
-    public static String CATEGORY_FIELD_TOO_SPARSE = "Data is most likely too sparse with the given category fields.";
-    public static String CATEGORY_FIELD_NO_DATA = "No entity was found with the given categorical fields.";
+    public static String CATEGORY_FIELD_TOO_SPARSE =
+        "Data is most likely too sparse with the given category fields. Consider revising category field/s or ingesting more data ";
+    public static String CATEGORY_FIELD_NO_DATA =
+        "No entity was found with the given categorical fields. Consider revising category field/s or ingesting more data";
     public static String FEATURE_QUERY_TOO_SPARSE =
         "Given data is most likely too sparse when given feature queries are applied. Consider revising feature queries.";
+    public static String TIMEOUT_ON_INTERVAL_REC = "Timed out getting interval recommendation";
 
     // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction
     public static final String FEATURE_INVALID_MSG_PREFIX = "Feature has an invalid query";

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -79,8 +79,8 @@ public class CommonErrorMessages {
     public static String INVALID_DETECTOR_NAME =
         "Valid characters for detector name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
     public static String DUPLICATE_FEATURE_AGGREGATION_NAMES = "Detector has duplicate feature aggregation query names: ";
-    public static String INVALID_TIMESTAMP = "Timestamp must be of type date";
-    public static String NON_EXISTENT_TIMESTAMP = "Timestamp not found in index mapping";
+    public static String INVALID_TIMESTAMP = "Timestamp field: (%s) must be of type date";
+    public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping:";
 
     public static String FAIL_TO_GET_DETECTOR = "Fail to get detector";
     public static String FAIL_TO_GET_DETECTOR_INFO = "Fail to get detector info";
@@ -107,11 +107,12 @@ public class CommonErrorMessages {
         + " characters.";
 
     public static String WINDOW_DELAY_REC = "We suggest using a window delay value of at least: ";
-    public static String NOT_ENOUGH_HISTORICAL_DATA = "There isn't enough historical data found with current configurations.";
-    public static String DETECTOR_INTERVAL_REC = "We suggest using a detector interval of: ";
+    public static String TIME_FIELD_NOT_ENOUGH_HISTORICAL_DATA =
+        "There isn't enough historical data found with current timefield selected.";
+    public static String DETECTOR_INTERVAL_REC = "Suggested detector interval: ";
     public static String RAW_DATA_TOO_SPARSE = "Given index data is potentially too sparse for model training.";
     public static String MODEL_VALIDATION_FAILED_UNEXPECTEDLY = "Model validation experienced issues completing.";
-    public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied.";
+    public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied. Consider changing the data filter";
     public static String CATEGORY_FIELD_TOO_SPARSE = "Data is most likely too sparse with the given category fields.";
     public static String CATEGORY_FIELD_NO_DATA = "No entity was found with the given categorical fields.";
     public static String FEATURE_QUERY_TOO_SPARSE = "Given data is most likely too sparse when given feature query is applied: ";

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -79,6 +79,8 @@ public class CommonErrorMessages {
     public static String INVALID_DETECTOR_NAME =
         "Valid characters for detector name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
     public static String DUPLICATE_FEATURE_AGGREGATION_NAMES = "Detector has duplicate feature aggregation query names: ";
+    public static String INVALID_TIMESTAMP = "Timestamp must be of type date";
+    public static String NON_EXISTENT_TIMESTAMP = "Timestamp not found in index mapping";
 
     public static String FAIL_TO_GET_DETECTOR = "Fail to get detector";
     public static String FAIL_TO_GET_DETECTOR_INFO = "Fail to get detector info";
@@ -103,4 +105,22 @@ public class CommonErrorMessages {
     public static String INVALID_DETECTOR_NAME_SIZE = "Name should be shortened. The maximum limit is "
         + MAX_DETECTOR_NAME_SIZE
         + " characters.";
+
+    public static String WINDOW_DELAY_REC = "We suggest using a window delay value of at least: ";
+    public static String NOT_ENOUGH_HISTORICAL_DATA = "There isn't enough historical data found with current configurations";
+    public static String DETECTOR_INTERVAL_REC = "We suggest using a detector interval of : ";
+    public static String RAW_DATA_TOO_SPARSE = "Given index data is potentially too sparse for model training.";
+    public static String MODEL_VALIDATION_FAILED_UNEXPECTEDLY = "Model validation experienced issues completing.";
+    public static String FILTER_QUERY_TOO_SPARSE = "Data is too sparse after data filter is applied.";
+    public static String CATEGORY_FIELD_TOO_SPARSE = "Data is most likely too sparse with the given category fields";
+    public static String FEATURE_QUERY_TOO_SPARSE = "Given data is most likely too sparse when given feature query is applied: ";
+
+    // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction
+    public static final String FEATURE_INVALID_MSG_PREFIX = "Feature has an invalid query";
+    public static final String FEATURE_WITH_EMPTY_DATA_MSG = FEATURE_INVALID_MSG_PREFIX + " returning empty aggregated data: ";
+    public static final String FEATURE_WITH_INVALID_QUERY_MSG = FEATURE_INVALID_MSG_PREFIX + " causing a runtime exception: ";
+    public static final String UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG =
+        "Feature has an unknown exception caught while executing the feature query: ";
+    public static final String VALIDATION_FEATURE_FAILURE = "Validation failed for feature(s) of detector %s";
+
 }

--- a/src/main/java/org/opensearch/ad/constant/CommonName.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonName.java
@@ -89,6 +89,7 @@ public class CommonName {
     public static final String TYPE = "type";
     public static final String KEYWORD_TYPE = "keyword";
     public static final String IP_TYPE = "ip";
+    public static final String DATE = "date";
 
     // used for updating mapping
     public static final String SCHEMA_VERSION_FIELD = "schema_version";
@@ -134,7 +135,8 @@ public class CommonName {
     // Validation
     // ======================================
     // detector validation aspect
-    public static final String DETECTOR = "detector";
+    public static final String DETECTOR_ASPECT = "detector";
+    public static final String MODEL_ASPECT = "model";
 
     // ======================================
     // Used for custom AD result index

--- a/src/main/java/org/opensearch/ad/constant/CommonName.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonName.java
@@ -89,7 +89,7 @@ public class CommonName {
     public static final String TYPE = "type";
     public static final String KEYWORD_TYPE = "keyword";
     public static final String IP_TYPE = "ip";
-    public static final String DATE = "date";
+    public static final String DATE_TYPE = "date";
 
     // used for updating mapping
     public static final String SCHEMA_VERSION_FIELD = "schema_version";

--- a/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
@@ -496,24 +496,6 @@ public class SearchFeatureDao extends AbstractRetriever {
             );
     }
 
-    /**
-     * Get the entity's earliest timestamps
-     * @param detector detector config
-     * @param listener listener to return back the requested timestamps
-     */
-    public void getMinDataTime(AnomalyDetector detector, ActionListener<Optional<Long>> listener) {
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.min(AGG_NAME_MIN).field(detector.getTimeField()))
-            .trackTotalHits(false)
-            .size(0);
-        SearchRequest searchRequest = new SearchRequest().indices(detector.getIndices().toArray(new String[0])).source(searchSourceBuilder);
-        client
-            .search(
-                searchRequest,
-                ActionListener.wrap(response -> { listener.onResponse(parseMinDataTime(response)); }, listener::onFailure)
-            );
-    }
-
     private Optional<Long> parseMinDataTime(SearchResponse searchResponse) {
         Optional<Map<String, Aggregation>> mapOptional = Optional
             .ofNullable(searchResponse)

--- a/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
@@ -496,6 +496,24 @@ public class SearchFeatureDao extends AbstractRetriever {
             );
     }
 
+    /**
+     * Get the entity's earliest timestamps
+     * @param detector detector config
+     * @param listener listener to return back the requested timestamps
+     */
+    public void getMinDataTime(AnomalyDetector detector, ActionListener<Optional<Long>> listener) {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .aggregation(AggregationBuilders.min(AGG_NAME_MIN).field(detector.getTimeField()))
+            .trackTotalHits(false)
+            .size(0);
+        SearchRequest searchRequest = new SearchRequest().indices(detector.getIndices().toArray(new String[0])).source(searchSourceBuilder);
+        client
+            .search(
+                searchRequest,
+                ActionListener.wrap(response -> { listener.onResponse(parseMinDataTime(response)); }, listener::onFailure)
+            );
+    }
+
     private Optional<Long> parseMinDataTime(SearchResponse searchResponse) {
         Optional<Map<String, Aggregation>> mapOptional = Optional
             .ofNullable(searchResponse)

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -94,7 +94,8 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String USER_FIELD = "user";
     public static final String DETECTOR_TYPE_FIELD = "detector_type";
     public static final String RESULT_INDEX_FIELD = "result_index";
-    public static final String MODEL_VALIDATION_ISSUE = "aggregation_issue";
+    public static final String AGGREGATION = "aggregation_issue";
+    public static final String TIMEOUT = "timeout";
     @Deprecated
     public static final String DETECTION_DATE_RANGE_FIELD = "detection_date_range";
 

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -95,6 +95,8 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String USER_FIELD = "user";
     public static final String DETECTOR_TYPE_FIELD = "detector_type";
     public static final String RESULT_INDEX_FIELD = "result_index";
+    public static final String GENERAL_DATA = "general_data";
+    public static final String MODEL_VALIDATION_ISSUE = "aggregation_issue";
     @Deprecated
     public static final String DETECTION_DATE_RANGE_FIELD = "detection_date_range";
 

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -77,7 +77,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String TYPE = "_doc";
     public static final String QUERY_PARAM_PERIOD_START = "period_start";
     public static final String QUERY_PARAM_PERIOD_END = "period_end";
-    public static final String PARSING_ISSUE = "query_parsing";
     public static final String GENERAL_SETTINGS = "general_settings";
 
     public static final String NAME_FIELD = "name";
@@ -95,7 +94,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String USER_FIELD = "user";
     public static final String DETECTOR_TYPE_FIELD = "detector_type";
     public static final String RESULT_INDEX_FIELD = "result_index";
-    public static final String GENERAL_DATA = "general_data";
     public static final String MODEL_VALIDATION_ISSUE = "aggregation_issue";
     @Deprecated
     public static final String DETECTION_DATE_RANGE_FIELD = "detection_date_range";

--- a/src/main/java/org/opensearch/ad/model/DetectorValidationIssue.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorValidationIssue.java
@@ -41,7 +41,7 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
     private final DetectorValidationIssueType type;
     private final String message;
     private Map<String, String> subIssues;
-    private String suggestion;
+    private IntervalTimeConfiguration intervalSuggestion;
 
     public ValidationAspect getAspect() {
         return aspect;
@@ -59,8 +59,8 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
         return subIssues;
     }
 
-    public String getSuggestion() {
-        return suggestion;
+    public IntervalTimeConfiguration getIntervalSuggestion() {
+        return intervalSuggestion;
     }
 
     public DetectorValidationIssue(
@@ -68,13 +68,13 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
         DetectorValidationIssueType type,
         String message,
         Map<String, String> subIssues,
-        String suggestion
+        IntervalTimeConfiguration intervalSuggestion
     ) {
         this.aspect = aspect;
         this.type = type;
         this.message = message;
         this.subIssues = subIssues;
-        this.suggestion = suggestion;
+        this.intervalSuggestion = intervalSuggestion;
     }
 
     public DetectorValidationIssue(ValidationAspect aspect, DetectorValidationIssueType type, String message) {
@@ -89,7 +89,7 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
             subIssues = input.readMap(StreamInput::readString, StreamInput::readString);
         }
         if (input.readBoolean()) {
-            suggestion = input.readString();
+            intervalSuggestion = IntervalTimeConfiguration.readFrom(input);
         }
     }
 
@@ -104,9 +104,9 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        if (suggestion != null) {
+        if (intervalSuggestion != null) {
             out.writeBoolean(true);
-            out.writeGenericValue(suggestion);
+            intervalSuggestion.writeTo(out);
         } else {
             out.writeBoolean(false);
         }
@@ -123,8 +123,8 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
             }
             subIssuesBuilder.endObject();
         }
-        if (suggestion != null) {
-            xContentBuilder.field(SUGGESTED_FIELD_NAME, suggestion);
+        if (intervalSuggestion != null) {
+            xContentBuilder.field(SUGGESTED_FIELD_NAME, intervalSuggestion);
         }
 
         return xContentBuilder.endObject().endObject();
@@ -140,7 +140,7 @@ public class DetectorValidationIssue implements ToXContentObject, Writeable {
         return Objects.equal(getAspect(), anotherIssue.getAspect())
             && Objects.equal(getMessage(), anotherIssue.getMessage())
             && Objects.equal(getSubIssues(), anotherIssue.getSubIssues())
-            && Objects.equal(getSuggestion(), anotherIssue.getSuggestion())
+            && Objects.equal(getIntervalSuggestion(), anotherIssue.getIntervalSuggestion())
             && Objects.equal(getType(), anotherIssue.getType());
     }
 

--- a/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
@@ -24,7 +24,10 @@ public enum DetectorValidationIssueType implements Name {
     FILTER_QUERY(AnomalyDetector.FILTER_QUERY_FIELD),
     WINDOW_DELAY(AnomalyDetector.WINDOW_DELAY_FIELD),
     GENERAL_SETTINGS(AnomalyDetector.GENERAL_SETTINGS),
-    RESULT_INDEX(AnomalyDetector.RESULT_INDEX_FIELD);
+    RESULT_INDEX(AnomalyDetector.RESULT_INDEX_FIELD),
+    GENERAL_DATA(AnomalyDetector.GENERAL_DATA),
+    MODEL_VALIDATION_ISSUE(AnomalyDetector.MODEL_VALIDATION_ISSUE); // TODO: this is a unique case where aggregation failed but not
+                                                                    // exception
 
     private String name;
 

--- a/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
@@ -25,8 +25,9 @@ public enum DetectorValidationIssueType implements Name {
     WINDOW_DELAY(AnomalyDetector.WINDOW_DELAY_FIELD),
     GENERAL_SETTINGS(AnomalyDetector.GENERAL_SETTINGS),
     RESULT_INDEX(AnomalyDetector.RESULT_INDEX_FIELD),
-    MODEL_VALIDATION_ISSUE(AnomalyDetector.MODEL_VALIDATION_ISSUE); // this is a unique case where aggregation failed but
-                                                                    // don't want to throw exception
+    TIMEOUT(AnomalyDetector.TIMEOUT),
+    AGGREGATION(AnomalyDetector.AGGREGATION); // this is a unique case where aggregation failed but
+                                              // don't want to throw exception
 
     private String name;
 

--- a/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
@@ -26,7 +26,7 @@ public enum DetectorValidationIssueType implements Name {
     GENERAL_SETTINGS(AnomalyDetector.GENERAL_SETTINGS),
     RESULT_INDEX(AnomalyDetector.RESULT_INDEX_FIELD),
     TIMEOUT(AnomalyDetector.TIMEOUT),
-    AGGREGATION(AnomalyDetector.AGGREGATION); // this is a unique case where aggregation failed but
+    AGGREGATION(AnomalyDetector.AGGREGATION); // this is a unique case where aggregation failed due to an issue in core but
                                               // don't want to throw exception
 
     private String name;

--- a/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorValidationIssueType.java
@@ -25,9 +25,8 @@ public enum DetectorValidationIssueType implements Name {
     WINDOW_DELAY(AnomalyDetector.WINDOW_DELAY_FIELD),
     GENERAL_SETTINGS(AnomalyDetector.GENERAL_SETTINGS),
     RESULT_INDEX(AnomalyDetector.RESULT_INDEX_FIELD),
-    GENERAL_DATA(AnomalyDetector.GENERAL_DATA),
-    MODEL_VALIDATION_ISSUE(AnomalyDetector.MODEL_VALIDATION_ISSUE); // TODO: this is a unique case where aggregation failed but not
-                                                                    // exception
+    MODEL_VALIDATION_ISSUE(AnomalyDetector.MODEL_VALIDATION_ISSUE); // this is a unique case where aggregation failed but
+                                                                    // don't want to throw exception
 
     private String name;
 

--- a/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
+++ b/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
@@ -61,6 +61,13 @@ public class IntervalTimeConfiguration extends TimeConfiguration {
         return new IntervalTimeConfiguration(input);
     }
 
+    public static long getIntervalInMinute(IntervalTimeConfiguration interval) {
+        if (interval.getUnit() == ChronoUnit.SECONDS) {
+            return interval.getInterval() / 60;
+        }
+        return interval.getInterval();
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(this.interval);

--- a/src/main/java/org/opensearch/ad/model/ValidationAspect.java
+++ b/src/main/java/org/opensearch/ad/model/ValidationAspect.java
@@ -28,7 +28,8 @@ import org.opensearch.ad.constant.CommonName;
  * </ul>
  */
 public enum ValidationAspect implements Name {
-    DETECTOR(CommonName.DETECTOR);
+    DETECTOR(CommonName.DETECTOR_ASPECT),
+    MODEL(CommonName.MODEL_ASPECT);
 
     private String name;
 
@@ -48,8 +49,10 @@ public enum ValidationAspect implements Name {
 
     public static ValidationAspect getName(String name) {
         switch (name) {
-            case CommonName.DETECTOR:
+            case CommonName.DETECTOR_ASPECT:
                 return DETECTOR;
+            case CommonName.MODEL_ASPECT:
+                return MODEL;
             default:
                 throw new IllegalArgumentException("Unsupported validation aspects");
         }

--- a/src/main/java/org/opensearch/ad/rest/AbstractAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/AbstractAnomalyDetectorAction.java
@@ -11,12 +11,7 @@
 
 package org.opensearch.ad.rest;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.DETECTION_INTERVAL;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.DETECTION_WINDOW_DELAY;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.*;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -39,6 +34,7 @@ public abstract class AbstractAnomalyDetectorAction extends BaseRestHandler {
         this.maxSingleEntityDetectors = MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings);
         this.maxMultiEntityDetectors = MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings);
         this.maxAnomalyFeatures = MAX_ANOMALY_FEATURES.get(settings);
+        // this.trainSampleTimeRangeInHours = TRAIN_SAMPLE_TIME_RANGE_IN_HOURS.get(settings);
         // TODO: will add more cluster setting consumer later
         // TODO: inject ClusterSettings only if clusterService is only used to get ClusterSettings
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REQUEST_TIMEOUT, it -> requestTimeout = it);

--- a/src/main/java/org/opensearch/ad/rest/AbstractAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/AbstractAnomalyDetectorAction.java
@@ -11,7 +11,12 @@
 
 package org.opensearch.ad.rest;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.*;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.DETECTION_INTERVAL;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.DETECTION_WINDOW_DELAY;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -34,7 +39,6 @@ public abstract class AbstractAnomalyDetectorAction extends BaseRestHandler {
         this.maxSingleEntityDetectors = MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings);
         this.maxMultiEntityDetectors = MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings);
         this.maxAnomalyFeatures = MAX_ANOMALY_FEATURES.get(settings);
-        // this.trainSampleTimeRangeInHours = TRAIN_SAMPLE_TIME_RANGE_IN_HOURS.get(settings);
         // TODO: will add more cluster setting consumer later
         // TODO: inject ClusterSettings only if clusterService is only used to get ClusterSettings
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REQUEST_TIMEOUT, it -> requestTimeout = it);

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -351,10 +351,6 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
                                     if (type instanceof Map) {
                                         foundField = true;
                                         Map<String, Object> metadataMap = (Map<String, Object>) type;
-                                        System.out.println("metadata");
-                                        for (Map.Entry<String, Object> entry : metadataMap.entrySet()) {
-                                            System.out.println(entry.getKey() + ":" + entry.getValue().toString());
-                                        }
                                         String typeName = (String) metadataMap.get(CommonName.TYPE);
                                         if (!typeName.equals(CommonName.DATE_TYPE)) {
                                             listener

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -326,8 +326,9 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
     }
 
     protected void validateTimeField(boolean indexingDryRun) {
+        String givenTimeField = anomalyDetector.getTimeField();
         GetFieldMappingsRequest getMappingsRequest = new GetFieldMappingsRequest();
-        getMappingsRequest.indices(anomalyDetector.getIndices().toArray(new String[0])).fields(anomalyDetector.getTimeField());
+        getMappingsRequest.indices(anomalyDetector.getIndices().toArray(new String[0])).fields(givenTimeField);
         getMappingsRequest.indicesOptions(IndicesOptions.strictExpand());
 
         // comments explaining fieldMappingResponse parsing can be found inside following method:
@@ -350,12 +351,16 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
                                     if (type instanceof Map) {
                                         foundField = true;
                                         Map<String, Object> metadataMap = (Map<String, Object>) type;
+                                        System.out.println("metadata");
+                                        for (Map.Entry<String, Object> entry : metadataMap.entrySet()) {
+                                            System.out.println(entry.getKey() + ":" + entry.getValue().toString());
+                                        }
                                         String typeName = (String) metadataMap.get(CommonName.TYPE);
-                                        if (!typeName.equals(CommonName.DATE)) {
+                                        if (!typeName.equals(CommonName.DATE_TYPE)) {
                                             listener
                                                 .onFailure(
                                                     new ADValidationException(
-                                                        CommonErrorMessages.INVALID_TIMESTAMP,
+                                                        String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIMESTAMP, givenTimeField),
                                                         DetectorValidationIssueType.TIMEFIELD_FIELD,
                                                         ValidationAspect.DETECTOR
                                                     )
@@ -373,7 +378,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
                 listener
                     .onFailure(
                         new ADValidationException(
-                            CommonErrorMessages.NON_EXISTENT_TIMESTAMP,
+                            String.format(Locale.ROOT, CommonErrorMessages.NON_EXISTENT_TIMESTAMP, givenTimeField),
                             DetectorValidationIssueType.TIMEFIELD_FIELD,
                             ValidationAspect.DETECTOR
                         )

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -97,7 +97,9 @@ public class IndexAnomalyDetectorActionHandler extends AbstractAnomalyDetectorAc
             user,
             adTaskManager,
             searchFeatureDao,
-            false
+            null,
+            false,
+            null
         );
     }
 

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -697,8 +696,8 @@ public class ModelValidationActionHandler {
         client.search(searchRequest, ActionListener.wrap(response -> processFeatureQuery(response, latestTime), listener::onFailure));
     }
 
-    private void sendWindowDelayRec(long latestTime) {
-        long minutesSinceLastStamp = TimeUnit.MILLISECONDS.toMinutes(Instant.now().toEpochMilli() - latestTime);
+    private void sendWindowDelayRec(long latestTimeInMillis) {
+        long minutesSinceLastStamp = (long) Math.ceil((Instant.now().toEpochMilli() - latestTimeInMillis) / 60000.0);
         listener
             .onFailure(
                 new ADValidationException(

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -132,8 +132,6 @@ public class ModelValidationActionHandler {
     // If detector is HCAD then we will find the top entity and treat as single entity for
     // validation purposes
     public void checkIfMultiEntityDetector() {
-        System.out.println("inside here");
-
         ActionListener<Map<String, Object>> recommendationListener = ActionListener
             .wrap(topEntity -> getLatestDateForValidation(topEntity), exception -> {
                 listener.onFailure(exception);
@@ -383,7 +381,6 @@ public class ModelValidationActionHandler {
                         );
                 }
                 double fullBucketRate = processBucketAggregationResults(aggregate);
-                System.out.println("full bucket rate: " + fullBucketRate);
                 // If rate is above success minimum then return interval suggestion.
                 if (fullBucketRate > INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE) {
                     intervalListener.onResponse(this.detectorInterval);

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -1,0 +1,716 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.rest.handler;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.CONFIG_BUCKET_MINIMUM_SUCCESS_RATE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_INTERVAL_REC_LENGTH_IN_MINUTES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.TOP_VALIDATE_TIMEOUT_IN_MILLIS;
+import static org.opensearch.ad.util.ParseUtils.parseAggregators;
+import static org.opensearch.ad.util.RestHandlerUtils.isExceptionCausedByInvalidQuery;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.common.exception.ADValidationException;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
+import org.opensearch.ad.common.exception.EndRunException;
+import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.feature.SearchFeatureDao;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.DetectorValidationIssueType;
+import org.opensearch.ad.model.Feature;
+import org.opensearch.ad.model.IntervalTimeConfiguration;
+import org.opensearch.ad.model.MergeableList;
+import org.opensearch.ad.model.TimeConfiguration;
+import org.opensearch.ad.model.ValidationAspect;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.transport.ValidateAnomalyDetectorResponse;
+import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
+import org.opensearch.ad.util.ParseUtils;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.AggregatorFactories;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.bucket.histogram.Histogram;
+import org.opensearch.search.aggregations.bucket.histogram.LongBounds;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * <p>This class executes all validation checks that are not blocking on the 'model' level.
+ * This mostly involves checking if the data is generally dense enough to complete model training
+ * which is based on if enough buckets in the last x intervals have at least 1 document present.</p>
+ * <p>Initially different bucket aggregations are executed with with every configuration applied and with
+ * different varying intervals in order to find the best interval for the data. If no interval is found with all
+ * configuration applied then each configuration is tested sequentially for sparsity</p>
+ */
+// TODO: potentially change where this is located
+public class ModelValidationActionHandler {
+    protected static final String AGG_NAME_TOP = "top_agg";
+    protected final AnomalyDetector anomalyDetector;
+    protected final ClusterService clusterService;
+    protected final Logger logger = LogManager.getLogger(AbstractAnomalyDetectorActionHandler.class);
+    protected final TimeValue requestTimeout;
+    protected final AnomalyDetectorActionHandler handler = new AnomalyDetectorActionHandler();
+    protected final Client client;
+    protected final NamedXContentRegistry xContentRegistry;
+    protected final ActionListener<ValidateAnomalyDetectorResponse> listener;
+    protected final SearchFeatureDao searchFeatureDao;
+    protected final Clock clock;
+    protected final String validationType;
+
+    /**
+     * Constructor function.
+     *
+     * @param clusterService                  ClusterService
+     * @param client                          ES node client that executes actions on the local node
+     * @param listener                        ES channel used to construct bytes / builder based outputs, and send responses
+     * @param anomalyDetector                 anomaly detector instance
+     * @param requestTimeout                  request time out configuration
+     * @param xContentRegistry                Registry which is used for XContentParser
+     * @param searchFeatureDao                Search feature DAO
+     * @param validationType                  Specified type for validation
+     * @param clock                           clock object to know when to timeout
+     */
+    public ModelValidationActionHandler(
+        ClusterService clusterService,
+        Client client,
+        ActionListener<ValidateAnomalyDetectorResponse> listener,
+        AnomalyDetector anomalyDetector,
+        TimeValue requestTimeout,
+        NamedXContentRegistry xContentRegistry,
+        SearchFeatureDao searchFeatureDao,
+        String validationType,
+        Clock clock
+    ) {
+        this.clusterService = clusterService;
+        this.client = client;
+        this.listener = listener;
+        this.anomalyDetector = anomalyDetector;
+        this.requestTimeout = requestTimeout;
+        this.xContentRegistry = xContentRegistry;
+        this.searchFeatureDao = searchFeatureDao;
+        this.validationType = validationType;
+        this.clock = clock;
+    }
+
+    // Need to first check if multi entity detector or not before doing any sort of validation.
+    // If detector is HCAD then we will find the top entity and treat that single entity for
+    // validation purposes
+    public void checkIfMultiEntityDetector() {
+        ActionListener<Map<String, Object>> recommendationListener = ActionListener
+            .wrap(topEntity -> startIntervalRecommendation(topEntity), exception -> {
+                listener.onFailure(exception);
+                logger.error("Failed to get top entity for categorical field", exception);
+            });
+        if (anomalyDetector.isMultientityDetector()) {
+            getTopEntity(recommendationListener);
+        } else {
+            recommendationListener.onResponse(Collections.emptyMap());
+        }
+    }
+
+    private void getTopEntity(ActionListener<Map<String, Object>> topEntityListener) {
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery().filter(anomalyDetector.getFilterQuery());
+        AggregationBuilder bucketAggs;
+        Map<String, Object> topKeys = new HashMap<>();
+        if (anomalyDetector.getCategoryField().size() == 1) {
+            bucketAggs = AggregationBuilders
+                .terms(AGG_NAME_TOP)
+                .field(anomalyDetector.getCategoryField().get(0))
+                .order(BucketOrder.count(true));
+        } else {
+
+            bucketAggs = AggregationBuilders
+                .composite(
+                    AGG_NAME_TOP,
+                    anomalyDetector
+                        .getCategoryField()
+                        .stream()
+                        .map(f -> new TermsValuesSourceBuilder(f).field(f))
+                        .collect(Collectors.toList())
+                )
+                .size(1000)
+                .subAggregation(
+                    PipelineAggregatorBuilders
+                        .bucketSort("bucketSort", Collections.singletonList(new FieldSortBuilder("_count").order(SortOrder.DESC)))
+                        .size(1)
+                );
+        }
+
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .query(boolQueryBuilder)
+            .aggregation(bucketAggs)
+            .trackTotalHits(false)
+            .size(0);
+        SearchRequest searchRequest = new SearchRequest()
+            .indices(anomalyDetector.getIndices().toArray(new String[0]))
+            .source(searchSourceBuilder);
+        client.search(searchRequest, ActionListener.wrap(response -> {
+            Aggregations aggs = response.getAggregations();
+            if (aggs == null) {
+                topEntityListener.onResponse(Collections.emptyMap());
+                return;
+            }
+            if (anomalyDetector.getCategoryField().size() == 1) {
+                Terms entities = aggs.get(AGG_NAME_TOP);
+                Object key = entities
+                    .getBuckets()
+                    .stream()
+                    .max(Comparator.comparingInt(entry -> (int) entry.getDocCount()))
+                    .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+                    .orElse(null);
+                topKeys.put(anomalyDetector.getCategoryField().get(0), key);
+            } else {
+                CompositeAggregation compositeAgg = aggs.get(AGG_NAME_TOP);
+                topKeys
+                    .putAll(
+                        compositeAgg
+                            .getBuckets()
+                            .stream()
+                            .flatMap(bucket -> bucket.getKey().entrySet().stream()) // this would create a flattened stream of map entries
+                            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()))
+                    );
+            }
+            topEntityListener.onResponse(topKeys);
+        }, topEntityListener::onFailure));
+    }
+
+    private void startIntervalRecommendation(Map<String, Object> topEntity) {
+        getLatestDateForValidation(topEntity);
+    }
+
+    private void getLatestDateForValidation(Map<String, Object> topEntity) {
+        ActionListener<Optional<Long>> latestTimeListener = ActionListener
+            .wrap(latest -> getSampleRangesForValidationChecks(latest, anomalyDetector, listener, topEntity), exception -> {
+                listener.onFailure(exception);
+                logger.error("Failed to create search request for last data point", exception);
+                return;
+            });
+        searchFeatureDao.getLatestDataTime(anomalyDetector, latestTimeListener);
+    }
+
+    private void getSampleRangesForValidationChecks(
+        Optional<Long> latestTime,
+        AnomalyDetector detector,
+        ActionListener<ValidateAnomalyDetectorResponse> listener,
+        Map<String, Object> topEntity
+    ) {
+        if (!latestTime.isPresent()) {
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.NOT_ENOUGH_HISTORICAL_DATA,
+                        DetectorValidationIssueType.GENERAL_DATA,
+                        ValidationAspect.MODEL
+                    )
+                );
+            return;
+        } else if (latestTime.get() <= 0) {
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.NOT_ENOUGH_HISTORICAL_DATA,
+                        DetectorValidationIssueType.GENERAL_DATA,
+                        ValidationAspect.MODEL
+                    )
+                );
+            return;
+        }
+        long timeRangeEnd = Math.min(Instant.now().toEpochMilli(), latestTime.get());
+        try {
+            getBucketAggregates(timeRangeEnd, listener, topEntity);
+        } catch (IOException e) {
+            listener.onFailure(new EndRunException(detector.getDetectorId(), CommonErrorMessages.INVALID_SEARCH_QUERY_MSG, e, true));
+            return;
+        }
+    }
+
+    private void getBucketAggregates(
+        long latestTime,
+        ActionListener<ValidateAnomalyDetectorResponse> listener,
+        Map<String, Object> topEntity
+    ) throws IOException {
+        List<String> featureFields = ParseUtils.getFeatureFieldNames(anomalyDetector, xContentRegistry);
+        AggregationBuilder aggregation = getBucketAggregation(latestTime);
+        BoolQueryBuilder query = QueryBuilders.boolQuery().filter(anomalyDetector.getFilterQuery());
+        if (anomalyDetector.isMultientityDetector()) {
+            for (Map.Entry<String, Object> entry : topEntity.entrySet()) {
+                query.filter(QueryBuilders.termQuery(entry.getKey(), entry.getValue()));
+            }
+        }
+        if (anomalyDetector.isMultiCategoryDetector()) {
+            for (String category : anomalyDetector.getCategoryField()) {
+                query.filter(QueryBuilders.existsQuery(category));
+            }
+        }
+        for (String featureField : featureFields) {
+            query.filter(QueryBuilders.existsQuery(featureField));
+        }
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .aggregation(aggregation)
+            .size(0)
+            .timeout(requestTimeout);
+        SearchRequest searchRequest = new SearchRequest(anomalyDetector.getIndices().toArray(new String[0])).source(searchSourceBuilder);
+        ActionListener<IntervalTimeConfiguration> intervalListener = ActionListener
+            .wrap(interval -> processIntervalRecommendation(interval, latestTime), exception -> {
+                listener.onFailure(exception);
+                logger.error("Failed to get interval recommendation", exception);
+                return;
+            });
+        client
+            .search(
+                searchRequest,
+                new ModelValidationActionHandler.DetectorIntervalRecommendationListener(
+                    intervalListener,
+                    searchRequest.source(),
+                    (IntervalTimeConfiguration) anomalyDetector.getDetectionInterval(),
+                    clock.millis() + TOP_VALIDATE_TIMEOUT_IN_MILLIS,
+                    latestTime
+                )
+            );
+    }
+
+    private double processBucketAggregationResults(Histogram buckets) {
+        int docCountOverOne = 0;
+        // For each entry
+        for (Histogram.Bucket entry : buckets.getBuckets()) {
+            if (entry.getDocCount() > 0) {
+                docCountOverOne++;
+            }
+        }
+        return (docCountOverOne / (double) getNumberOfSamples());
+    }
+
+    /**
+     * ActionListener class to handle bucketed search results in a paginated fashion.
+     * Note that the bucket_sort aggregation is a pipeline aggregation, and is executed
+     * after all non-pipeline aggregations (including the composite bucket aggregation).
+     * Because of this, the sorting is only done locally based on the buckets
+     * in the current page. To get around this issue, we use a max
+     * heap and add all results to the heap until there are no more result buckets,
+     * to get the globally sorted set of result buckets.
+     */
+    class DetectorIntervalRecommendationListener implements ActionListener<SearchResponse> {
+        private final ActionListener<IntervalTimeConfiguration> intervalListener;
+        SearchSourceBuilder searchSourceBuilder;
+        IntervalTimeConfiguration detectorInterval;
+        private final long expirationEpochMs;
+        private final long latestTime;
+
+        DetectorIntervalRecommendationListener(
+            ActionListener<IntervalTimeConfiguration> intervalListener,
+            SearchSourceBuilder searchSourceBuilder,
+            IntervalTimeConfiguration detectorInterval,
+            long expirationEpochMs,
+            long latestTime
+        ) {
+            this.intervalListener = intervalListener;
+            this.searchSourceBuilder = searchSourceBuilder;
+            this.detectorInterval = detectorInterval;
+            this.expirationEpochMs = expirationEpochMs;
+            this.latestTime = latestTime;
+        }
+
+        private AggregationBuilder getNewAggregationBuilder(long newInterval) {
+            return AggregationBuilders
+                .dateHistogram("agg")
+                .field(anomalyDetector.getTimeField())
+                .minDocCount(0)
+                .hardBounds(getTimeRangeBounds(latestTime, new IntervalTimeConfiguration(newInterval, ChronoUnit.MINUTES)))
+                .fixedInterval(DateHistogramInterval.minutes((int) newInterval));
+        }
+
+        private long convertIntervalToMinutes(IntervalTimeConfiguration interval) {
+            long currentInterval = interval.getInterval();
+            if (interval.getUnit() == ChronoUnit.MILLIS) {
+                currentInterval /= 60000;
+            }
+            return currentInterval;
+        }
+
+        @Override
+        public void onResponse(SearchResponse response) {
+            try {
+                Histogram aggregate = checkBucketResultErrors(response);
+                if (aggregate == null) {
+                    return;
+                }
+
+                double fullBucketRate = processBucketAggregationResults(aggregate);
+                long newInterval = (long) Math.ceil(convertIntervalToMinutes(detectorInterval) + 1);
+                // If rate is below success minimum then call search again.
+                if (fullBucketRate > INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE) {
+                    intervalListener.onResponse(this.detectorInterval);
+                } else if (expirationEpochMs < clock.millis()) {
+                    listener
+                        .onFailure(
+                            new AnomalyDetectionException(
+                                "Timed out getting interval recommendation. Please continue with detector creation."
+                            )
+                        );
+                    logger.info("Timed out getting interval recommendation");
+                } else if (newInterval < MAX_INTERVAL_REC_LENGTH_IN_MINUTES) {
+                    this.detectorInterval = new IntervalTimeConfiguration(newInterval, ChronoUnit.MINUTES);
+                    // Searching again using an updated interval
+                    SearchSourceBuilder updatedSearchSourceBuilder = getSearchSourceBuilder(
+                        searchSourceBuilder.query(),
+                        getNewAggregationBuilder(newInterval)
+                    );
+                    client
+                        .search(
+                            new SearchRequest()
+                                .indices(anomalyDetector.getIndices().toArray(new String[0]))
+                                .source(updatedSearchSourceBuilder),
+                            this
+                        );
+                    // this case means all intervals up to max interval recommendation length have been tried
+                    // which further means the next step is to go through A/B validation checks
+                } else {
+                    intervalListener.onResponse(null);
+                    return;
+                }
+
+            } catch (Exception e) {
+                onFailure(e);
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            logger.error("Failed to paginate top anomaly results", e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void processIntervalRecommendation(IntervalTimeConfiguration interval, long latestTime) {
+        if (interval == null) {
+            checkRawDataSparsity(latestTime);
+        } else {
+            if (interval.equals(anomalyDetector.getDetectionInterval())) {
+                logger.info("Using the current interval there is enough dense data ");
+                // The rate of buckets with at least 1 doc with given interval is above the success rate
+                listener.onResponse(null);
+                return;
+            }
+            // return response with interval recommendation
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.DETECTOR_INTERVAL_REC + interval.getInterval(),
+                        DetectorValidationIssueType.DETECTION_INTERVAL,
+                        ValidationAspect.MODEL,
+                        interval
+                    )
+                );
+        }
+    }
+
+    private AggregationBuilder getBucketAggregation(long latestTime) {
+        return AggregationBuilders
+            .dateHistogram("agg")
+            .field(anomalyDetector.getTimeField())
+            .minDocCount(0)
+            .hardBounds(getTimeRangeBounds(latestTime, (IntervalTimeConfiguration) anomalyDetector.getDetectionInterval()))
+            .fixedInterval(DateHistogramInterval.minutes((int) anomalyDetector.getDetectorIntervalInMinutes()));
+    }
+
+    private SearchSourceBuilder getSearchSourceBuilder(QueryBuilder query, AggregationBuilder aggregation) {
+        return new SearchSourceBuilder().query(query).aggregation(aggregation).size(0).timeout(requestTimeout);
+    }
+
+    private void checkRawDataSparsity(long latestTime) {
+        AggregationBuilder aggregation = getBucketAggregation(latestTime);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().aggregation(aggregation).size(0).timeout(requestTimeout);
+        try {
+            AggregatorFactories.Builder internalAgg = parseAggregators(
+                anomalyDetector.getFeatureAttributes().get(0).getAggregation().toString(),
+                xContentRegistry,
+                anomalyDetector.getFeatureAttributes().get(0).getId()
+            );
+            aggregation.subAggregation(internalAgg.getAggregatorFactories().iterator().next());
+            SearchRequest searchRequest = new SearchRequest(anomalyDetector.getIndices().toArray(new String[0]))
+                .source(searchSourceBuilder);
+            client.search(searchRequest, ActionListener.wrap(response -> processRawDataResults(response, latestTime), listener::onFailure));
+        } catch (Exception ex) {
+            listener.onFailure(ex);
+        }
+    }
+
+    private Histogram checkBucketResultErrors(SearchResponse response) {
+        Aggregations aggs = response.getAggregations();
+        if (aggs == null) {
+            // This would indicate some bug or some opensearch core changes that we are not aware of (we don't keep up-to-date with
+            // the large amounts of changes there). For this reason I'm not throwing a SearchException but instead a validation exception
+            // which will be converted to validation response.
+            logger.warn("Unexpected null aggregation.");
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.MODEL_VALIDATION_FAILED_UNEXPECTEDLY,
+                        DetectorValidationIssueType.MODEL_VALIDATION_ISSUE,
+                        ValidationAspect.MODEL
+                    )
+                );
+            return null;
+        }
+        Histogram aggregate = aggs.get("agg");
+        if (aggregate == null) {
+            listener.onFailure(new IllegalArgumentException("Failed to find valid aggregation result"));
+            return null;
+        }
+        return aggregate;
+    }
+
+    private void processRawDataResults(SearchResponse response, long latestTime) {
+        Histogram aggregate = checkBucketResultErrors(response);
+        if (aggregate == null) {
+            return;
+        }
+        double fullBucketRate = processBucketAggregationResults(aggregate);
+        if (fullBucketRate < CONFIG_BUCKET_MINIMUM_SUCCESS_RATE) {
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.RAW_DATA_TOO_SPARSE,
+                        DetectorValidationIssueType.INDICES,
+                        ValidationAspect.MODEL
+                    )
+                );
+        } else {
+            checkDataFilterSparsity(latestTime);
+        }
+    }
+
+    private void checkDataFilterSparsity(long latestTime) {
+        AggregationBuilder aggregation = getBucketAggregation(latestTime);
+        BoolQueryBuilder query = QueryBuilders.boolQuery().filter(anomalyDetector.getFilterQuery());
+        SearchSourceBuilder searchSourceBuilder = getSearchSourceBuilder(query, aggregation);
+        SearchRequest searchRequest = new SearchRequest(anomalyDetector.getIndices().toArray(new String[0])).source(searchSourceBuilder);
+        client.search(searchRequest, ActionListener.wrap(response -> processDataFilterResults(response, latestTime), listener::onFailure));
+    }
+
+    private void processDataFilterResults(SearchResponse response, long latestTime) {
+        Histogram aggregate = checkBucketResultErrors(response);
+        if (aggregate == null) {
+            return;
+        }
+        double fullBucketRate = processBucketAggregationResults(aggregate);
+        if (fullBucketRate < CONFIG_BUCKET_MINIMUM_SUCCESS_RATE) {
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.FILTER_QUERY_TOO_SPARSE,
+                        DetectorValidationIssueType.FILTER_QUERY,
+                        ValidationAspect.MODEL
+                    )
+                );
+        } else if (anomalyDetector.isMultientityDetector()) {
+            getTopEntityForCategoryField(latestTime);
+        } else {
+            try {
+                checkFeatureQuery(latestTime);
+            } catch (Exception ex) {
+                logger.error(ex);
+                listener.onFailure(ex);
+            }
+        }
+    }
+
+    private void getTopEntityForCategoryField(long latestTime) {
+        ActionListener<Map<String, Object>> getTopEntityListener = ActionListener
+            .wrap(topEntity -> checkCategoryFieldSparsity(topEntity, latestTime), exception -> {
+                listener.onFailure(exception);
+                logger.error("Failed to get top entity for categorical field", exception);
+                return;
+            });
+        getTopEntity(getTopEntityListener);
+    }
+
+    private void checkCategoryFieldSparsity(Map<String, Object> topEntity, long latestTime) {
+        if (topEntity.isEmpty()) {
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.CATEGORY_FIELD_TOO_SPARSE,
+                        DetectorValidationIssueType.CATEGORY,
+                        ValidationAspect.MODEL
+                    )
+                );
+            return;
+        }
+        BoolQueryBuilder query = QueryBuilders.boolQuery().filter(anomalyDetector.getFilterQuery());
+        for (Map.Entry<String, Object> entry : topEntity.entrySet()) {
+            query.filter(QueryBuilders.termQuery(entry.getKey(), entry.getValue()));
+        }
+        AggregationBuilder aggregation = getBucketAggregation(latestTime);
+        SearchSourceBuilder searchSourceBuilder = getSearchSourceBuilder(query, aggregation);
+        SearchRequest searchRequest = new SearchRequest(anomalyDetector.getIndices().toArray(new String[0])).source(searchSourceBuilder);
+        client.search(searchRequest, ActionListener.wrap(response -> processTopEntityResults(response, latestTime), listener::onFailure));
+    }
+
+    private void processTopEntityResults(SearchResponse response, long latestTime) {
+        Histogram aggregate = checkBucketResultErrors(response);
+        if (aggregate == null) {
+            return;
+        }
+        double fullBucketRate = processBucketAggregationResults(aggregate);
+        if (fullBucketRate < CONFIG_BUCKET_MINIMUM_SUCCESS_RATE) {
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.CATEGORY_FIELD_TOO_SPARSE,
+                        DetectorValidationIssueType.CATEGORY,
+                        ValidationAspect.MODEL
+                    )
+                );
+            return;
+        } else {
+            try {
+                checkFeatureQuery(latestTime);
+            } catch (Exception ex) {
+                logger.error(ex);
+                listener.onFailure(ex);
+            }
+        }
+    }
+
+    private void checkFeatureQuery(long latestTime) throws IOException {
+        ActionListener<MergeableList<double[]>> validateFeatureQueriesListener = ActionListener
+            .wrap(response -> { windowDelayRecommendation(latestTime); }, exception -> {
+                listener
+                    .onFailure(
+                        new ADValidationException(
+                            exception.getMessage(),
+                            DetectorValidationIssueType.FEATURE_ATTRIBUTES,
+                            ValidationAspect.DETECTOR
+                        )
+                    );
+            });
+        MultiResponsesDelegateActionListener<MergeableList<double[]>> multiFeatureQueriesResponseListener =
+            new MultiResponsesDelegateActionListener<>(
+                validateFeatureQueriesListener,
+                anomalyDetector.getFeatureAttributes().size(),
+                String.format(Locale.ROOT, CommonErrorMessages.VALIDATION_FEATURE_FAILURE, anomalyDetector.getName()),
+                false
+            );
+
+        for (Feature feature : anomalyDetector.getFeatureAttributes()) {
+            AggregationBuilder aggregation = getBucketAggregation(latestTime);
+            BoolQueryBuilder query = QueryBuilders.boolQuery().filter(anomalyDetector.getFilterQuery());
+            List<String> featureFields = ParseUtils.getFieldNamesForFeature(feature, xContentRegistry);
+            for (String featureField : featureFields) {
+                query.filter(QueryBuilders.existsQuery(featureField));
+            }
+            SearchSourceBuilder searchSourceBuilder = getSearchSourceBuilder(query, aggregation);
+            SearchRequest searchRequest = new SearchRequest(anomalyDetector.getIndices().toArray(new String[0]))
+                .source(searchSourceBuilder);
+            client.search(searchRequest, ActionListener.wrap(response -> {
+                Histogram aggregate = checkBucketResultErrors(response);
+                if (aggregate == null) {
+                    return;
+                }
+                double fullBucketRate = processBucketAggregationResults(aggregate);
+                if (fullBucketRate < CONFIG_BUCKET_MINIMUM_SUCCESS_RATE) {
+                    multiFeatureQueriesResponseListener
+                        .onFailure(
+                            new ADValidationException(
+                                CommonErrorMessages.FEATURE_QUERY_TOO_SPARSE + feature.getName(),
+                                DetectorValidationIssueType.FEATURE_ATTRIBUTES,
+                                ValidationAspect.MODEL
+                            )
+                        );
+                } else {
+                    multiFeatureQueriesResponseListener
+                        .onResponse(new MergeableList<>(new ArrayList<>(Collections.singletonList(new double[] { fullBucketRate }))));
+                }
+            }, e -> {
+                String errorMessage;
+                if (isExceptionCausedByInvalidQuery(e)) {
+                    errorMessage = CommonErrorMessages.FEATURE_WITH_INVALID_QUERY_MSG + feature.getName();
+                } else {
+                    errorMessage = CommonErrorMessages.UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG + feature.getName();
+                }
+                logger.error(errorMessage, e);
+                multiFeatureQueriesResponseListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.BAD_REQUEST, e));
+            }));
+        }
+    }
+
+    private void windowDelayRecommendation(long latestTime) {
+        long delayMillis = timeConfigToMilliSec(anomalyDetector.getWindowDelay());
+        if ((Instant.now().toEpochMilli() - latestTime > delayMillis)) {
+            long minutesSinceLastStamp = TimeUnit.MILLISECONDS.toMinutes(Instant.now().toEpochMilli() - latestTime);
+            listener
+                .onFailure(
+                    new ADValidationException(
+                        CommonErrorMessages.WINDOW_DELAY_REC + minutesSinceLastStamp,
+                        DetectorValidationIssueType.WINDOW_DELAY,
+                        ValidationAspect.MODEL,
+                        new IntervalTimeConfiguration(minutesSinceLastStamp, ChronoUnit.MINUTES)
+                    )
+                );
+            return;
+        }
+        listener.onResponse(null);
+    }
+
+    private LongBounds getTimeRangeBounds(long endMillis, IntervalTimeConfiguration detectorIntervalInMinutes) {
+        Long detectorInterval = timeConfigToMilliSec(detectorIntervalInMinutes);
+        Long startMillis = endMillis - ((long) getNumberOfSamples() * detectorInterval);
+        return new LongBounds(startMillis, endMillis);
+    }
+
+    private int getNumberOfSamples() {
+        long interval = anomalyDetector.getDetectorIntervalInMilliseconds();
+        return Math
+            .max(
+                (int) (Duration.ofHours(AnomalyDetectorSettings.TRAIN_SAMPLE_TIME_RANGE_IN_HOURS).toMillis() / interval),
+                AnomalyDetectorSettings.MIN_TRAIN_SAMPLES
+            );
+    }
+
+    private Long timeConfigToMilliSec(TimeConfiguration config) {
+        return Optional.ofNullable((IntervalTimeConfiguration) config).map(t -> t.toDuration().toMillis()).orElse(0L);
+    }
+}

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -552,7 +552,7 @@ public class ModelValidationActionHandler {
             return;
         }
         double fullBucketRate = processBucketAggregationResults(aggregate);
-        if (fullBucketRate < CONFIG_BUCKET_MINIMUM_SUCCESS_RATE) {
+        if (fullBucketRate < INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE) {
             listener
                 .onFailure(
                     new ADValidationException(

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -132,6 +132,8 @@ public class ModelValidationActionHandler {
     // If detector is HCAD then we will find the top entity and treat as single entity for
     // validation purposes
     public void checkIfMultiEntityDetector() {
+        System.out.println("inside here");
+
         ActionListener<Map<String, Object>> recommendationListener = ActionListener
             .wrap(topEntity -> getLatestDateForValidation(topEntity), exception -> {
                 listener.onFailure(exception);
@@ -276,7 +278,7 @@ public class ModelValidationActionHandler {
                 listener
                     .onFailure(
                         new ADValidationException(
-                            CommonErrorMessages.CATEGORY_FIELD_NO_DATA,
+                            CommonErrorMessages.CATEGORY_FIELD_TOO_SPARSE,
                             DetectorValidationIssueType.CATEGORY,
                             ValidationAspect.MODEL
                         )
@@ -381,6 +383,7 @@ public class ModelValidationActionHandler {
                         );
                 }
                 double fullBucketRate = processBucketAggregationResults(aggregate);
+                System.out.println("full bucket rate: " + fullBucketRate);
                 // If rate is above success minimum then return interval suggestion.
                 if (fullBucketRate > INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE) {
                     intervalListener.onResponse(this.detectorInterval);

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -795,7 +795,12 @@ public final class AnomalyDetectorSettings {
     // ======================================
     public static final long TOP_VALIDATE_TIMEOUT_IN_MILLIS = 60_000;
     public static final long MAX_INTERVAL_REC_LENGTH_IN_MINUTES = 120L;
-    public static final double INTERVAL_RECOMMENDATION_MULTIPLIER = 1.2;
+    public static final double INTERVAL_RECOMMENDATION_INCREASING_MULTIPLIER = 1.2;
+    public static final double INTERVAL_RECOMMENDATION_DECREASING_MULTIPLIER = 0.8;
     public static final double INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE = 0.75;
     public static final double CONFIG_BUCKET_MINIMUM_SUCCESS_RATE = 0.25;
+    // This value is set to decrease the number of times we decrease the interval when recommending a new one
+    // The reason we need a max is because user could give an arbitrarly large interval where we don't know even
+    // with multiplying the interval down how many intervals will be tried.
+    public static final int MAX_TIMES_DECREASING_INTERVAL = 10;
 }

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -793,8 +793,8 @@ public final class AnomalyDetectorSettings {
     // ======================================
     // Validate Detector API setting
     // ======================================
-    public static final long TOP_VALIDATE_TIMEOUT_IN_MILLIS = 60_000;
-    public static final long MAX_INTERVAL_REC_LENGTH_IN_MINUTES = 120L;
+    public static final long TOP_VALIDATE_TIMEOUT_IN_MILLIS = 10_000;
+    public static final long MAX_INTERVAL_REC_LENGTH_IN_MINUTES = 60L;
     public static final double INTERVAL_RECOMMENDATION_INCREASING_MULTIPLIER = 1.2;
     public static final double INTERVAL_RECOMMENDATION_DECREASING_MULTIPLIER = 0.8;
     public static final double INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE = 0.75;

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -789,4 +789,13 @@ public final class AnomalyDetectorSettings {
     // Cold start setting
     // ======================================
     public static int MAX_COLD_START_ROUNDS = 2;
+
+    // ======================================
+    // Validate Detector API setting
+    // ======================================
+    public static final long TOP_VALIDATE_TIMEOUT_IN_MILLIS = 60_000;
+    public static final long MAX_INTERVAL_REC_LENGTH_IN_MINUTES = 120L;
+    public static final double INTERVAL_RECOMMENDATION_MULTIPLIER = 1.2;
+    public static final double INTERVAL_BUCKET_MINIMUM_SUCCESS_RATE = 0.75;
+    public static final double CONFIG_BUCKET_MINIMUM_SUCCESS_RATE = 0.25;
 }

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -15,6 +15,7 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKE
 import static org.opensearch.ad.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
 
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -33,6 +34,7 @@ import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorValidationIssue;
 import org.opensearch.ad.model.DetectorValidationIssueType;
+import org.opensearch.ad.model.IntervalTimeConfiguration;
 import org.opensearch.ad.model.ValidationAspect;
 import org.opensearch.ad.rest.handler.AnomalyDetectorFunction;
 import org.opensearch.ad.rest.handler.ValidateAnomalyDetectorActionHandler;
@@ -61,6 +63,7 @@ public class ValidateAnomalyDetectorTransportAction extends
     private final AnomalyDetectionIndices anomalyDetectionIndices;
     private final SearchFeatureDao searchFeatureDao;
     private volatile Boolean filterByEnabled;
+    private Clock clock;
 
     @Inject
     public ValidateAnomalyDetectorTransportAction(
@@ -81,6 +84,7 @@ public class ValidateAnomalyDetectorTransportAction extends
         this.filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.searchFeatureDao = searchFeatureDao;
+        this.clock = Clock.systemUTC();
     }
 
     @Override
@@ -150,7 +154,8 @@ public class ValidateAnomalyDetectorTransportAction extends
                 xContentRegistry,
                 user,
                 searchFeatureDao,
-                request.getValidationType()
+                request.getValidationType(),
+                clock
             );
             try {
                 handler.start();
@@ -167,7 +172,7 @@ public class ValidateAnomalyDetectorTransportAction extends
         String originalErrorMessage = exception.getMessage();
         String errorMessage = "";
         Map<String, String> subIssues = null;
-        String suggestion = null;
+        IntervalTimeConfiguration intervalSuggestion = null;
 
         switch (exception.getType()) {
             case FEATURE_ATTRIBUTES:
@@ -186,17 +191,24 @@ public class ValidateAnomalyDetectorTransportAction extends
             case NAME:
             case CATEGORY:
             case DETECTION_INTERVAL:
+                if (exception.getAspect().equals(ValidationAspect.MODEL)) {
+                    intervalSuggestion = exception.getIntervalSuggestion();
+                }
             case FILTER_QUERY:
             case TIMEFIELD_FIELD:
             case SHINGLE_SIZE_FIELD:
             case WINDOW_DELAY:
+                if (exception.getAspect().equals(ValidationAspect.MODEL)) {
+                    intervalSuggestion = exception.getIntervalSuggestion();
+                }
             case RESULT_INDEX:
             case GENERAL_SETTINGS:
+            case MODEL_VALIDATION_ISSUE:
             case INDICES:
                 errorMessage = originalErrorMessage;
                 break;
         }
-        return new DetectorValidationIssue(exception.getAspect(), exception.getType(), errorMessage, subIssues, suggestion);
+        return new DetectorValidationIssue(exception.getAspect(), exception.getType(), errorMessage, subIssues, intervalSuggestion);
     }
 
     // Example of method output:

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -172,8 +172,7 @@ public class ValidateAnomalyDetectorTransportAction extends
         String originalErrorMessage = exception.getMessage();
         String errorMessage = "";
         Map<String, String> subIssues = null;
-        IntervalTimeConfiguration intervalSuggestion = null;
-
+        IntervalTimeConfiguration intervalSuggestion = exception.getIntervalSuggestion();
         switch (exception.getType()) {
             case FEATURE_ATTRIBUTES:
                 int firstLeftBracketIndex = originalErrorMessage.indexOf("[");
@@ -191,16 +190,10 @@ public class ValidateAnomalyDetectorTransportAction extends
             case NAME:
             case CATEGORY:
             case DETECTION_INTERVAL:
-                if (exception.getAspect().equals(ValidationAspect.MODEL)) {
-                    intervalSuggestion = exception.getIntervalSuggestion();
-                }
             case FILTER_QUERY:
             case TIMEFIELD_FIELD:
             case SHINGLE_SIZE_FIELD:
             case WINDOW_DELAY:
-                if (exception.getAspect().equals(ValidationAspect.MODEL)) {
-                    intervalSuggestion = exception.getIntervalSuggestion();
-                }
             case RESULT_INDEX:
             case GENERAL_SETTINGS:
             case MODEL_VALIDATION_ISSUE:

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -196,7 +196,8 @@ public class ValidateAnomalyDetectorTransportAction extends
             case WINDOW_DELAY:
             case RESULT_INDEX:
             case GENERAL_SETTINGS:
-            case MODEL_VALIDATION_ISSUE:
+            case AGGREGATION:
+            case TIMEOUT:
             case INDICES:
                 errorMessage = originalErrorMessage;
                 break;

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -212,7 +212,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
 
         // extend NodeClient since its execute method is final and mockito does not allow to mock final methods
         // we can also use spy to overstep the final methods
-        NodeClient client = getCustomNodeClient(detectorResponse, userIndexResponse);
+        NodeClient client = getCustomNodeClient(detectorResponse, userIndexResponse, detector, threadPool);
         NodeClient clientSpy = spy(client);
 
         handler = new IndexAnomalyDetectorActionHandler(
@@ -501,7 +501,6 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         } else {
             assertTrue(value.getMessage().contains(IndexAnomalyDetectorActionHandler.CATEGORICAL_FIELD_TYPE_ERR_MSG));
         }
-
     }
 
     @Ignore
@@ -519,8 +518,13 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         testUpdateTemplate(TEXT_FIELD_TYPE);
     }
 
-    private NodeClient getCustomNodeClient(SearchResponse detectorResponse, SearchResponse userIndexResponse) {
-        return new NodeClient(Settings.EMPTY, threadPool) {
+    public static NodeClient getCustomNodeClient(
+        SearchResponse detectorResponse,
+        SearchResponse userIndexResponse,
+        AnomalyDetector detector,
+        ThreadPool pool
+    ) {
+        return new NodeClient(Settings.EMPTY, pool) {
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,
@@ -562,7 +566,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         when(userIndexResponse.getHits()).thenReturn(TestHelpers.createSearchHits(userIndexHits));
         // extend NodeClient since its execute method is final and mockito does not allow to mock final methods
         // we can also use spy to overstep the final methods
-        NodeClient client = getCustomNodeClient(detectorResponse, userIndexResponse);
+        NodeClient client = getCustomNodeClient(detectorResponse, userIndexResponse, detector, threadPool);
         NodeClient clientSpy = spy(client);
 
         handler = new IndexAnomalyDetectorActionHandler(

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -26,13 +26,13 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.mockito.ArgumentCaptor;
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
@@ -47,12 +47,10 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.common.exception.ADValidationException;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
-import org.opensearch.ad.model.Feature;
 import org.opensearch.ad.rest.handler.IndexAnomalyDetectorActionHandler;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.ad.transport.IndexAnomalyDetectorResponse;
@@ -68,8 +66,6 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  *
@@ -204,26 +200,24 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void testNoCategoricalField() throws IOException {
+    public void testMoreThanTenThousandSingleEntityDetectors() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
         int totalHits = 1001;
         when(mockResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 2);
+        SearchResponse detectorResponse = mock(SearchResponse.class);
+        when(detectorResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
+        SearchResponse userIndexResponse = mock(SearchResponse.class);
+        int userIndexHits = 0;
+        when(userIndexResponse.getHits()).thenReturn(TestHelpers.createSearchHits(userIndexHits));
 
-            assertTrue(args[0] instanceof SearchRequest);
-            assertTrue(args[1] instanceof ActionListener);
-
-            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
-            listener.onResponse(mockResponse);
-
-            return null;
-        }).when(clientMock).search(any(SearchRequest.class), any());
+        // extend NodeClient since its execute method is final and mockito does not allow to mock final methods
+        // we can also use spy to overstep the final methods
+        NodeClient client = getCustomNodeClient(detectorResponse, userIndexResponse);
+        NodeClient clientSpy = spy(client);
 
         handler = new IndexAnomalyDetectorActionHandler(
             clusterService,
-            clientMock,
+            clientSpy,
             transportService,
             channel,
             anomalyDetectionIndices,
@@ -281,9 +275,11 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
                     if (action.equals(SearchAction.INSTANCE)) {
                         listener.onResponse((Response) detectorResponse);
                     } else {
+                        // passes first get field mapping call where timestamp has to be of type date
+                        // fails on second call where categorical field is checked to be type keyword or IP
                         // we need to put the test in the same package of GetFieldMappingsResponse since its constructor is package private
                         GetFieldMappingsResponse response = new GetFieldMappingsResponse(
-                            TestHelpers.createFieldMappings(detector.getIndices().get(0), field, TEXT_FIELD_TYPE)
+                            TestHelpers.createFieldMappings(detector.getIndices().get(0), field, "date")
                         );
                         listener.onResponse((Response) response);
                     }
@@ -337,7 +333,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         SearchResponse userIndexResponse = mock(SearchResponse.class);
         int userIndexHits = 0;
         when(userIndexResponse.getHits()).thenReturn(TestHelpers.createSearchHits(userIndexHits));
-
+        AtomicBoolean isPreCategoryMappingQuery = new AtomicBoolean(true);
         // extend NodeClient since its execute method is final and mockito does not allow to mock final methods
         // we can also use spy to overstep the final methods
         NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
@@ -356,8 +352,13 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
                         } else {
                             listener.onResponse((Response) userIndexResponse);
                         }
+                    } else if (isPreCategoryMappingQuery.get()) {
+                        isPreCategoryMappingQuery.set(false);
+                        GetFieldMappingsResponse response = new GetFieldMappingsResponse(
+                            TestHelpers.createFieldMappings(detector.getIndices().get(0), field, "date")
+                        );
+                        listener.onResponse((Response) response);
                     } else {
-
                         GetFieldMappingsResponse response = new GetFieldMappingsResponse(
                             TestHelpers.createFieldMappings(detector.getIndices().get(0), field, filedTypeName)
                         );
@@ -397,7 +398,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
 
         handler.start();
 
-        verify(clientSpy, times(1)).execute(eq(GetFieldMappingsAction.INSTANCE), any(), any());
+        verify(clientSpy, times(2)).execute(eq(GetFieldMappingsAction.INSTANCE), any(), any());
         verify(channel).onFailure(response.capture());
         Exception value = response.getValue();
         assertTrue(value instanceof IllegalArgumentException);
@@ -518,32 +519,77 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         testUpdateTemplate(TEXT_FIELD_TYPE);
     }
 
+    private NodeClient getCustomNodeClient(SearchResponse detectorResponse, SearchResponse userIndexResponse) {
+        return new NodeClient(Settings.EMPTY, threadPool) {
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> action,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                try {
+                    if (action.equals(SearchAction.INSTANCE)) {
+                        assertTrue(request instanceof SearchRequest);
+                        SearchRequest searchRequest = (SearchRequest) request;
+                        if (searchRequest.indices()[0].equals(ANOMALY_DETECTORS_INDEX)) {
+                            listener.onResponse((Response) detectorResponse);
+                        } else {
+                            listener.onResponse((Response) userIndexResponse);
+                        }
+                    } else {
+                        GetFieldMappingsResponse response = new GetFieldMappingsResponse(
+                            TestHelpers.createFieldMappings(detector.getIndices().get(0), "timestamp", "date")
+                        );
+                        listener.onResponse((Response) response);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+    }
+
     @SuppressWarnings("unchecked")
     public void testMoreThanTenMultiEntityDetectors() throws IOException {
-        SearchResponse mockResponse = mock(SearchResponse.class);
-
+        String field = "a";
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(field));
+        SearchResponse detectorResponse = mock(SearchResponse.class);
         int totalHits = 11;
+        when(detectorResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
 
-        when(mockResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
+        SearchResponse userIndexResponse = mock(SearchResponse.class);
+        int userIndexHits = 0;
+        when(userIndexResponse.getHits()).thenReturn(TestHelpers.createSearchHits(userIndexHits));
+        // extend NodeClient since its execute method is final and mockito does not allow to mock final methods
+        // we can also use spy to overstep the final methods
+        NodeClient client = getCustomNodeClient(detectorResponse, userIndexResponse);
+        NodeClient clientSpy = spy(client);
 
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 2);
-
-            assertTrue(args[0] instanceof SearchRequest);
-            assertTrue(args[1] instanceof ActionListener);
-
-            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
-
-            listener.onResponse(mockResponse);
-
-            return null;
-        }).when(clientMock).search(any(SearchRequest.class), any());
+        handler = new IndexAnomalyDetectorActionHandler(
+            clusterService,
+            clientSpy,
+            transportService,
+            channel,
+            anomalyDetectionIndices,
+            detectorId,
+            seqNo,
+            primaryTerm,
+            refreshPolicy,
+            detector,
+            requestTimeout,
+            maxSingleEntityAnomalyDetectors,
+            maxMultiEntityAnomalyDetectors,
+            maxAnomalyFeatures,
+            method,
+            xContentRegistry(),
+            null,
+            adTaskManager,
+            searchFeatureDao
+        );
 
         handler.start();
-
         ArgumentCaptor<Exception> response = ArgumentCaptor.forClass(Exception.class);
-        verify(clientMock, times(1)).search(any(SearchRequest.class), any());
+        verify(clientSpy, times(1)).search(any(SearchRequest.class), any());
         verify(channel).onFailure(response.capture());
         Exception value = response.getValue();
         assertTrue(value instanceof IllegalArgumentException);
@@ -707,51 +753,5 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
         // make sure execution passes all necessary checks
         assertTrue(value instanceof IllegalStateException);
         assertTrue(value.getMessage().contains("NodeClient has not been initialized"));
-    }
-
-    @SuppressWarnings("unchecked")
-    public void testCreateAnomalyDetectorWithDuplicateFeatureAggregationNames() throws IOException {
-        Feature featureOne = TestHelpers.randomFeature("featureName", "test-1");
-        Feature featureTwo = TestHelpers.randomFeature("featureNameTwo", "test-1");
-        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(ImmutableList.of(featureOne, featureTwo));
-        SearchResponse mockResponse = mock(SearchResponse.class);
-        when(mockResponse.getHits()).thenReturn(TestHelpers.createSearchHits(9));
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 2);
-            assertTrue(args[0] instanceof SearchRequest);
-            assertTrue(args[1] instanceof ActionListener);
-            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
-            listener.onResponse(mockResponse);
-            return null;
-        }).when(clientMock).search(any(SearchRequest.class), any());
-
-        handler = new IndexAnomalyDetectorActionHandler(
-            clusterService,
-            clientMock,
-            transportService,
-            channel,
-            anomalyDetectionIndices,
-            detectorId,
-            seqNo,
-            primaryTerm,
-            refreshPolicy,
-            anomalyDetector,
-            requestTimeout,
-            maxSingleEntityAnomalyDetectors,
-            maxMultiEntityAnomalyDetectors,
-            maxAnomalyFeatures,
-            method,
-            xContentRegistry(),
-            null,
-            adTaskManager,
-            searchFeatureDao
-        );
-        ArgumentCaptor<Exception> response = ArgumentCaptor.forClass(Exception.class);
-        handler.start();
-        verify(channel).onFailure(response.capture());
-        Exception value = response.getValue();
-        assertTrue(value instanceof OpenSearchStatusException);
-        assertTrue(value.getMessage().contains(CommonErrorMessages.DUPLICATE_FEATURE_AGGREGATION_NAMES));
     }
 }

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Locale;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -126,7 +125,6 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Ignore
     public void testValidateMoreThanThousandSingleEntityDetectorLimit() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
         int totalHits = maxSingleEntityAnomalyDetectors + 1;
@@ -177,7 +175,6 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Ignore
     public void testValidateMoreThanTenMultiEntityDetectorsLimit() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
 

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
@@ -21,10 +21,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Locale;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -54,6 +56,8 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import com.google.common.collect.ImmutableList;
+
 public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
 
     protected AbstractAnomalyDetectorActionHandler<ValidateAnomalyDetectorResponse> handler;
@@ -74,6 +78,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     protected RestRequest.Method method;
     protected ADTaskManager adTaskManager;
     protected SearchFeatureDao searchFeatureDao;
+    protected Clock clock;
 
     @Mock
     private Client clientMock;
@@ -99,11 +104,13 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
         detectorId = "123";
         seqNo = 0L;
         primaryTerm = 0L;
+        clock = mock(Clock.class);
 
         refreshPolicy = WriteRequest.RefreshPolicy.IMMEDIATE;
 
         String field = "a";
-        detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(field));
+        detector = TestHelpers
+            .randomAnomalyDetectorUsingCategoryFields(detectorId, "timestamp", ImmutableList.of("test-index"), Arrays.asList(field));
 
         requestTimeout = new TimeValue(1000L);
         maxSingleEntityAnomalyDetectors = 1000;
@@ -119,6 +126,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
+    @Ignore
     public void testValidateMoreThanThousandSingleEntityDetectorLimit() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
         int totalHits = maxSingleEntityAnomalyDetectors + 1;
@@ -150,7 +158,8 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
             xContentRegistry(),
             null,
             searchFeatureDao,
-            ValidationAspect.DETECTOR.getName()
+            ValidationAspect.DETECTOR.getName(),
+            clock
         );
         handler.start();
         ArgumentCaptor<Exception> response = ArgumentCaptor.forClass(Exception.class);
@@ -168,6 +177,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
+    @Ignore
     public void testValidateMoreThanTenMultiEntityDetectorsLimit() throws IOException {
         SearchResponse mockResponse = mock(SearchResponse.class);
 
@@ -203,7 +213,8 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
             xContentRegistry(),
             null,
             searchFeatureDao,
-            ""
+            "",
+            clock
         );
         handler.start();
 

--- a/src/test/java/org/opensearch/ad/ADIntegTestCase.java
+++ b/src/test/java/org/opensearch/ad/ADIntegTestCase.java
@@ -322,4 +322,11 @@ public abstract class ADIntegTestCase extends OpenSearchIntegTestCase {
             .parseAggregation("{\"" + aggregationName + "\":{\"max\":{\"field\":\"" + fieldName + "\"}}}");
         return new Feature(randomAlphaOfLength(5), featureName, true, aggregationBuilder);
     }
+
+    public Feature sumValueFeature(String aggregationName, String fieldName, String featureName) throws IOException {
+        AggregationBuilder aggregationBuilder = TestHelpers
+            .parseAggregation("{\"" + aggregationName + "\":{\"value_count\":{\"field\":\"" + fieldName + "\"}}}");
+        return new Feature(randomAlphaOfLength(5), featureName, true, aggregationBuilder);
+    }
+
 }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -154,7 +154,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
         // step comes next in terms of accessing/update/deleting the detector, this will help avoid
         // lots of flaky tests
         try {
-            Thread.sleep(2500);
+            Thread.sleep(5000);
         } catch (InterruptedException ex) {
             logger.error("Failed to sleep after creating detector", ex);
         }

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -412,13 +412,21 @@ public class TestHelpers {
     }
 
     public static AnomalyDetector randomAnomalyDetector(List<Feature> features) throws IOException {
+        return randomAnomalyDetector(randomAlphaOfLength(5), randomAlphaOfLength(10).toLowerCase(), features);
+    }
+
+    public static AnomalyDetector randomAnomalyDetector(String timefield, String indexName) throws IOException {
+        return randomAnomalyDetector(timefield, indexName, ImmutableList.of(randomFeature(true)));
+    }
+
+    public static AnomalyDetector randomAnomalyDetector(String timefield, String indexName, List<Feature> features) throws IOException {
         return new AnomalyDetector(
             randomAlphaOfLength(10),
             randomLong(),
             randomAlphaOfLength(20),
             randomAlphaOfLength(30),
-            randomAlphaOfLength(5),
-            ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+            timefield,
+            ImmutableList.of(indexName.toLowerCase()),
             features,
             randomQuery(),
             randomIntervalTimeConfiguration(),
@@ -1051,6 +1059,24 @@ public class TestHelpers {
                 data,
                 null
             );
+    }
+
+    public static void createIndexWithTimeField(RestClient client, String indexName, String timeField) throws IOException {
+        StringBuilder indexMappings = new StringBuilder();
+        indexMappings.append("{\"properties\":{");
+        indexMappings.append("\"" + timeField + "\":{\"type\":\"date\"}");
+        indexMappings.append("}}");
+        createIndex(client, indexName.toLowerCase(), TestHelpers.toHttpEntity("{\"name\": \"test\"}"));
+        createIndexMapping(client, indexName.toLowerCase(), TestHelpers.toHttpEntity(indexMappings.toString()));
+    }
+
+    public static void createEmptyIndexWithTimeField(RestClient client, String indexName, String timeField) throws IOException {
+        StringBuilder indexMappings = new StringBuilder();
+        indexMappings.append("{\"properties\":{");
+        indexMappings.append("\"" + timeField + "\":{\"type\":\"date\"}");
+        indexMappings.append("}}");
+        createEmptyIndex(client, indexName.toLowerCase());
+        createIndexMapping(client, indexName.toLowerCase(), TestHelpers.toHttpEntity(indexMappings.toString()));
     }
 
     public static void createIndexWithHCADFields(RestClient client, String indexName, Map<String, String> categoryFieldsAndTypes)

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -336,7 +336,6 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
         long recDetectorIntervalMinutes = recDetectorIntervalMillis / 60000;
         List<JsonObject> data = createData(2000, recDetectorIntervalMillis);
         indexTrainData("validation", data, 2000, client);
-        indexTestData(data, "validation", 2000, client);
         long detectorInterval = 1;
         String requestBody = String
             .format(
@@ -391,19 +390,6 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
         client.performRequest(request);
         Thread.sleep(1_000);
         data.stream().limit(trainTestSplit).forEach(r -> {
-            try {
-                Request req = new Request("POST", String.format("/%s/_doc/", datasetName));
-                req.setJsonEntity(r.toString());
-                client.performRequest(req);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        Thread.sleep(1_000);
-    }
-
-    private void indexTestData(List<JsonObject> data, String datasetName, int trainTestSplit, RestClient client) throws Exception {
-        data.stream().skip(trainTestSplit).forEach(r -> {
             try {
                 Request req = new Request("POST", String.format("/%s/_doc/", datasetName));
                 req.setJsonEntity(r.toString());

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -334,7 +334,6 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
         RestClient client = client();
         long recDetectorIntervalMillis = 180000;
         long recDetectorIntervalMinutes = recDetectorIntervalMillis / 60000;
-        System.out.println(recDetectorIntervalMinutes);
         List<JsonObject> data = createData(2000, recDetectorIntervalMillis);
         indexTrainData("validation", data, 2000, client);
         indexTestData(data, "validation", 2000, client);

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -36,18 +36,24 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.opensearch.ad.ODFERestTestCase;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.WarningsHandler;
 import org.opensearch.common.Strings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.common.xcontent.support.XContentMapValues;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 public class DetectionResultEvalutationIT extends ODFERestTestCase {
     protected static final Logger LOG = (Logger) LogManager.getLogger(DetectionResultEvalutationIT.class);
@@ -322,5 +328,91 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
         request.setJsonEntity(Strings.toString(settingCommand));
 
         adminClient().performRequest(request);
+    }
+
+    public void testValidationIntervalRecommendation() throws Exception {
+        RestClient client = client();
+        long recDetectorIntervalMillis = 180000;
+        long recDetectorIntervalMinutes = recDetectorIntervalMillis / 60000;
+        System.out.println(recDetectorIntervalMinutes);
+        List<JsonObject> data = createData(2000, recDetectorIntervalMillis);
+        indexTrainData("validation", data, 2000, client);
+        indexTestData(data, "validation", 2000, client);
+        long detectorInterval = 1;
+        String requestBody = String
+            .format(
+                Locale.ROOT,
+                "{ \"name\": \"test\", \"description\": \"test\", \"time_field\": \"timestamp\""
+                    + ", \"indices\": [\"validation\"], \"feature_attributes\": [{ \"feature_name\": \"feature 1\", \"feature_enabled\": "
+                    + "\"true\", \"aggregation_query\": { \"Feature1\": { \"sum\": { \"field\": \"Feature1\" } } } }, { \"feature_name\""
+                    + ": \"feature 2\", \"feature_enabled\": \"true\", \"aggregation_query\": { \"Feature2\": { \"sum\": { \"field\": "
+                    + "\"Feature2\" } } } }], \"detection_interval\": { \"period\": { \"interval\": %d, \"unit\": \"Minutes\" } }"
+                    + ",\"window_delay\":{\"period\":{\"interval\":10,\"unit\":\"Minutes\"}}}",
+                detectorInterval
+            );
+        Response resp = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/_validate/model",
+                ImmutableMap.of(),
+                toHttpEntity(requestBody),
+                null
+            );
+        Map<String, Object> responseMap = entityAsMap(resp);
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, String>> messageMap = (Map<String, Map<String, String>>) XContentMapValues
+            .extractValue("model", responseMap);
+        assertEquals(
+            CommonErrorMessages.DETECTOR_INTERVAL_REC + recDetectorIntervalMinutes,
+            messageMap.get("detection_interval").get("message")
+        );
+    }
+
+    private List<JsonObject> createData(int numOfDataPoints, long detectorIntervalMS) {
+        List<JsonObject> list = new ArrayList<>();
+        for (int i = 1; i < numOfDataPoints; i++) {
+            long valueFeature1 = randomLongBetween(1, 10000000);
+            long valueFeature2 = randomLongBetween(1, 10000000);
+            JsonObject obj = new JsonObject();
+            JsonElement element = new JsonPrimitive(Instant.now().toEpochMilli() - (detectorIntervalMS * i));
+            obj.add("timestamp", element);
+            obj.add("Feature1", new JsonPrimitive(valueFeature1));
+            obj.add("Feature2", new JsonPrimitive(valueFeature2));
+            list.add(obj);
+        }
+        return list;
+    }
+
+    private void indexTrainData(String datasetName, List<JsonObject> data, int trainTestSplit, RestClient client) throws Exception {
+        Request request = new Request("PUT", datasetName);
+        String requestBody = "{ \"mappings\": { \"properties\": { \"timestamp\": { \"type\": \"date\"},"
+            + " \"Feature1\": { \"type\": \"long\" }, \"Feature2\": { \"type\": \"long\" } } } }";
+        request.setJsonEntity(requestBody);
+        client.performRequest(request);
+        Thread.sleep(1_000);
+        data.stream().limit(trainTestSplit).forEach(r -> {
+            try {
+                Request req = new Request("POST", String.format("/%s/_doc/", datasetName));
+                req.setJsonEntity(r.toString());
+                client.performRequest(req);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        Thread.sleep(1_000);
+    }
+
+    private void indexTestData(List<JsonObject> data, String datasetName, int trainTestSplit, RestClient client) throws Exception {
+        data.stream().skip(trainTestSplit).forEach(r -> {
+            try {
+                Request req = new Request("POST", String.format("/%s/_doc/", datasetName));
+                req.setJsonEntity(r.toString());
+                client.performRequest(req);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        Thread.sleep(1_000);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 import org.junit.Test;
 import org.opensearch.ad.ADIntegTestCase;
@@ -40,13 +41,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
     @Test
     public void testValidateAnomalyDetectorWithNoIssue() throws IOException {
         AnomalyDetector anomalyDetector = TestHelpers
-            .randomAnomalyDetector(
-                "timestamp",
-                "test-index",
-                ImmutableList.of(sumValueFeature(nameField, ipField + ".is_error", "test-2"))
-            );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+            .randomAnomalyDetector(timeField, "test-index", ImmutableList.of(sumValueFeature(nameField, ipField + ".is_error", "test-2")));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -79,9 +75,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
 
     @Test
     public void testValidateAnomalyDetectorWithDuplicateName() throws IOException {
-        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector("timestamp", "index-test");
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(timeField, "index-test");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         createDetectorIndex();
         createDetector(anomalyDetector);
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
@@ -101,9 +96,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
     @Test
     public void testValidateAnomalyDetectorWithNonExistingFeatureField() throws IOException {
         Feature maxFeature = maxValueFeature(nameField, "non_existing_field", nameField);
-        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector("timestamp", "test-index", ImmutableList.of(maxFeature));
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(timeField, "test-index", ImmutableList.of(maxFeature));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -126,9 +120,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         Feature maxFeature = maxValueFeature(nameField, categoryField, "test-1");
         Feature maxFeatureTwo = maxValueFeature(nameField, categoryField, "test-2");
         AnomalyDetector anomalyDetector = TestHelpers
-            .randomAnomalyDetector("timestamp", "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+            .randomAnomalyDetector(timeField, "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -149,9 +142,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         Feature maxFeature = maxValueFeature(nameField, categoryField, nameField);
         Feature maxFeatureTwo = maxValueFeature(nameField, categoryField, nameField);
         AnomalyDetector anomalyDetector = TestHelpers
-            .randomAnomalyDetector("timestamp", "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+            .randomAnomalyDetector(timeField, "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -173,9 +165,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         Feature maxFeature = maxValueFeature(nameField, categoryField, nameField);
         Feature maxFeatureTwo = maxValueFeature("test_1", categoryField, nameField);
         AnomalyDetector anomalyDetector = TestHelpers
-            .randomAnomalyDetector("timestamp", "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+            .randomAnomalyDetector(timeField, "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -194,9 +185,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
     @Test
     public void testValidateAnomalyDetectorWithInvalidFeatureField() throws IOException {
         Feature maxFeature = maxValueFeature(nameField, categoryField, nameField);
-        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector("timestamp", "test-index", ImmutableList.of(maxFeature));
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(timeField, "test-index", ImmutableList.of(maxFeature));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -221,12 +211,11 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         AggregationBuilder aggregationBuilder = TestHelpers.parseAggregation("{\"test\":{\"terms\":{\"field\":\"type\"}}}");
         AnomalyDetector anomalyDetector = TestHelpers
             .randomAnomalyDetector(
-                "timestamp",
+                timeField,
                 "test-index",
                 ImmutableList.of(new Feature(randomAlphaOfLength(5), nameField, true, aggregationBuilder))
             );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -248,9 +237,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         Feature maxFeature = maxValueFeature(nameField, categoryField, nameField);
         Feature maxFeatureTwo = maxValueFeature("test_two", categoryField, "test_two");
         AnomalyDetector anomalyDetector = TestHelpers
-            .randomAnomalyDetector("timestamp", "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+            .randomAnomalyDetector(timeField, "test-index", ImmutableList.of(maxFeature, maxFeatureTwo));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -280,12 +268,11 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
                 ImmutableList.of(TestHelpers.randomFeature()),
                 randomAlphaOfLength(5).toLowerCase(),
                 randomIntBetween(1, 5),
-                "timestamp",
+                timeField,
                 null,
                 resultIndex
             );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -319,12 +306,11 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
                 ImmutableList.of(TestHelpers.randomFeature()),
                 randomAlphaOfLength(5).toLowerCase(),
                 randomIntBetween(1, 5),
-                "timestamp",
+                timeField,
                 null,
                 resultIndex
             );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -349,12 +335,11 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
                 ImmutableList.of(TestHelpers.randomFeature()),
                 randomAlphaOfLength(5).toLowerCase(),
                 randomIntBetween(1, 5),
-                "timestamp",
+                timeField,
                 null,
                 resultIndex
             );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -374,7 +359,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             randomLong(),
             "#$32",
             randomAlphaOfLength(5),
-            "timestamp",
+            timeField,
             ImmutableList.of(randomAlphaOfLength(5).toLowerCase()),
             ImmutableList.of(TestHelpers.randomFeature()),
             TestHelpers.randomQuery(),
@@ -388,8 +373,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             TestHelpers.randomUser(),
             null
         );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -411,7 +395,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             randomLong(),
             "abababababababababababababababababababababababababababababababababababababababababababababababab",
             randomAlphaOfLength(5),
-            "timestamp",
+            timeField,
             ImmutableList.of(randomAlphaOfLength(5).toLowerCase()),
             ImmutableList.of(TestHelpers.randomFeature()),
             TestHelpers.randomQuery(),
@@ -425,8 +409,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             TestHelpers.randomUser(),
             null
         );
-        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
-        ingestTestDataValidate(anomalyDetector.getIndices().get(0), startTime, 1, "error");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
             anomalyDetector,
             ValidationAspect.DETECTOR.getName(),
@@ -440,4 +423,47 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
         assertTrue(response.getIssue().getMessage().contains("Name should be shortened. The maximum limit is"));
     }
+
+    @Test
+    public void testValidateAnomalyDetectorWithNonExistentTimefield() throws IOException {
+        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now());
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertEquals(DetectorValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
+        assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
+        assertEquals(
+            String.format(Locale.ROOT, CommonErrorMessages.NON_EXISTENT_TIMESTAMP, anomalyDetector.getTimeField()),
+            response.getIssue().getMessage()
+        );
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorWithNonDateTimeField() throws IOException {
+        AnomalyDetector anomalyDetector = TestHelpers.randomAnomalyDetector(categoryField, "index-test");
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
+        ValidateAnomalyDetectorRequest request = new ValidateAnomalyDetectorRequest(
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            5,
+            5,
+            5,
+            new TimeValue(5_000L)
+        );
+        ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertEquals(DetectorValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
+        assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
+        assertEquals(
+            String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()),
+            response.getIssue().getMessage()
+        );
+    }
+
 }


### PR DESCRIPTION
### Description
This PR adds two new changes.

1.  Adds model (“non-blocker”) type validation to the current validation API. The model type validation is non-blocking in nature meaning that any warning that arise are simply suggestions or added information to the user about which configuration could be changed in order to increase the likelihood of model training completing successfully. These validation checks could also potentially recommend a specific detector interval or window delay value that the user can try to use.
    * Every-time model type validation is called, it initially also calls the blocker validation since there its not possible to run non-blocker checks if there is a blocking issue initially. 
2. Adds a check that the given timefield exists in the index mapping and also that it is of type date to AbstractAnomalyDetectorActionHandler which means this check is now executed for model

### Non-Blocker validation steps:

1. Get latest time stamp (if no latest time stamp found then user is told there is not enough historical data)
2. Check if detector is of type multi-entity and if it is then only look at the top entity for any proceeding validation
3. Check if general density of data is good enough for current configurations to complete model training with all the configurations applied.
    * This check will be run multiple times with different interval configurations until an interval is either recommended, same as the given one or no interval can be found
4. If no interval can be found with all configurations applied that will lead to data that is dense enough then proceed to run general density check by sequentially adding configurations one at a time
    * For example, first only the raw data is looked at in terms of how dense the data is →  if raw data on its own is dense enough then next the data filter (filter_query) will be added and general density will be checked for again
5. If no other issues exist in the data then check if any new window delay recommendation is possible (latest time stamp is used)

### Additional Info (Important):

* All validation for general density involves a bucket aggregation that finds if enough buckets in the last x intervals have at least 1 document present.
* I will be adding more new tests in separate commit or PR
* Response wording haven't finished tech writer review yet
### API Request:
* Path: `_plugins/_anomaly_detection/detectors/_validate/<aspect>`
* Parameter(aspect)
    * `model`
* Payload: Detector Configs
 
### Examples
 #### Example 1 (data ingested only every 5 mins, recommends 5 minutes interval of 1 minute) :
 ```
{
    "name": "test-hc-detector",
    "description": "Test detector",
    "time_field": "@timestamp",
    "indices": [
        "host-cloudwatch-two"
    ],
    "feature_attributes": [
        {
            "feature_name": "test",
            "feature_enabled": true,
            "aggregation_query": {
                "test": {
                    "avg": {
                        "field": "cpu"
                    }
                }
            }
        }
    ],
    "filter_query": {
        "bool": {
            "filter": [
                {
                    "exists": {
                        "field": "host"
                    }
                }
            ],
            "adjust_pure_negative": true,
            "boost": 1
        }
    },
    "detection_interval": {
        "period": {
            "interval": 1,
            "unit": "Minutes"
        }
    },
    "window_delay": {
        "period": {
            "interval": 1,
            "unit": "Minutes"
        }
    },
    "category_field": [
        "host"
    ]
}
```

#### Response 1:

```
{
    "model": {
        "detection_interval": {
            "message": "We suggest using a detector interval of: 5",
            "suggested_value": {
                "period": {
                    "interval": 5,
                    "unit": "Minutes"
                }
            }
        }
    }
}
```
#### Example 2 request (filter query leads to not enough dense data)
* CPU values in this data set range between 5-15 minutes
```
{
    "name": "test-hc-detector",
  ...
   "filter_query": {
        "bool": {
            "filter": [
                {
                    "range": {
                        "cpu": {
                            "gt": 10000
                        }
                    }
                }
            ],
            "adjust_pure_negative": true,
            "boost": 1
        }
    }
    "detection_interval": {
        "period": {
            "interval": 5,
            "unit": "Minutes"
        }
    },
    ...
}
```
#### Response 2: 
```
{
    "model": {
        "filter_query": {
            "message": "Data is too sparse after data filter is applied."
        }
    }
}
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
