### PR TITLE
[Backport 1.x] adding auto backport workflow plus documentation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -80,3 +80,11 @@ You can do this by running `./gradlew run -PnumNodes=<numberOfNodesYouWant>`
 
 You can also debug a multi-node cluster, by using a combination of above multi-node and debug steps.
 But, you must set up debugger configurations to listen on each port starting from `5005` and increasing by 1 for each node.
+
+### Backports
+
+The Github workflow in [`backport.yml`](.github/workflows/backport.yml) creates backport PRs automatically when the
+original PR with an appropriate label `backport <backport-branch-name>` is merged to main with the backport workflow
+run successfully on the PR. For example, if a PR on main needs to be backported to `1.x` branch, add a label
+`backport 1.x` to the PR and make sure the backport workflow runs on the PR along with other checks. Once this PR is
+merged to main, the workflow will create a backport PR to the `1.x` branch.


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Backporting [this commit](https://github.com/opensearch-project/anomaly-detection/commit/387412f83639b6a8d03036df144c02ed820bddd5) to `1.x` branch.

Had to manually backport since the backport bot doesn't handle merge-commit PRs, which was the case for this PR ([link](https://github.com/opensearch-project/anomaly-detection/pull/368))

Also, I've blocked that type of PR merge in the repo settings so that this can't happen again
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
