### PR TITLE
Add JDK 8 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11, 14]
+        java: [8, 11, 14]
 
     name: Build and Test Anomaly detection Plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Adds JDK8 to CI. 
 
### Issues Resolved
Resolves #320 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
