### PR TITLE
Fix docker tag to unblock running integ tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Pull and Run Docker
         run: |
           plugin=`ls build/distributions/*.zip`
-          version=1.3.0-SNAPSHOT
+          version=1.3.0
           plugin_version=1.3.0.0-SNAPSHOT
           echo Using OpenSearch $version with AD $plugin_version
           cd ..

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -111,7 +111,7 @@ public class CommonErrorMessages {
     public static String TIME_FIELD_NOT_ENOUGH_HISTORICAL_DATA =
         "There isn't enough historical data found with current timefield selected.";
     public static String DETECTOR_INTERVAL_REC =
-        "The selected detector interval might collect sparse data. Consider changing interval length too: ";
+        "The selected detector interval might collect sparse data. Consider changing interval length to: ";
     public static String RAW_DATA_TOO_SPARSE =
         "Source index data is potentially too sparse for model training. Consider changing interval length or ingesting more data";
     public static String MODEL_VALIDATION_FAILED_UNEXPECTEDLY = "Model validation experienced issues completing.";

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -125,6 +125,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
     }
 
     protected AnomalyDetector createAnomalyDetector(AnomalyDetector detector, Boolean refresh, RestClient client) throws IOException {
+        TestHelpers.createIndexWithTimeField(client(), detector.getIndices().get(0), detector.getTimeField());
         Response response = TestHelpers
             .makeRequest(client, "POST", TestHelpers.AD_BASE_DETECTORS_URI, ImmutableMap.of(), TestHelpers.toHttpEntity(detector), null);
         assertEquals("Create anomaly detector failed", RestStatus.CREATED, TestHelpers.restStatus(response));

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -125,7 +125,6 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
     }
 
     protected AnomalyDetector createAnomalyDetector(AnomalyDetector detector, Boolean refresh, RestClient client) throws IOException {
-        TestHelpers.createIndexWithTimeField(client(), detector.getIndices().get(0), detector.getTimeField());
         Response response = TestHelpers
             .makeRequest(client, "POST", TestHelpers.AD_BASE_DETECTORS_URI, ImmutableMap.of(), TestHelpers.toHttpEntity(detector), null);
         assertEquals("Create anomaly detector failed", RestStatus.CREATED, TestHelpers.restStatus(response));

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -221,6 +221,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         // User Fish has AD full access, and has "odfe" backend role which is one of Alice's backend role, so
         // Fish should be able to update detectors created by Alice. But the detector's backend role should
         // not be replaced as Fish's backend roles.
+        TestHelpers.createIndexWithTimeField(client(), newDetector.getIndices().get(0), newDetector.getTimeField());
         Response response = updateAnomalyDetector(aliceDetector.getDetectorId(), newDetector, fishClient);
         Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
         AnomalyDetector anomalyDetector = getAnomalyDetector(aliceDetector.getDetectorId(), aliceClient);
@@ -314,6 +315,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
 
         // User cat has permission to create index
         resultIndex = CommonName.CUSTOM_RESULT_INDEX_PREFIX + "test2";
+        TestHelpers.createIndexWithTimeField(client(), anomalyDetector.getIndices().get(0), anomalyDetector.getTimeField());
         AnomalyDetector detectorOfCat = createAnomalyDetector(cloneDetector(anomalyDetector, resultIndex), true, catClient);
         assertEquals(resultIndex, detectorOfCat.getResultIndex());
     }


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Now that staging docker images are continuously updated in dockerhub every time there's a new bundle build, we can use the upcoming version to pull in the images, construct the dockerfile, and run the integ tests with security enabled in them.

This updates the tag to match the naming strategy used in dockerhub.

Also updates:
- error message in validation API typo
- 2 broken tests as pointed out in #430. The issue is that a validation check causes failures due to the source index not having a valid time field, so this adds a sample doc with a valid time field before detector creation.

TODO:
- [x] Fix any failing tests showing up as mentioned in #430

 
### Issues Resolved
#430 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
