### PR TITLE
Changed default description to empty string instead of null

### DIFF
--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -420,7 +420,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         TimeValue defaultDetectionWindowDelay
     ) throws IOException {
         String name = null;
-        String description = null;
+        String description = "";
         String timeField = null;
         List<String> indices = new ArrayList<String>();
         QueryBuilder filterQuery = QueryBuilders.matchAllQuery();

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -636,4 +636,16 @@ public class AnomalyDetectorTests extends AbstractADTest {
         errorMessage = AnomalyDetector.validateResultIndex(CUSTOM_RESULT_INDEX_PREFIX + "abc#");
         assertEquals(INVALID_CHAR_IN_RESULT_INDEX_NAME, errorMessage);
     }
+
+    public void testParseAnomalyDetectorWithNoDescription() throws IOException {
+        String detectorString = "{\"name\":\"todagtCMkwpcaedpyYUM\",\"time_field\":\"dJRwh\",\"indices\":[\"eIrgWMqAED\"],"
+            + "\"feature_attributes\":[{\"feature_id\":\"lxYRN\",\"feature_name\":\"eqSeU\",\"feature_enabled\""
+            + ":true,\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}],\"detection_interval\":"
+            + "{\"period\":{\"interval\":425,\"unit\":\"Minutes\"}},\"window_delay\":{\"period\":{\"interval\":973,"
+            + "\"unit\":\"Minutes\"}},\"shingle_size\":4,\"schema_version\":-1203962153,\"ui_metadata\":{\"JbAaV\":{\"feature_id\":"
+            + "\"rIFjS\",\"feature_name\":\"QXCmS\",\"feature_enabled\":false,\"aggregation_query\":{\"aa\":"
+            + "{\"value_count\":{\"field\":\"ok\"}}}}},\"last_update_time\":1568396089028}";
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
+        assertEquals(parsedDetector.getDescription(), "");
+    }
 }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Changed the default description field to be set to an empty string instead of a null field. This means that description should also be changed from a `required` field as listed in [documentation](https://opensearch.org/docs/latest/monitoring-plugins/ad/api/#create-anomaly-detector) to an `optional` field since if detector description is missing then it will be filled as an empty string. 

Currently if there is a missing description field, the backend still creates the detector even though it is listed as `required` which causes issues on the frontend which tries to parse a null a value unsuccessfully when getting the relevant detector. 

Other option is to throw an exception if description is missing and hence enforce the `required` description which we don't enforce on the backend today and we also let users know it is optional on the frontend, where we just have it as empty if not filled out. For this reason, it makes more sense to just keep it consistent as an 'optional' field from UX point of view.

Reproduced the bug stated in the issue before change was made and tested that bug doesn't occur after this change 

### Issues Resolved
resolves #437 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
