### PR TITLE
[Backport 1.x] Upgraded to protostuff 1.8.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -583,8 +583,8 @@ dependencies {
     compile files('lib/randomcutforest-core-2.0.1.jar')
 
     // used for serializing/deserializing rcf models.
-    compile group: 'io.protostuff', name: 'protostuff-core', version: '1.7.4'
-    compile group: 'io.protostuff', name: 'protostuff-runtime', version: '1.7.4'
+    compile group: 'io.protostuff', name: 'protostuff-core', version: '1.8.0'
+    compile group: 'io.protostuff', name: 'protostuff-runtime', version: '1.8.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
     compile "org.jacoco:org.jacoco.agent:0.8.5"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Backport of https://github.com/opensearch-project/anomaly-detection/pull/439 to 1.x.
 
### Issues Resolved

Half of https://github.com/opensearch-project/anomaly-detection/issues/433.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
