### PR TITLE
Reduced jacoco exclusions and added more tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -478,43 +478,31 @@ task release(type: Copy, group: 'build') {
 List<String> jacocoExclusions = [
         // code for configuration, settings, etc is excluded from coverage
         'org.opensearch.ad.AnomalyDetectorPlugin',
-        'org.opensearch.ad.settings.AnomalyDetectorSettings',
 
-        //TODO: Add more cases for model validation API, both UT and IT
-        //TODO: add more test cases later for these package
-        'org.opensearch.ad.model.*',
+        'org.opensearch.ad.model.ModelProfileOnNode',
+        'org.opensearch.ad.model.InitProgressProfile',
+        'org.opensearch.ad.model.ADTaskProfile',
+        'org.opensearch.ad.model.AnomalyResultBucket',
+        'org.opensearch.ad.model.EntityProfileName',
         'org.opensearch.ad.rest.*',
-        'org.opensearch.ad.transport.handler.DetectionStateHandler',
         'org.opensearch.ad.AnomalyDetectorJobRunner',
 
         // Class containing just constants.  Don't need to test
         'org.opensearch.ad.constant.*',
 
-        // mostly skeleton code.  Tested major logic in restful api tests
-        'org.opensearch.ad.settings.EnabledSetting',
-
-        'org.opensearch.ad.common.exception.FeatureNotAvailableException',
-        'org.opensearch.ad.common.exception.AnomalyDetectionException',
+        //'org.opensearch.ad.common.exception.AnomalyDetectionException',
         'org.opensearch.ad.util.ClientUtil',
 
         'org.opensearch.ad.transport.StopDetectorRequest',
         'org.opensearch.ad.transport.StopDetectorResponse',
-        'org.opensearch.ad.transport.StopDetectorTransportAction',
-        'org.opensearch.ad.transport.DeleteDetectorAction',
-        'org.opensearch.ad.transport.CronTransportAction',
         'org.opensearch.ad.transport.CronRequest',
-        'org.opensearch.ad.transport.ADStatsNodesAction',
         'org.opensearch.ad.AnomalyDetectorRunner',
-        'org.opensearch.ad.util.ParseUtils',
 
         // related to transport actions added for security
-        'org.opensearch.ad.transport.StatsAnomalyDetectorTransportAction',
         'org.opensearch.ad.transport.DeleteAnomalyDetectorTransportAction*',
-        'org.opensearch.ad.transport.SearchAnomalyDetectorTransportAction*',
         'org.opensearch.ad.transport.GetAnomalyDetectorTransportAction*',
         'org.opensearch.ad.transport.SearchAnomalyResultTransportAction*',
         'org.opensearch.ad.transport.SearchAnomalyDetectorInfoTransportAction*',
-
 
         // TODO: unified flow caused coverage drop
         'org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction',
@@ -522,11 +510,11 @@ List<String> jacocoExclusions = [
         // https://github.com/opensearch-project/anomaly-detection/issues/241
         'org.opensearch.ad.task.ADBatchTaskRunner',
         'org.opensearch.ad.task.ADTaskManager',
-        
+
         //TODO: custom result index caused coverage drop
-        'org.opensearch.ad.indices.AnomalyDetectionIndices',
         'org.opensearch.ad.transport.handler.AnomalyResultBulkIndexHandler'
 ]
+
 
 jacocoTestCoverageVerification {
     violationRules {

--- a/build.gradle
+++ b/build.gradle
@@ -484,7 +484,6 @@ List<String> jacocoExclusions = [
 
         'org.opensearch.ad.model.ModelProfileOnNode',
         'org.opensearch.ad.model.InitProgressProfile',
-        'org.opensearch.ad.model.ADTaskProfile',
         'org.opensearch.ad.rest.*',
         'org.opensearch.ad.AnomalyDetectorJobRunner',
 

--- a/build.gradle
+++ b/build.gradle
@@ -479,15 +479,16 @@ List<String> jacocoExclusions = [
         // code for configuration, settings, etc is excluded from coverage
         'org.opensearch.ad.AnomalyDetectorPlugin',
 
+        // rest layer is tested in integration testing mostly, difficult to mock all of it
+        'org.opensearch.ad.rest.*',
+
         'org.opensearch.ad.model.ModelProfileOnNode',
         'org.opensearch.ad.model.InitProgressProfile',
         'org.opensearch.ad.model.ADTaskProfile',
-        'org.opensearch.ad.model.AnomalyResultBucket',
-        'org.opensearch.ad.model.EntityProfileName',
         'org.opensearch.ad.rest.*',
         'org.opensearch.ad.AnomalyDetectorJobRunner',
 
-        // Class containing just constants.  Don't need to test
+        // Class containing just constants. Don't need to test
         'org.opensearch.ad.constant.*',
 
         //'org.opensearch.ad.common.exception.AnomalyDetectionException',

--- a/src/main/java/org/opensearch/ad/model/EntityProfileName.java
+++ b/src/main/java/org/opensearch/ad/model/EntityProfileName.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.opensearch.ad.Name;
+import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 
 public enum EntityProfileName implements Name {
@@ -50,7 +51,7 @@ public enum EntityProfileName implements Name {
             case CommonName.MODELS:
                 return MODELS;
             default:
-                throw new IllegalArgumentException("Unsupported profile types");
+                throw new IllegalArgumentException(CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -82,7 +82,7 @@ import org.opensearch.search.sort.SortOrder;
  * different varying intervals in order to find the best interval for the data. If no interval is found with all
  * configuration applied then each configuration is tested sequentially for sparsity</p>
  */
-// TODO: potentially change where this is located
+// TODO: Add more UT and IT
 public class ModelValidationActionHandler {
     protected static final String AGG_NAME_TOP = "top_agg";
     protected static final String AGGREGATION = "agg";

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorPluginTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorPluginTests.java
@@ -78,4 +78,9 @@ public class AnomalyDetectorPluginTests extends ADUnitTestCase {
         assertTrue(null != buffer);
     }
 
+    public void testOverriddenJobTypeAndIndex() {
+        assertEquals("opendistro_anomaly_detector", plugin.getJobType());
+        assertEquals(".opendistro-anomaly-detector-jobs", plugin.getJobIndex());
+    }
+
 }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -634,4 +634,10 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
         }), stateNError);
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
     }
+
+    public void testInitProgressProfile() {
+        InitProgressProfile progressOne = new InitProgressProfile("0%", 0, requiredSamples);
+        InitProgressProfile progressTwo = new InitProgressProfile("0%", 0, requiredSamples);
+        assertTrue(progressOne.equals(progressTwo));
+    }
 }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -638,6 +638,8 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
     public void testInitProgressProfile() {
         InitProgressProfile progressOne = new InitProgressProfile("0%", 0, requiredSamples);
         InitProgressProfile progressTwo = new InitProgressProfile("0%", 0, requiredSamples);
+        InitProgressProfile progressThree = new InitProgressProfile("96%", 2, requiredSamples);
         assertTrue(progressOne.equals(progressTwo));
+        assertFalse(progressOne.equals(progressThree));
     }
 }

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -57,6 +57,7 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.feature.Features;
@@ -1482,6 +1483,17 @@ public class TestHelpers {
             randomAlphaOfLength(5),
             subIssues,
             null
+        );
+        return issue;
+    }
+
+    public static DetectorValidationIssue randomDetectorValidationIssueWithDetectorIntervalRec(long intervalRec) {
+        DetectorValidationIssue issue = new DetectorValidationIssue(
+            ValidationAspect.MODEL,
+            DetectorValidationIssueType.DETECTION_INTERVAL,
+            CommonErrorMessages.DETECTOR_INTERVAL_REC + intervalRec,
+            null,
+            new IntervalTimeConfiguration(intervalRec, ChronoUnit.MINUTES)
         );
         return issue;
     }

--- a/src/test/java/org/opensearch/ad/common/exception/ADValidationExceptionTests.java
+++ b/src/test/java/org/opensearch/ad/common/exception/ADValidationExceptionTests.java
@@ -11,16 +11,24 @@
 
 package org.opensearch.ad.common.exception;
 
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.DetectorValidationIssueType;
 import org.opensearch.ad.model.ValidationAspect;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class ADValidationExceptionTests extends OpenSearchTestCase {
-    public void testConstructor() {
+    public void testConstructorDetector() {
         String message = randomAlphaOfLength(5);
         ADValidationException exception = new ADValidationException(message, DetectorValidationIssueType.NAME, ValidationAspect.DETECTOR);
         assertEquals(DetectorValidationIssueType.NAME, exception.getType());
         assertEquals(ValidationAspect.DETECTOR, exception.getAspect());
+    }
+
+    public void testConstructorModel() {
+        String message = randomAlphaOfLength(5);
+        ADValidationException exception = new ADValidationException(message, DetectorValidationIssueType.CATEGORY, ValidationAspect.MODEL);
+        assertEquals(DetectorValidationIssueType.CATEGORY, exception.getType());
+        assertEquals(ValidationAspect.getName(CommonName.MODEL_ASPECT), exception.getAspect());
     }
 
     public void testToString() {

--- a/src/test/java/org/opensearch/ad/model/ADEntityTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/ADEntityTaskProfileTests.java
@@ -31,18 +31,24 @@ public class ADEntityTaskProfileTests extends OpenSearchSingleNodeTestCase {
         return getInstanceFromNode(NamedWriteableRegistry.class);
     }
 
+    private ADEntityTaskProfile createADEntityTaskProfile() {
+        Entity entity = createEntityAndAttributes();
+        return new ADEntityTaskProfile(1, 23L, false, 1, 2L, "1234", entity, "4321", ADTaskType.HISTORICAL_HC_ENTITY.name());
+    }
+
+    private Entity createEntityAndAttributes() {
+        TreeMap<String, String> attributes = new TreeMap<>();
+        String name1 = "host";
+        String val1 = "server_2";
+        String name2 = "service";
+        String val2 = "app_4";
+        attributes.put(name1, val1);
+        attributes.put(name2, val2);
+        return Entity.createEntityFromOrderedMap(attributes);
+    }
+
     public void testADEntityTaskProfileSerialization() throws IOException {
-        ADEntityTaskProfile entityTask = new ADEntityTaskProfile(
-            1,
-            23L,
-            false,
-            1,
-            2L,
-            "1234",
-            null,
-            "4321",
-            ADTaskType.HISTORICAL_HC_ENTITY.name()
-        );
+        ADEntityTaskProfile entityTask = createADEntityTaskProfile();
         BytesStreamOutput output = new BytesStreamOutput();
         entityTask.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
@@ -51,25 +57,7 @@ public class ADEntityTaskProfileTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testParseADEntityTaskProfile() throws IOException {
-        TreeMap<String, String> attributes = new TreeMap<>();
-        String name1 = "host";
-        String val1 = "server_2";
-        String name2 = "service";
-        String val2 = "app_4";
-        attributes.put(name1, val1);
-        attributes.put(name2, val2);
-        Entity entity = Entity.createEntityFromOrderedMap(attributes);
-        ADEntityTaskProfile entityTask = new ADEntityTaskProfile(
-            1,
-            23L,
-            false,
-            1,
-            2L,
-            "1234",
-            entity,
-            "4321",
-            ADTaskType.HISTORICAL_HC_ENTITY.name()
-        );
+        ADEntityTaskProfile entityTask = createADEntityTaskProfile();
         String adEntityTaskProfileString = TestHelpers
             .xContentBuilderToString(entityTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         ADEntityTaskProfile parsedEntityTask = ADEntityTaskProfile.parse(TestHelpers.parser(adEntityTaskProfileString));
@@ -85,6 +73,46 @@ public class ADEntityTaskProfileTests extends OpenSearchSingleNodeTestCase {
             2L,
             "1234",
             null,
+            "4321",
+            ADTaskType.HISTORICAL_HC_ENTITY.name()
+        );
+        assertEquals(Integer.valueOf(1), entityTask.getShingleSize());
+        assertEquals(23L, (long) entityTask.getRcfTotalUpdates());
+        assertNull(entityTask.getEntity());
+        String adEntityTaskProfileString = TestHelpers
+            .xContentBuilderToString(entityTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADEntityTaskProfile parsedEntityTask = ADEntityTaskProfile.parse(TestHelpers.parser(adEntityTaskProfileString));
+        assertEquals(entityTask, parsedEntityTask);
+    }
+
+    public void testADEntityTaskProfileEqual() {
+        ADEntityTaskProfile entityTaskOne = createADEntityTaskProfile();
+        ADEntityTaskProfile entityTaskTwo = createADEntityTaskProfile();
+        ADEntityTaskProfile entityTaskThree = new ADEntityTaskProfile(
+            null,
+            null,
+            false,
+            1,
+            null,
+            "1234",
+            null,
+            "4321",
+            ADTaskType.HISTORICAL_HC_ENTITY.name()
+        );
+        assertTrue(entityTaskOne.equals(entityTaskTwo));
+        assertFalse(entityTaskOne.equals(entityTaskThree));
+    }
+
+    public void testParseADEntityTaskProfileWithMultipleNullFields() throws IOException {
+        Entity entity = createEntityAndAttributes();
+        ADEntityTaskProfile entityTask = new ADEntityTaskProfile(
+            null,
+            null,
+            false,
+            1,
+            null,
+            "1234",
+            entity,
             "4321",
             ADTaskType.HISTORICAL_HC_ENTITY.name()
         );

--- a/src/test/java/org/opensearch/ad/model/AnomalyResultBucketTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyResultBucketTests.java
@@ -31,9 +31,21 @@ public class AnomalyResultBucketTests extends AbstractADTest {
         assertTrue(parsedAnomalyResultBucket.equals(anomalyResultBucket));
     }
 
+    public void testAnomalyResultBucketEquals() {
+        Map<String, Object> keyOne = new HashMap<>();
+        keyOne.put("test-field-1", "test-value-1");
+        Map<String, Object> keyTwo = new HashMap<>();
+        keyTwo.put("test-field-2", "test-value-2");
+        AnomalyResultBucket testBucketOne = new AnomalyResultBucket(keyOne, 3, 0.5);
+        AnomalyResultBucket testBucketTwo = new AnomalyResultBucket(keyOne, 5, 0.75);
+        AnomalyResultBucket testBucketThree = new AnomalyResultBucket(keyTwo, 7, 0.2);
+        assertFalse(testBucketOne.equals(testBucketTwo));
+        assertFalse(testBucketTwo.equals(testBucketThree));
+    }
+
     @SuppressWarnings("unchecked")
     public void testToXContent() throws IOException {
-        Map<String, Object> key = new HashMap<String, Object>() {
+        Map<String, Object> key = new HashMap<>() {
             {
                 put("test-field-1", "test-value-1");
             }

--- a/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorInternalStateTests.java
@@ -24,4 +24,18 @@ public class DetectorInternalStateTests extends OpenSearchSingleNodeTestCase {
         DetectorInternalState parsedInternalState = DetectorInternalState.parse(TestHelpers.parser(internalStateString));
         assertEquals(internalState, parsedInternalState);
     }
+
+    public void testClonedDetectorInternalState() throws IOException {
+        DetectorInternalState originalState = new DetectorInternalState.Builder()
+            .lastUpdateTime(Instant.ofEpochMilli(100L))
+            .error("error-test")
+            .build();
+        DetectorInternalState clonedState = (DetectorInternalState) originalState.clone();
+        // parse original InternalState
+        String internalStateString = TestHelpers
+            .xContentBuilderToString(originalState.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        DetectorInternalState parsedInternalState = DetectorInternalState.parse(TestHelpers.parser(internalStateString));
+        // compare parsed to cloned
+        assertEquals(clonedState, parsedInternalState);
+    }
 }

--- a/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
@@ -41,6 +41,7 @@ public class DetectorProfileTests extends OpenSearchTestCase {
             )
             .shingleSize(randomInt())
             .coordinatingNode(randomAlphaOfLength(10))
+            .totalSizeInBytes(-1)
             .totalEntities(randomLong())
             .activeEntities(randomLong())
             .adTaskProfile(
@@ -87,8 +88,27 @@ public class DetectorProfileTests extends OpenSearchTestCase {
     }
 
     public void testDetectorProfileName() throws IllegalArgumentException {
-        DetectorProfileName.getName(CommonName.AD_TASK);
+        assertEquals("ad_task", DetectorProfileName.getName(CommonName.AD_TASK).getName());
+        assertEquals("state", DetectorProfileName.getName(CommonName.STATE).getName());
+        assertEquals("error", DetectorProfileName.getName(CommonName.ERROR).getName());
+        assertEquals("coordinating_node", DetectorProfileName.getName(CommonName.COORDINATING_NODE).getName());
+        assertEquals("shingle_size", DetectorProfileName.getName(CommonName.SHINGLE_SIZE).getName());
+        assertEquals("total_size_in_bytes", DetectorProfileName.getName(CommonName.TOTAL_SIZE_IN_BYTES).getName());
+        assertEquals("models", DetectorProfileName.getName(CommonName.MODELS).getName());
+        assertEquals("init_progress", DetectorProfileName.getName(CommonName.INIT_PROGRESS).getName());
+        assertEquals("total_entities", DetectorProfileName.getName(CommonName.TOTAL_ENTITIES).getName());
+        assertEquals("active_entities", DetectorProfileName.getName(CommonName.ACTIVE_ENTITIES).getName());
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> DetectorProfileName.getName("abc"));
         assertEquals(exception.getMessage(), CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
+    }
+
+    public void testDetectorProfileSet() throws IllegalArgumentException {
+        DetectorProfile detectorProfileOne = createRandomDetectorProfile();
+        detectorProfileOne.setShingleSize(20);
+        assertEquals(20, detectorProfileOne.getShingleSize());
+        detectorProfileOne.setActiveEntities(10L);
+        assertEquals(10L, (long) detectorProfileOne.getActiveEntities());
+        detectorProfileOne.setModelCount(10L);
+        assertEquals(10L, (long) detectorProfileOne.getActiveEntities());
     }
 }

--- a/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
@@ -27,9 +27,7 @@ import test.org.opensearch.ad.util.JsonDeserializer;
 public class EntityProfileTests extends AbstractADTest {
     public void testMerge() {
         EntityProfile profile1 = new EntityProfile(null, -1, -1, null, null, EntityState.INIT);
-
         EntityProfile profile2 = new EntityProfile(null, -1, -1, null, null, EntityState.UNKNOWN);
-
         profile1.merge(profile2);
         assertEquals(profile1.getState(), EntityState.INIT);
         assertTrue(profile1.toString().contains(EntityState.INIT.toString()));
@@ -45,6 +43,24 @@ public class EntityProfileTests extends AbstractADTest {
         assertEquals("INIT", JsonDeserializer.getTextValue(json, CommonName.STATE));
 
         EntityProfile profile2 = new EntityProfile(null, -1, -1, null, null, EntityState.UNKNOWN);
+
+        builder = jsonBuilder();
+        profile2.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        json = Strings.toString(builder);
+
+        assertTrue(false == JsonDeserializer.hasChildNode(json, CommonName.STATE));
+    }
+
+    public void testToXContentTimeStampAboveZero() throws IOException, JsonPathNotFoundException {
+        EntityProfile profile1 = new EntityProfile(null, 1, 1, null, null, EntityState.INIT);
+
+        XContentBuilder builder = jsonBuilder();
+        profile1.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = Strings.toString(builder);
+
+        assertEquals("INIT", JsonDeserializer.getTextValue(json, CommonName.STATE));
+
+        EntityProfile profile2 = new EntityProfile(null, 1, 1, null, null, EntityState.UNKNOWN);
 
         builder = jsonBuilder();
         profile2.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/src/test/java/org/opensearch/ad/model/MergeableListTests.java
+++ b/src/test/java/org/opensearch/ad/model/MergeableListTests.java
@@ -31,12 +31,22 @@ public class MergeableListTests extends AbstractADTest {
         ls1.add("item1");
         ls1.add("item2");
         List<String> ls2 = new ArrayList<String>();
-        ls1.add("item3");
-        ls1.add("item4");
+        ls2.add("item3");
+        ls2.add("item4");
         MergeableList<String> mergeListOne = new MergeableList<>(ls1);
         MergeableList<String> mergeListTwo = new MergeableList<>(ls2);
         mergeListOne.merge(mergeListTwo);
         assertEquals(4, mergeListOne.getElements().size());
         assertEquals("item3", mergeListOne.getElements().get(2));
+    }
+
+    public void testMergeableListFailMerge() {
+        List<String> ls1 = new ArrayList<>();
+        ls1.add("item1");
+        ls1.add("item2");
+        MergeableList<String> mergeListOne = new MergeableList<>(ls1);
+        MergeableList<String> mergeListTwo = new MergeableList<>(null);
+        mergeListOne.merge(mergeListTwo);
+        assertEquals(2, mergeListOne.getElements().size());
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
@@ -171,9 +171,6 @@ public class ADTaskProfileTests extends OpenSearchSingleNodeTestCase {
         } else {
             assertEquals(profile.getTaskId(), parsedProfile.getAdTaskProfile().getTaskId());
         }
-        // assertEquals(profile, adTaskProfileNodeResponses.get(0).getAdTaskProfile());
-
-        // assertEquals(profile, response2.getNodes().get(0).getAdTaskProfile());
     }
 
     public void testADTaskProfileParseFullConstructor() throws IOException {

--- a/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
@@ -38,6 +38,7 @@ import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
+import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
@@ -371,5 +372,12 @@ public class EntityProfileTests extends AbstractADTest {
         assertTrue(false == set.contains(response));
         set.add(response);
         assertTrue(set.contains(response));
+    }
+
+    public void testEntityProfileName() {
+        assertEquals("state", EntityProfileName.getName(CommonName.STATE).getName());
+        assertEquals("models", EntityProfileName.getName(CommonName.MODELS).getName());
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> EntityProfileName.getName("abc"));
+        assertEquals(exception.getMessage(), CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -465,5 +465,4 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             response.getIssue().getMessage()
         );
     }
-
 }

--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -16,6 +16,7 @@ import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
@@ -275,5 +276,15 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         assertFalse(
             ParseUtils.listEqualsWithoutConsideringOrder(ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5)))
         );
+    }
+
+    public void testGetFeatureFieldNames() throws IOException {
+        Feature feature1 = TestHelpers.randomFeature("feature-name1", "field-name1", "sum", true);
+        Feature feature2 = TestHelpers.randomFeature("feature-name2", "field-name2", "sum", true);
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableList.of(feature1, feature2), null, now);
+        List<String> fieldNames = ParseUtils.getFeatureFieldNames(detector, TestHelpers.xContentRegistry());
+        assertTrue(fieldNames.contains("field-name1"));
+        assertTrue(fieldNames.contains("field-name2"));
     }
 }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
This PR adds some tests to various classes that had low coverage as well as removes any unnecessary files from the `jacocoExclusion` list on `build.gradle`. We had some files there that were either already above the coverage minimum or didn’t exist anymore. Specifically `.../model.*` was listed and with additional testing added here and in previous PR (https://github.com/opensearch-project/anomaly-detection/pull/335) 34 classes were taken off the exclusion list and now only 2 classes from model package are still excluded.

I wont close the related issue (https://github.com/opensearch-project/anomaly-detection/issues/424) yet since more work needs to be done addressing the TODOs, potentially reducing coverage minimums and finishing rest of `model` package testing. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
