### PR TITLE
Fixed ADTaskProfile toXContent bug and added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ out/
 .classpath
 .vscode
 bin/
+._.DS_Store

--- a/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
+++ b/src/main/java/org/opensearch/ad/model/ADTaskProfile.java
@@ -257,7 +257,7 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
             xContentBuilder.field(ENTITY_TASK_PROFILE_FIELD, entityTaskProfiles.toArray());
         }
         if (latestHCTaskRunTime != null) {
-            xContentBuilder.field(ENTITY_TASK_PROFILE_FIELD, latestHCTaskRunTime);
+            xContentBuilder.field(LATEST_HC_TASK_RUN_TIME_FIELD, latestHCTaskRunTime);
         }
         return xContentBuilder.endObject();
     }

--- a/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
@@ -175,4 +175,29 @@ public class ADTaskProfileTests extends OpenSearchSingleNodeTestCase {
 
         // assertEquals(profile, response2.getNodes().get(0).getAdTaskProfile());
     }
+
+    public void testADTaskProfileParseFullConstructor() throws IOException {
+        ADTaskProfile adTaskProfile = new ADTaskProfile(
+            TestHelpers.randomAdTask(),
+            randomInt(),
+            randomLong(),
+            randomBoolean(),
+            randomInt(),
+            randomLong(),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomInt(),
+            randomBoolean(),
+            randomInt(),
+            randomInt(),
+            randomInt(),
+            ImmutableList.of(randomAlphaOfLength(5)),
+            Instant.now().toEpochMilli()
+        );
+        String adTaskProfileString = TestHelpers
+            .xContentBuilderToString(adTaskProfile.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTaskProfile parsedADTaskProfile = ADTaskProfile.parse(TestHelpers.parser(adTaskProfileString));
+        assertEquals(adTaskProfile, parsedADTaskProfile);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
1. Fixed bug in `ADTaskProfile.toXContent()` which added `ENTITY_TASK_PROFILE_FIELD` instead of `LATEST_HC_TASK_RUN_TIME_FIELD` when `latestHCTaskRunTime` was present in constructor. Also added a test case for this. This previously would cause a parsing exception if a non null `latestHCTaskRunTime` was given to constructor.
2. Added `._.DS_Store` to `.gitignore` as its a file that gets auto created by macOS Finder which isn't relevant.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
