### PR TITLE
Adding test-retry plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ plugins {
     id 'nebula.ospackage' version "8.3.0" apply false
     id "com.diffplug.gradle.spotless" version "3.26.1"
     id 'java-library'
-    id 'org.gradle.test-retry' version '1.0.0'
+    id 'org.gradle.test-retry' version '1.3.1'
 }
 
 tasks.withType(JavaCompile) {
@@ -154,7 +154,8 @@ test {
     retry {
         if (isCiServer) {
             failOnPassedAfterRetry = false
-            maxRetries = 8
+            maxRetries = 6
+            maxFailures = 10
         }
     }
     include '**/*Tests.class'
@@ -172,7 +173,8 @@ integTest {
     retry {
         if (isCiServer) {
             failOnPassedAfterRetry = false
-            maxRetries = 8
+            maxRetries = 6
+            maxFailures = 10
         }
     }
     dependsOn "bundlePlugin"

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ plugins {
     id 'nebula.ospackage' version "8.3.0" apply false
     id "com.diffplug.gradle.spotless" version "3.26.1"
     id 'java-library'
+    id 'org.gradle.test-retry' version '1.0.0'
 }
 
 tasks.withType(JavaCompile) {
@@ -150,6 +151,11 @@ def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absolu
 opensearch_tmp_dir.mkdirs()
 
 test {
+    retry {
+        failOnPassedAfterRetry = false
+        maxFailures = 10
+        maxRetries = 10
+    }
     include '**/*Tests.class'
     systemProperty 'tests.security.manager', 'false'
 }
@@ -162,6 +168,11 @@ task integTest(type: RestIntegTestTask) {
 tasks.named("check").configure { dependsOn(integTest) }
 
 integTest {
+    retry {
+        failOnPassedAfterRetry = false
+        maxFailures = 10
+        maxRetries = 10
+    }
     dependsOn "bundlePlugin"
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath

--- a/build.gradle
+++ b/build.gradle
@@ -149,12 +149,13 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()
-
+boolean isCiServer = System.getenv().containsKey("CI")
 test {
     retry {
-        failOnPassedAfterRetry = false
-        maxFailures = 10
-        maxRetries = 10
+        if (isCiServer) {
+            failOnPassedAfterRetry = false
+            maxRetries = 8
+        }
     }
     include '**/*Tests.class'
     systemProperty 'tests.security.manager', 'false'
@@ -169,9 +170,10 @@ tasks.named("check").configure { dependsOn(integTest) }
 
 integTest {
     retry {
-        failOnPassedAfterRetry = false
-        maxFailures = 10
-        maxRetries = 10
+        if (isCiServer) {
+            failOnPassedAfterRetry = false
+            maxRetries = 8
+        }
     }
     dependsOn "bundlePlugin"
     systemProperty 'tests.security.manager', 'false'

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -599,8 +599,15 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
     public void testRestartHCADDetector() throws Exception {
         // TODO: this test case will run for a much longer time and timeout with security enabled
         if (!isHttps()) {
-            disableResourceNotFoundFaultTolerence();
-            verifyRestart("synthetic", 1, 8);
+            try {
+                disableResourceNotFoundFaultTolerence();
+                verifyRestart("synthetic", 1, 8);
+            } catch (Throwable throwable) {
+                LOG.info("Retry restart test case", throwable);
+                cleanUpCluster();
+                wipeAllODFEIndices();
+                fail();
+            }
         }
     }
 

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -427,6 +427,7 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
                 request = new Request("POST", String.format(Locale.ROOT, "/%s/_refresh", datasetName));
                 client.performRequest(request);
             }
+            Thread.sleep(1_000);
         } while (maxWaitCycles-- >= 0);
     }
 
@@ -592,26 +593,14 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
                 throw new RuntimeException(e);
             }
         });
-        Thread.sleep(1_000);
+        Thread.sleep(3_000);
     }
 
     public void testRestartHCADDetector() throws Exception {
         // TODO: this test case will run for a much longer time and timeout with security enabled
         if (!isHttps()) {
-            int maxRetries = 3;
-            int i = 0;
-            for (; i < maxRetries; i++) {
-                try {
-                    disableResourceNotFoundFaultTolerence();
-                    verifyRestart("synthetic", 1, 8);
-                    break;
-                } catch (Throwable throwable) {
-                    LOG.info("Retry restart test case", throwable);
-                    cleanUpCluster();
-                    wipeAllODFEIndices();
-                }
-            }
-            assertTrue("failed all retries", i < maxRetries);
+            disableResourceNotFoundFaultTolerence();
+            verifyRestart("synthetic", 1, 8);
         }
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -465,4 +465,9 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             response.getIssue().getMessage()
         );
     }
+
+    @Test
+    public void testShouldFail() {
+        assertTrue(false);
+    }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -465,9 +465,4 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             response.getIssue().getMessage()
         );
     }
-
-    @Test
-    public void testShouldFail() {
-        assertTrue(false);
-    }
 }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Testing out new gradle plugin that retries failed test.
* Added this to both unit tests and integ tests
* `maxFailures`: "The maximum number of test failures that are allowed before retrying is disabled." (set to 10)
* `maxRetries`: "The maximum number of times to retry an individual test." (set to 10)
* `getFailOnPassedAfterRetry`: "Whether tests that initially fail and then pass on retry should fail the task." (set to **false** since if it passes once its good enough to pass build)

**Will be re-running workflows a few times on this PR to try this out and potentially adjust max failures/retries setting.** https://blog.gradle.org/gradle-flaky-test-retry-plugin

### Related Issues
#451 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
