### PR TITLE
Fix restart HCAD detector bug

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.CleanState;
 import org.opensearch.ad.MaintenanceState;
 import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.caching.DoorKeeper;
@@ -63,7 +64,7 @@ import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
  * Training models for HCAD detectors
  *
  */
-public class EntityColdStarter implements MaintenanceState {
+public class EntityColdStarter implements MaintenanceState, CleanState {
     private static final Logger logger = LogManager.getLogger(EntityColdStarter.class);
     private final Clock clock;
     private final ThreadPool threadPool;
@@ -742,5 +743,10 @@ public class EntityColdStarter implements MaintenanceState {
                 doorKeeper.maintenance();
             }
         });
+    }
+
+    @Override
+    public void clear(String detectorId) {
+        doorKeepers.remove(detectorId);
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
@@ -23,6 +23,7 @@ import org.opensearch.action.support.nodes.TransportNodesAction;
 import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.feature.FeatureManager;
+import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.cluster.service.ClusterService;
@@ -39,6 +40,7 @@ public class DeleteModelTransportAction extends
     private FeatureManager featureManager;
     private CacheProvider cache;
     private ADTaskCacheManager adTaskCacheManager;
+    private EntityColdStarter coldStarter;
 
     @Inject
     public DeleteModelTransportAction(
@@ -50,7 +52,8 @@ public class DeleteModelTransportAction extends
         ModelManager modelManager,
         FeatureManager featureManager,
         CacheProvider cache,
-        ADTaskCacheManager adTaskCacheManager
+        ADTaskCacheManager adTaskCacheManager,
+        EntityColdStarter coldStarter
     ) {
         super(
             DeleteModelAction.NAME,
@@ -68,6 +71,7 @@ public class DeleteModelTransportAction extends
         this.featureManager = featureManager;
         this.cache = cache;
         this.adTaskCacheManager = adTaskCacheManager;
+        this.coldStarter = coldStarter;
     }
 
     @Override
@@ -120,6 +124,8 @@ public class DeleteModelTransportAction extends
         nodeStateManager.clear(adID);
 
         cache.get().clear(adID);
+
+        coldStarter.clear(adID);
 
         // delete realtime task cache
         adTaskCacheManager.removeRealtimeTaskCache(adID);

--- a/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
@@ -34,6 +34,7 @@ import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.FeatureManager;
+import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.cluster.ClusterName;
@@ -76,7 +77,7 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
         EntityCache entityCache = mock(EntityCache.class);
         when(cacheProvider.get()).thenReturn(entityCache);
         ADTaskCacheManager adTaskCacheManager = mock(ADTaskCacheManager.class);
-        NodeStateManager stateManager = mock(NodeStateManager.class);
+        EntityColdStarter coldStarter = mock(EntityColdStarter.class);
 
         action = new DeleteModelTransportAction(
             threadPool,
@@ -87,7 +88,8 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
             modelManager,
             featureManager,
             cacheProvider,
-            adTaskCacheManager
+            adTaskCacheManager,
+            coldStarter
         );
     }
 


### PR DESCRIPTION
### Description
To prevent repeatedly cold starting a model due to sparse data, HCAD has a cache that remembers we have done cold start for a model. A second attempt to cold start will need to wait for 60 detector intervals. Previously, when stopping a detector, I forgot to clean the cache. So the cache remembers the model and won’t retry cold start after some time. This PR fixes the bug by cleaning the cache when stopping a detector.

Testing done:
1. added unit and integration tests.
2. manually reproduced the issue and verified the fix.

Signed-off-by: Kaituo Li <kaituo@amazon.com>
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/400
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
