### PR TITLE
Fixing jdk 8 compile issue for 1.x only

### DIFF
--- a/src/test/java/org/opensearch/ad/model/AnomalyResultBucketTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyResultBucketTests.java
@@ -45,7 +45,7 @@ public class AnomalyResultBucketTests extends AbstractADTest {
 
     @SuppressWarnings("unchecked")
     public void testToXContent() throws IOException {
-        Map<String, Object> key = new HashMap<>() {
+        Map<String, Object> key = new HashMap<String, Object>() {
             {
                 put("test-field-1", "test-value-1");
             }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Changed `<>` to `<String, Object>` since `Cannot use '<>' with anonymous inner classes` error occurs for JDK 8. This compiled fine on main since that now only uses jdk11 and up but 1.x branch can't compile without this code change as it supports java 8.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
