### PR TITLE
Changes default version to 2.0.0-alpha1 and fixes CVE-2020-36518

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,20 +29,20 @@ jobs:
 
       - name: Assemble anomaly-detection
         run: |
-          ./gradlew assemble -Dopensearch.version=2.0.0-SNAPSHOT
-          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-SNAPSHOT ..."
-          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-SNAPSHOT
-          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-SNAPSHOT ..."
+          ./gradlew assemble
+          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT ..."
+          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT
+          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT ..."
           ls ./build/distributions/
-          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-SNAPSHOT
-          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-SNAPSHOT ..."
-          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-SNAPSHOT
+          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT
+          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT ..."
+          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=2.0.0-SNAPSHOT
+          ./gradlew build
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=2.0.0-SNAPSHOT
+          ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
           ./gradlew integTest -PnumNodes=3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,14 +29,16 @@ jobs:
 
       - name: Assemble anomaly-detection
         run: |
+          plugin_version=`./gradlew properties -q | grep "opensearch_build:" | awk '{print $2}'`
+          echo plugin_version $plugin_version
           ./gradlew assemble
-          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT ..."
-          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT
-          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT ..."
+          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/$plugin_version ..."
+          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/$plugin_version
+          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/$plugin_version ..."
           ls ./build/distributions/
-          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT
-          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT ..."
-          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/2.0.0.0-alpha1-SNAPSHOT
+          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/$plugin_version
+          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/$plugin_version ..."
+          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/$plugin_version
       - name: Build and Run Tests
         run: |
           ./gradlew build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11, 14]
+        java: [11]
       fail-fast: false
 
     name: Build and Test Anomaly detection Plugin

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ configurations.all {
     if (it.state != Configuration.State.UNRESOLVED) return
     resolutionStrategy {
         force "joda-time:joda-time:${versions.joda}"
-        force "com.fasterxml.jackson.core:jackson-core:2.12.6"
+        force "com.fasterxml.jackson.core:jackson-core:2.13.2"
         force "commons-logging:commons-logging:${versions.commonslogging}"
         force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
         force "commons-codec:commons-codec:${versions.commonscodec}"
@@ -588,9 +588,9 @@ dependencies {
 
     // force Jackson version to avoid version conflict issue
     implementation 'software.amazon.randomcutforest:randomcutforest-serialization:2.0.1'
-    implementation "com.fasterxml.jackson.core:jackson-core:2.12.6"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.6"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.12.6"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.13.2"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.2"
     implementation files('lib/randomcutforest-parkservices-2.0.1.jar')
     implementation files('lib/randomcutforest-core-2.0.1.jar')
 

--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,7 @@ String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2","1.3.0-SNAPSHOT"]
+            versions = ["7.10.2", "2.0.0-alpha1-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,13 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
-        // 1.2.0 -> 1.2.0.0, and 1.2.0-SNAPSHOT -> 1.2.0.0-SNAPSHOT
-        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
+        // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
+        for (int j = 1; j < version_tokens.size(); j++) {
+            opensearch_build = opensearch_build + '-' + version_tokens[j]
+        }
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,17 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
+        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier")
         // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
-        for (int j = 1; j < version_tokens.size(); j++) {
-            opensearch_build = opensearch_build + '-' + version_tokens[j]
+        if (buildVersionQualifier) {
+            opensearch_build += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            opensearch_build += "-SNAPSHOT"
         }
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -533,7 +533,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      */
     public void initAnomalyDetectorIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
         CreateIndexRequest request = new CreateIndexRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
-            .mapping(AnomalyDetector.TYPE, getAnomalyDetectorMappings(), XContentType.JSON)
+            .mapping(getAnomalyDetectorMappings())
             .settings(settings);
         adminClient.indices().create(request, markMappingUpToDate(ADIndex.CONFIG, actionListener));
     }
@@ -597,7 +597,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
         ActionListener<CreateIndexResponse> actionListener
     ) throws IOException {
         String mapping = getAnomalyResultMappings();
-        CreateIndexRequest request = new CreateIndexRequest(resultIndex).mapping(CommonName.MAPPING_TYPE, mapping, XContentType.JSON);
+        CreateIndexRequest request = new CreateIndexRequest(resultIndex).mapping(mapping);
         if (alias != null) {
             request.alias(new Alias(CommonName.ANOMALY_RESULT_INDEX_ALIAS));
         }
@@ -617,7 +617,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     public void initAnomalyDetectorJobIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
             CreateIndexRequest request = new CreateIndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
-                .mapping(AnomalyDetector.TYPE, getAnomalyDetectorJobMappings(), XContentType.JSON);
+                .mapping(getAnomalyDetectorJobMappings());
             request
                 .settings(
                     Settings
@@ -649,7 +649,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     public void initDetectionStateIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
             CreateIndexRequest request = new CreateIndexRequest(CommonName.DETECTION_STATE_INDEX)
-                .mapping(AnomalyDetector.TYPE, getDetectionStateMappings(), XContentType.JSON)
+                .mapping(getDetectionStateMappings())
                 .settings(settings);
             adminClient.indices().create(request, markMappingUpToDate(ADIndex.STATE, actionListener));
         } catch (IOException e) {
@@ -672,7 +672,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
             throw new EndRunException("", "Cannot find checkpoint mapping file", true);
         }
         CreateIndexRequest request = new CreateIndexRequest(CommonName.CHECKPOINT_INDEX_NAME)
-            .mapping(CommonName.MAPPING_TYPE, mapping, XContentType.JSON);
+            .mapping(mapping);
         choosePrimaryShards(request);
         adminClient.indices().create(request, markMappingUpToDate(ADIndex.CHECKPOINT, actionListener));
     }
@@ -729,7 +729,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
         }
         CreateIndexRequest createRequest = rollOverRequest.getCreateIndexRequest();
 
-        createRequest.index(AD_RESULT_HISTORY_INDEX_PATTERN).mapping(CommonName.MAPPING_TYPE, adResultMapping, XContentType.JSON);
+        createRequest.index(AD_RESULT_HISTORY_INDEX_PATTERN).mapping(adResultMapping);
 
         choosePrimaryShards(createRequest);
 

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -533,7 +533,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      */
     public void initAnomalyDetectorIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
         CreateIndexRequest request = new CreateIndexRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
-            .mapping(getAnomalyDetectorMappings())
+            .mapping(getAnomalyDetectorMappings(), XContentType.JSON)
             .settings(settings);
         adminClient.indices().create(request, markMappingUpToDate(ADIndex.CONFIG, actionListener));
     }
@@ -597,7 +597,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
         ActionListener<CreateIndexResponse> actionListener
     ) throws IOException {
         String mapping = getAnomalyResultMappings();
-        CreateIndexRequest request = new CreateIndexRequest(resultIndex).mapping(mapping);
+        CreateIndexRequest request = new CreateIndexRequest(resultIndex).mapping(mapping, XContentType.JSON);
         if (alias != null) {
             request.alias(new Alias(CommonName.ANOMALY_RESULT_INDEX_ALIAS));
         }
@@ -617,7 +617,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     public void initAnomalyDetectorJobIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
             CreateIndexRequest request = new CreateIndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
-                .mapping(getAnomalyDetectorJobMappings());
+                .mapping(getAnomalyDetectorJobMappings(), XContentType.JSON);
             request
                 .settings(
                     Settings
@@ -649,7 +649,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     public void initDetectionStateIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
             CreateIndexRequest request = new CreateIndexRequest(CommonName.DETECTION_STATE_INDEX)
-                .mapping(getDetectionStateMappings())
+                .mapping(getDetectionStateMappings(), XContentType.JSON)
                 .settings(settings);
             adminClient.indices().create(request, markMappingUpToDate(ADIndex.STATE, actionListener));
         } catch (IOException e) {
@@ -671,8 +671,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
         } catch (IOException e) {
             throw new EndRunException("", "Cannot find checkpoint mapping file", true);
         }
-        CreateIndexRequest request = new CreateIndexRequest(CommonName.CHECKPOINT_INDEX_NAME)
-            .mapping(mapping);
+        CreateIndexRequest request = new CreateIndexRequest(CommonName.CHECKPOINT_INDEX_NAME).mapping(mapping, XContentType.JSON);
         choosePrimaryShards(request);
         adminClient.indices().create(request, markMappingUpToDate(ADIndex.CHECKPOINT, actionListener));
     }
@@ -729,7 +728,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
         }
         CreateIndexRequest createRequest = rollOverRequest.getCreateIndexRequest();
 
-        createRequest.index(AD_RESULT_HISTORY_INDEX_PATTERN).mapping(adResultMapping);
+        createRequest.index(AD_RESULT_HISTORY_INDEX_PATTERN).mapping(adResultMapping, XContentType.JSON);
 
         choosePrimaryShards(createRequest);
 

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -335,34 +335,31 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
         // AbstractAnomalyDetectorActionHandler.validateCategoricalField(String, boolean)
         ActionListener<GetFieldMappingsResponse> mappingsListener = ActionListener.wrap(getMappingsResponse -> {
             boolean foundField = false;
-            Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>>> mappingsByIndex = getMappingsResponse
-                .mappings();
+            Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByIndex = getMappingsResponse.mappings();
 
-            for (Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByType : mappingsByIndex.values()) {
-                for (Map<String, GetFieldMappingsResponse.FieldMappingMetadata> mappingsByField : mappingsByType.values()) {
-                    for (Map.Entry<String, GetFieldMappingsResponse.FieldMappingMetadata> field2Metadata : mappingsByField.entrySet()) {
+            for (Map<String, GetFieldMappingsResponse.FieldMappingMetadata> mappingsByField : mappingsByIndex.values()) {
+                for (Map.Entry<String, GetFieldMappingsResponse.FieldMappingMetadata> field2Metadata : mappingsByField.entrySet()) {
 
-                        GetFieldMappingsResponse.FieldMappingMetadata fieldMetadata = field2Metadata.getValue();
-                        if (fieldMetadata != null) {
-                            // sourceAsMap returns sth like {host2={type=keyword}} with host2 being a nested field
-                            Map<String, Object> fieldMap = fieldMetadata.sourceAsMap();
-                            if (fieldMap != null) {
-                                for (Object type : fieldMap.values()) {
-                                    if (type instanceof Map) {
-                                        foundField = true;
-                                        Map<String, Object> metadataMap = (Map<String, Object>) type;
-                                        String typeName = (String) metadataMap.get(CommonName.TYPE);
-                                        if (!typeName.equals(CommonName.DATE_TYPE)) {
-                                            listener
-                                                .onFailure(
-                                                    new ADValidationException(
-                                                        String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIMESTAMP, givenTimeField),
-                                                        DetectorValidationIssueType.TIMEFIELD_FIELD,
-                                                        ValidationAspect.DETECTOR
-                                                    )
-                                                );
-                                            return;
-                                        }
+                    GetFieldMappingsResponse.FieldMappingMetadata fieldMetadata = field2Metadata.getValue();
+                    if (fieldMetadata != null) {
+                        // sourceAsMap returns sth like {host2={type=keyword}} with host2 being a nested field
+                        Map<String, Object> fieldMap = fieldMetadata.sourceAsMap();
+                        if (fieldMap != null) {
+                            for (Object type : fieldMap.values()) {
+                                if (type instanceof Map) {
+                                    foundField = true;
+                                    Map<String, Object> metadataMap = (Map<String, Object>) type;
+                                    String typeName = (String) metadataMap.get(CommonName.TYPE);
+                                    if (!typeName.equals(CommonName.DATE_TYPE)) {
+                                        listener
+                                            .onFailure(
+                                                new ADValidationException(
+                                                    String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIMESTAMP, givenTimeField),
+                                                    DetectorValidationIssueType.TIMEFIELD_FIELD,
+                                                    ValidationAspect.DETECTOR
+                                                )
+                                            );
+                                        return;
                                     }
                                 }
                             }
@@ -608,45 +605,42 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             boolean foundField = false;
 
             // Review why the change from FieldMappingMetadata to GetFieldMappingsResponse.FieldMappingMetadata
-            Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>>> mappingsByIndex = getMappingsResponse
-                .mappings();
+            Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByIndex = getMappingsResponse.mappings();
 
-            for (Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByType : mappingsByIndex.values()) {
-                for (Map<String, GetFieldMappingsResponse.FieldMappingMetadata> mappingsByField : mappingsByType.values()) {
-                    for (Map.Entry<String, GetFieldMappingsResponse.FieldMappingMetadata> field2Metadata : mappingsByField.entrySet()) {
-                        // example output:
-                        // host_nest.host2=FieldMappingMetadata{fullName='host_nest.host2',
-                        // source=org.opensearch.common.bytes.BytesArray@8fb4de08}
+            for (Map<String, GetFieldMappingsResponse.FieldMappingMetadata> mappingsByField : mappingsByIndex.values()) {
+                for (Map.Entry<String, GetFieldMappingsResponse.FieldMappingMetadata> field2Metadata : mappingsByField.entrySet()) {
+                    // example output:
+                    // host_nest.host2=FieldMappingMetadata{fullName='host_nest.host2',
+                    // source=org.opensearch.common.bytes.BytesArray@8fb4de08}
 
-                        // Review why the change from FieldMappingMetadata to GetFieldMappingsResponse.FieldMappingMetadata
+                    // Review why the change from FieldMappingMetadata to GetFieldMappingsResponse.FieldMappingMetadata
 
-                        GetFieldMappingsResponse.FieldMappingMetadata fieldMetadata = field2Metadata.getValue();
+                    GetFieldMappingsResponse.FieldMappingMetadata fieldMetadata = field2Metadata.getValue();
 
-                        if (fieldMetadata != null) {
-                            // sourceAsMap returns sth like {host2={type=keyword}} with host2 being a nested field
-                            Map<String, Object> fieldMap = fieldMetadata.sourceAsMap();
-                            if (fieldMap != null) {
-                                for (Object type : fieldMap.values()) {
-                                    if (type != null && type instanceof Map) {
-                                        foundField = true;
-                                        Map<String, Object> metadataMap = (Map<String, Object>) type;
-                                        String typeName = (String) metadataMap.get(CommonName.TYPE);
-                                        if (!typeName.equals(CommonName.KEYWORD_TYPE) && !typeName.equals(CommonName.IP_TYPE)) {
-                                            listener
-                                                .onFailure(
-                                                    new ADValidationException(
-                                                        CATEGORICAL_FIELD_TYPE_ERR_MSG,
-                                                        DetectorValidationIssueType.CATEGORY,
-                                                        ValidationAspect.DETECTOR
-                                                    )
-                                                );
-                                            return;
-                                        }
+                    if (fieldMetadata != null) {
+                        // sourceAsMap returns sth like {host2={type=keyword}} with host2 being a nested field
+                        Map<String, Object> fieldMap = fieldMetadata.sourceAsMap();
+                        if (fieldMap != null) {
+                            for (Object type : fieldMap.values()) {
+                                if (type != null && type instanceof Map) {
+                                    foundField = true;
+                                    Map<String, Object> metadataMap = (Map<String, Object>) type;
+                                    String typeName = (String) metadataMap.get(CommonName.TYPE);
+                                    if (!typeName.equals(CommonName.KEYWORD_TYPE) && !typeName.equals(CommonName.IP_TYPE)) {
+                                        listener
+                                            .onFailure(
+                                                new ADValidationException(
+                                                    CATEGORICAL_FIELD_TYPE_ERR_MSG,
+                                                    DetectorValidationIssueType.CATEGORY,
+                                                    ValidationAspect.DETECTOR
+                                                )
+                                            );
+                                        return;
                                     }
                                 }
                             }
-
                         }
+
                     }
                 }
             }

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -52,6 +52,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetadata;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
@@ -1046,7 +1047,7 @@ public class TestHelpers {
     }
 
     public static CreateIndexResponse createIndex(AdminClient adminClient, String indexName, String indexMapping) {
-        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(AnomalyDetector.TYPE, indexMapping, XContentType.JSON);
+        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(indexMapping);
         return adminClient.indices().create(request).actionGet(5_000);
     }
 
@@ -1211,17 +1212,17 @@ public class TestHelpers {
         return new DetectorInternalState.Builder().lastUpdateTime(lastUpdateTime).error(error).build();
     }
 
-    public static Map<String, Map<String, Map<String, FieldMappingMetadata>>> createFieldMappings(
+    public static Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> createFieldMappings(
         String index,
         String fieldName,
         String fieldType
     ) throws IOException {
-        Map<String, Map<String, Map<String, FieldMappingMetadata>>> mappings = new HashMap<>();
+        Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappings = new HashMap<>();
         FieldMappingMetadata fieldMappingMetadata = new FieldMappingMetadata(
             fieldName,
             new BytesArray("{\"" + fieldName + "\":{\"type\":\"" + fieldType + "\"}}")
         );
-        mappings.put(index, Collections.singletonMap(CommonName.MAPPING_TYPE, Collections.singletonMap(fieldName, fieldMappingMetadata)));
+        mappings.put(index, Collections.singletonMap(fieldName, fieldMappingMetadata));
         return mappings;
     }
 

--- a/src/test/java/org/opensearch/ad/indices/RolloverTests.java
+++ b/src/test/java/org/opensearch/ad/indices/RolloverTests.java
@@ -129,7 +129,7 @@ public class RolloverTests extends AbstractADTest {
 
         CreateIndexRequest createIndexRequest = request.getCreateIndexRequest();
         assertEquals(AnomalyDetectionIndices.AD_RESULT_HISTORY_INDEX_PATTERN, createIndexRequest.index());
-        assertTrue(createIndexRequest.mappings().get(CommonName.MAPPING_TYPE).contains("data_start_time"));
+        assertTrue(createIndexRequest.mappings().contains("data_start_time"));
     }
 
     public void testNotRolledOver() {
@@ -169,7 +169,7 @@ public class RolloverTests extends AbstractADTest {
 
             CreateIndexRequest createIndexRequest = request.getCreateIndexRequest();
             assertEquals(AnomalyDetectionIndices.AD_RESULT_HISTORY_INDEX_PATTERN, createIndexRequest.index());
-            assertTrue(createIndexRequest.mappings().get(CommonName.MAPPING_TYPE).contains("data_start_time"));
+            assertTrue(createIndexRequest.mappings().contains("data_start_time"));
             listener.onResponse(new RolloverResponse(null, null, Collections.emptyMap(), request.isDryRun(), true, true, true));
             return null;
         }).when(indicesClient).rolloverIndex(any(), any());


### PR DESCRIPTION
### Description
Changes in this PR:
1. Updates default version qualifier to alpha1
2. Fixes more mapping type changes and return type of method based of core changes
3. updates Jackson databind to 2.13.2.2, jackson core to 2.13.2 and jacson annotations to 2.13.2.
`Jackson databind 2.13.2.2` fixes this issue https://github.com/opensearch-project/anomaly-detection/issues/436
4. Removes JDK 14 support
### Issues Resolved
resolves https://github.com/opensearch-project/anomaly-detection/issues/436
resolves #479 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
