### PR TITLE
Making default qualifier alpha1 in AD plugin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,17 +51,25 @@ jobs:
 #        ToDo: Check infra team for 2.0 docker availability and re-enable  
 #       - name: Pull and Run Docker
 #         run: |
-#           plugin=`ls build/distributions/*.zip`
-#           version=2.0.0
-#           plugin_version=2.0.0.0-SNAPSHOT
-#           echo Using OpenSearch $version with AD $plugin_version
+#          plugin=`basename $(ls plugin/build/distributions/*.zip)`
+#          version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
+#          plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
+#          qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
+#          candidate_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
+#          docker_version=$version-$qualifier
+#
+#          [[ -z $candidate_version ]] && candidate_version=$qualifier && qualifier=""
+#
+#          echo plugin version plugin_version qualifier candidate_version docker_version
+#          echo "($plugin) ($version) ($plugin_version) ($qualifier) ($candidate_version) ($docker_version)"
+#
 #           cd ..
-#           if docker pull opensearchstaging/opensearch:$version
+#           if docker pull opensearchstaging/opensearch:$docker_version
 #           then
-#             echo "FROM opensearchstaging/opensearch:$version" >> Dockerfile
+#             echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
 #             echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-anomaly-detection ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-anomaly-detection; fi" >> Dockerfile
-#             echo "ADD anomaly-detection/build/distributions/opensearch-anomaly-detection-$plugin_version.zip /tmp/" >> Dockerfile
-#             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-anomaly-detection-$plugin_version.zip" >> Dockerfile
+#             echo "ADD anomaly-detection/build/distributions/$plugin /tmp/" >> Dockerfile
+#             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile
 #             docker build -t opensearch-ad:test .
 #             echo "imagePresent=true" >> $GITHUB_ENV
 #           else

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
         // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Making default qualifier alpha1 in AD plugin
 
### Issues Resolved
#432
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
