### PR TITLE
Check if indices exist in the presence of empty search results

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -478,7 +478,9 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 nextDetectionStartTime,
                 settings,
                 maxEntitiesPerInterval,
-                pageSize
+                pageSize,
+                indexNameExpressionResolver,
+                clusterService
             );
 
             PageIterator pageIterator = null;

--- a/src/test/java/org/opensearch/ad/feature/NoPowermockSearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/ad/feature/NoPowermockSearchFeatureDaoTests.java
@@ -599,8 +599,10 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractADTest {
             new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService()),
             1
         );
-        hllpp.collect(0, BitMixer.mix64(randomIntBetween(1, 100)));
-        hllpp.collect(0, BitMixer.mix64(randomIntBetween(1, 100)));
+        long hash1 = BitMixer.mix64(randomIntBetween(1, 100));
+        long hash2 = BitMixer.mix64(randomIntBetween(1, 100));
+        hllpp.collect(0, hash1);
+        hllpp.collect(0, hash2);
 
         Constructor ctor = null;
         ctor = InternalCardinality.class.getDeclaredConstructor(String.class, AbstractHyperLogLogPlusPlus.class, Map.class);
@@ -626,7 +628,8 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractADTest {
         assertTrue(parsedResult.isPresent());
         double[] parsedCardinality = parsedResult.get();
         assertEquals(1, parsedCardinality.length);
-        assertEquals(2, parsedCardinality[0], 0.001);
+        double buckets = hash1 == hash2 ? 1 : 2;
+        assertEquals(buckets, parsedCardinality[0], 0.001);
 
         // release MockBigArrays; otherwise, test will fail
         Releasables.close(hllpp);

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -1296,7 +1296,6 @@ public class MultiEntityResultTests extends AbstractADTest {
      * @throws InterruptedException while waiting for execution gets interruptted
      */
     public void testMissingIndex() throws InterruptedException {
-        // when(indexNameResolver.concreteIndexNames(any(), any(), any(String[].class))).thenReturn(new String[] {});
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
 
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description
Previously, CompositeRetriever throws an IllegalArgumentException in the presence of empty results, which gets translated to internal failure and increments AD failure count. When the source index is a regex like blah*, we will get an empty response even if the index does not exist. This PR checks indices exist in the presence of empty search results. If yes, we throw an IndexNotFoundException that ends up being converted to EndRunException; if no, we still throw an IllegalArgumentException.

Testing done:
1. added unit tests
2. reproduced manually and verified the change fixed the issue.

Signed-off-by: Kaituo Li <kaituo@amazon.com>
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
