### PR TITLE
add more unit tests for AD transport actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -546,17 +546,11 @@ List<String> jacocoExclusions = [
         //'org.opensearch.ad.common.exception.AnomalyDetectionException',
         'org.opensearch.ad.util.ClientUtil',
 
-        'org.opensearch.ad.transport.StopDetectorRequest',
-        'org.opensearch.ad.transport.StopDetectorResponse',
         'org.opensearch.ad.transport.CronRequest',
         'org.opensearch.ad.AnomalyDetectorRunner',
 
         // related to transport actions added for security
-        'org.opensearch.ad.transport.DeleteAnomalyDetectorTransportAction*',
-        'org.opensearch.ad.transport.GetAnomalyDetectorTransportAction*',
-        'org.opensearch.ad.transport.SearchAnomalyResultTransportAction*',
-        'org.opensearch.ad.transport.SearchAnomalyDetectorInfoTransportAction*',
-        'org.opensearch.ad.transport.AnomalyDetectorJobRequest',
+        'org.opensearch.ad.transport.DeleteAnomalyDetectorTransportAction.1',
 
         // TODO: unified flow caused coverage drop
         'org.opensearch.ad.transport.DeleteAnomalyResultsTransportAction',

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -12,6 +12,7 @@
 package org.opensearch.ad;
 
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static org.opensearch.cluster.node.DiscoveryNodeRole.BUILT_IN_ROLES;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
@@ -108,6 +109,7 @@ import org.opensearch.common.Priority;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -1494,5 +1496,27 @@ public class TestHelpers {
             new IntervalTimeConfiguration(intervalRec, ChronoUnit.MINUTES)
         );
         return issue;
+    }
+
+    public static ClusterState createClusterState() {
+        ImmutableOpenMap<String, IndexMetadata> immutableOpenMap = ImmutableOpenMap
+            .<String, IndexMetadata>builder()
+            .fPut(
+                ANOMALY_DETECTOR_JOB_INDEX,
+                IndexMetadata
+                    .builder("test")
+                    .settings(
+                        Settings
+                            .builder()
+                            .put("index.number_of_shards", 1)
+                            .put("index.number_of_replicas", 1)
+                            .put("index.version.created", Version.CURRENT.id)
+                    )
+                    .build()
+            )
+            .build();
+        Metadata metaData = Metadata.builder().indices(immutableOpenMap).build();
+        ClusterState clusterState = new ClusterState(new ClusterName("test_name"), 1l, "uuid", metaData, null, null, null, null, 1, true);
+        return clusterState;
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import org.junit.Test;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
+import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.client.Client;
@@ -112,6 +114,18 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
 
     @Test
     public void testAdJobRequest() throws IOException {
+        DetectionDateRange detectionDateRange = new DetectionDateRange(Instant.MIN, Instant.now());
+        request = new AnomalyDetectorJobRequest("1234", detectionDateRange, false, 4567, 7890, "_start");
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        AnomalyDetectorJobRequest newRequest = new AnomalyDetectorJobRequest(input);
+        Assert.assertEquals(request.getDetectorID(), newRequest.getDetectorID());
+    }
+
+    @Test
+    public void testAdJobRequest_NullDetectionDateRange() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         StreamInput input = out.bytes().streamInput();

--- a/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.transport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.ad.AbstractADTest;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.model.ADTask;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyDetectorJob;
+import org.opensearch.ad.model.IntervalTimeConfiguration;
+import org.opensearch.ad.rest.handler.AnomalyDetectorFunction;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.collect.ImmutableOpenMap;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.Transport;
+import org.opensearch.transport.TransportService;
+
+public class DeleteAnomalyDetectorTests extends AbstractADTest {
+    private DeleteAnomalyDetectorTransportAction action;
+    private TransportService transportService;
+    private ActionFilters actionFilters;
+    private Client client;
+    private ADTaskManager adTaskManager;
+    private PlainActionFuture<DeleteResponse> future;
+    private DeleteResponse deleteResponse;
+    private GetResponse getResponse;
+    ClusterService clusterService;
+    private AnomalyDetectorJob jobParameter;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        setUpThreadPool(EntityProfileTests.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        tearDownThreadPool();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            null,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
+
+        actionFilters = mock(ActionFilters.class);
+        adTaskManager = mock(ADTaskManager.class);
+        action = new DeleteAnomalyDetectorTransportAction(
+            transportService,
+            actionFilters,
+            client,
+            clusterService,
+            Settings.EMPTY,
+            xContentRegistry(),
+            adTaskManager
+        );
+
+        jobParameter = mock(AnomalyDetectorJob.class);
+        when(jobParameter.getName()).thenReturn(randomAlphaOfLength(10));
+        IntervalSchedule schedule = new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES);
+        when(jobParameter.getSchedule()).thenReturn(schedule);
+        when(jobParameter.getWindowDelay()).thenReturn(new IntervalTimeConfiguration(10, ChronoUnit.SECONDS));
+    }
+
+    public void testDeleteADTransportAction_FailDeleteResponse() {
+        future = mock(PlainActionFuture.class);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest("1234");
+        setupMocks(true, true, false, false);
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(adTaskManager).deleteADTasks(eq("1234"), any(), any());
+        verify(client, times(1)).delete(any(), any());
+        verify(future).onFailure(any(OpenSearchStatusException.class));
+    }
+
+    public void testDeleteADTransportAction_NullAnomalyDetector() {
+        future = mock(PlainActionFuture.class);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest("1234");
+        setupMocks(true, false, false, false);
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(adTaskManager).deleteADTasks(eq("1234"), any(), any());
+        verify(client, times(3)).delete(any(), any());
+    }
+
+    public void testDeleteADTransportAction_DeleteResponseException() {
+        future = mock(PlainActionFuture.class);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest("1234");
+        setupMocks(true, false, true, false);
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(adTaskManager).deleteADTasks(eq("1234"), any(), any());
+        verify(client, times(1)).delete(any(), any());
+        verify(future).onFailure(any(RuntimeException.class));
+    }
+
+    public void testDeleteADTransportAction_LatestDetectorLevelTask() {
+        when(clusterService.state()).thenReturn(createClusterState());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            Consumer<Optional<ADTask>> consumer = (Consumer<Optional<ADTask>>) args[2];
+            ADTask adTask = ADTask.builder().state("RUNNING").build();
+            consumer.accept(Optional.of(adTask));
+            return null;
+        }).when(adTaskManager).getAndExecuteOnLatestDetectorLevelTask(eq("1234"), any(), any(), eq(transportService), eq(true), any());
+
+        future = mock(PlainActionFuture.class);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest("1234");
+        setupMocks(false, false, false, false);
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(future).onFailure(any(OpenSearchStatusException.class));
+    }
+
+    public void testDeleteADTransportAction_JobRunning() {
+        when(clusterService.state()).thenReturn(createClusterState());
+        future = mock(PlainActionFuture.class);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest("1234");
+        setupMocks(false, false, false, false);
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(future).onFailure(any(RuntimeException.class));
+    }
+
+    public void testDeleteADTransportAction_GetResponseException() {
+        when(clusterService.state()).thenReturn(createClusterState());
+        future = mock(PlainActionFuture.class);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest("1234");
+        setupMocks(false, false, false, true);
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(client).get(any(), any());
+        verify(client).get(any(), any());
+    }
+
+    private ClusterState createClusterState() {
+        ImmutableOpenMap<String, IndexMetadata> immutableOpenMap = ImmutableOpenMap
+            .<String, IndexMetadata>builder()
+            .fPut(
+                ANOMALY_DETECTOR_JOB_INDEX,
+                IndexMetadata
+                    .builder("test")
+                    .settings(
+                        Settings
+                            .builder()
+                            .put("index.number_of_shards", 1)
+                            .put("index.number_of_replicas", 1)
+                            .put("index.version.created", Version.CURRENT.id)
+                    )
+                    .build()
+            )
+            .build();
+        Metadata metaData = Metadata.builder().indices(immutableOpenMap).build();
+        ClusterState clusterState = new ClusterState(new ClusterName("test_name"), 1l, "uuid", metaData, null, null, null, null, 1, true);
+        return clusterState;
+    }
+
+    private void setupMocks(
+        boolean nullAnomalyDetectorResponse,
+        boolean failDeleteDeleteResponse,
+        boolean deleteResponseException,
+        boolean getResponseFailure
+    ) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            Consumer<Optional<AnomalyDetector>> consumer = (Consumer<Optional<AnomalyDetector>>) args[1];
+            if (nullAnomalyDetectorResponse) {
+                consumer.accept(Optional.empty());
+            } else {
+                AnomalyDetector ad = mock(AnomalyDetector.class);
+                consumer.accept(Optional.of(ad));
+            }
+            return null;
+        }).when(adTaskManager).getDetector(any(), any(), any());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            AnomalyDetectorFunction function = (AnomalyDetectorFunction) args[1];
+
+            function.execute();
+            return null;
+        }).when(adTaskManager).deleteADTasks(eq("1234"), any(), any());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<DeleteResponse> listener = (ActionListener<DeleteResponse>) args[1];
+            deleteResponse = mock(DeleteResponse.class);
+            if (deleteResponseException) {
+                listener.onFailure(new RuntimeException("Failed to delete anomaly detector job"));
+                return null;
+            }
+            if (failDeleteDeleteResponse) {
+                doReturn(DocWriteResponse.Result.CREATED).when(deleteResponse).getResult();
+            } else {
+                doReturn(DocWriteResponse.Result.DELETED).when(deleteResponse).getResult();
+            }
+            listener.onResponse(deleteResponse);
+            return null;
+        }).when(client).delete(any(), any());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+            if (getResponseFailure) {
+                listener.onFailure(new RuntimeException("Fail to get anomaly detector job"));
+                return null;
+            }
+            getResponse = new GetResponse(
+                new GetResult(
+                    AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX,
+                    "id",
+                    UNASSIGNED_SEQ_NO,
+                    0,
+                    -1,
+                    true,
+                    BytesReference
+                        .bytes(
+                            new AnomalyDetectorJob(
+                                "1234",
+                                jobParameter.getSchedule(),
+                                jobParameter.getWindowDelay(),
+                                true,
+                                Instant.now().minusSeconds(60),
+                                Instant.now(),
+                                Instant.now(),
+                                60L,
+                                TestHelpers.randomUser(),
+                                jobParameter.getResultIndex()
+                            ).toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS)
+                        ),
+                    Collections.emptyMap(),
+                    Collections.emptyMap()
+                )
+            );
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -11,18 +11,197 @@
 
 package org.opensearch.ad.transport;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ad.TestHelpers.createClusterState;
+import static org.opensearch.ad.TestHelpers.createSearchResponse;
 import static org.opensearch.ad.TestHelpers.matchAllRequest;
 import static org.opensearch.ad.indices.AnomalyDetectionIndices.ALL_AD_RESULTS_INDEX_PATTERN;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.search.MultiSearchResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ad.HistoricalAnalysisIntegTestCase;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.transport.handler.ADSearchHandler;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.Aggregation;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalOrder;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.Transport;
+import org.opensearch.transport.TransportService;
+
+import com.google.common.collect.ImmutableList;
 
 public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestCase {
+    private SearchAnomalyResultTransportAction action;
+    private TransportService transportService;
+    private ThreadPool threadPool;
+    private ThreadContext threadContext;
+    private Client client;
+    private ClusterService clusterService;
+    private ActionFilters actionFilters;
+    private ADSearchHandler searchHandler;
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+    private PlainActionFuture<SearchResponse> future;
+    private ClusterState clusterState;
+    private SearchResponse searchResponse;
+    private MultiSearchResponse multiSearchResponse;
+    private StringTerms resultIndicesAgg;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        clusterState = createClusterState();
+        when(clusterService.state()).thenReturn(clusterState);
+
+        transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            null,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        client = mock(Client.class);
+        threadPool = mock(ThreadPool.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        Settings settings = Settings.builder().build();
+        threadContext = new ThreadContext(settings);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        actionFilters = mock(ActionFilters.class);
+        searchHandler = mock(ADSearchHandler.class);
+        indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
+        action = new SearchAnomalyResultTransportAction(
+            transportService,
+            actionFilters,
+            searchHandler,
+            clusterService,
+            indexNameExpressionResolver,
+            client
+        );
+    }
+
+    @Test
+    public void testSearchAnomalyResult_NoIndices() {
+        future = mock(PlainActionFuture.class);
+        SearchRequest request = new SearchRequest().indices(new String[] {});
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(future).onFailure(any(IllegalArgumentException.class));
+    }
+
+    @Test
+    public void testSearchAnomalyResult_NullAggregationInSearchResponse() {
+        future = mock(PlainActionFuture.class);
+        SearchRequest request = new SearchRequest().indices(new String[] { "opensearch-ad-plugin-result-test" });
+        when(indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpen(), request.indices()))
+            .thenReturn(new String[] { "opensearch-ad-plugin-result-test" });
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
+            listener.onResponse(createSearchResponse(TestHelpers.randomAnomalyDetectResult(0.87)));
+            return null;
+        }).when(client).search(any(), any());
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(client).search(any(), any());
+    }
+
+    @Test
+    public void testSearchAnomalyResult_MultiSearch() {
+        future = mock(PlainActionFuture.class);
+        SearchRequest request = new SearchRequest().indices(new String[] { "opensearch-ad-plugin-result-test" });
+        when(indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpen(), request.indices()))
+            .thenReturn(new String[] { "opensearch-ad-plugin-result-test" });
+
+        searchResponse = mock(SearchResponse.class);
+        resultIndicesAgg = new StringTerms(
+            "result_index",
+            InternalOrder.key(false),
+            BucketOrder.count(false),
+            1,
+            0,
+            Collections.emptyMap(),
+            DocValueFormat.RAW,
+            1,
+            false,
+            0,
+            createBuckets(),
+            0
+        );
+        List<Aggregation> list = new ArrayList<>();
+        list.add(resultIndicesAgg);
+        Aggregations aggregations = new Aggregations(list);
+
+        when(searchResponse.getAggregations()).thenReturn(aggregations);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(), any());
+
+        multiSearchResponse = mock(MultiSearchResponse.class);
+        MultiSearchResponse.Item multiSearchResponseItem = mock(MultiSearchResponse.Item.class);
+        when(multiSearchResponse.getResponses()).thenReturn(new MultiSearchResponse.Item[] { multiSearchResponseItem });
+        when(multiSearchResponseItem.getFailure()).thenReturn(null);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<MultiSearchResponse> listener = (ActionListener<MultiSearchResponse>) args[1];
+            listener.onResponse(multiSearchResponse);
+            return null;
+        }).when(client).multiSearch(any(), any());
+
+        action.doExecute(mock(Task.class), request, future);
+        verify(client).search(any(), any());
+        verify(client).multiSearch(any(), any());
+        verify(searchHandler).search(any(), any());
+        ;
+    }
 
     @Test
     public void testSearchResultAction() throws IOException {
@@ -46,4 +225,18 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
         assertEquals(0, searchResponse.getHits().getTotalHits().value);
     }
 
+    private List<StringTerms.Bucket> createBuckets() {
+        String entity1Name = "opensearch-ad-plugin-result-test";
+        long entity1Count = 3;
+        StringTerms.Bucket entity1Bucket = new StringTerms.Bucket(
+            new BytesRef(entity1Name.getBytes(StandardCharsets.UTF_8), 0, entity1Name.getBytes(StandardCharsets.UTF_8).length),
+            entity1Count,
+            null,
+            false,
+            0L,
+            DocValueFormat.RAW
+        );
+        List<StringTerms.Bucket> stringBuckets = ImmutableList.of(entity1Bucket);
+        return stringBuckets;
+    }
 }


### PR DESCRIPTION
Signed-off-by: Xun Zhang <xunzh@amazon.com>

### Description
Increase tests coverage for GetAnomalyDetectorTransportAction and remove it and subclasses from Jacoco exclusive list. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
