### PR TITLE
[Backport to 1.3] Empty search results bug fix (#495)

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -478,7 +478,9 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 nextDetectionStartTime,
                 settings,
                 maxEntitiesPerInterval,
-                pageSize
+                pageSize,
+                indexNameExpressionResolver,
+                clusterService
             );
 
             PageIterator pageIterator = null;

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -1098,7 +1098,9 @@ public class MultiEntityResultTests extends AbstractADTest {
             clock,
             settings,
             10000,
-            1000
+            1000,
+            indexNameResolver,
+            clusterService
         );
         Map<Entity, double[]> results = new HashMap<>();
         Entity entity1 = Entity.createEntityByReordering(attrs1);
@@ -1122,7 +1124,9 @@ public class MultiEntityResultTests extends AbstractADTest {
             clock,
             settings,
             10000,
-            1000
+            1000,
+            indexNameResolver,
+            clusterService
         );
 
         CompositeRetriever.Page page = retriever.new Page(null);
@@ -1282,5 +1286,45 @@ public class MultiEntityResultTests extends AbstractADTest {
         verify(stateManager).setException(anyString(), exceptionCaptor.capture());
         EndRunException endRunException = (EndRunException) (exceptionCaptor.getValue());
         assertTrue(!endRunException.isEndNow());
+    }
+
+    /**
+     * A missing index will cause the search result to contain null aggregation
+     * like {"took":0,"timed_out":false,"_shards":{"total":0,"successful":0,"skipped":0,"failed":0},"hits":{"max_score":0.0,"hits":[]}}
+     *
+     * The test verifies we can handle such situation and won't throw exceptions
+     * @throws InterruptedException while waiting for execution gets interruptted
+     */
+    public void testMissingIndex() throws InterruptedException {
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener
+                .onResponse(
+                    new SearchResponse(
+                        new SearchResponseSections(SearchHits.empty(), null, null, false, null, null, 1),
+                        null,
+                        1,
+                        1,
+                        0,
+                        0,
+                        ShardSearchFailure.EMPTY_ARRAY,
+                        Clusters.EMPTY
+                    )
+                );
+            inProgressLatch.countDown();
+            return null;
+        }).when(client).search(any(), any());
+
+        PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
+
+        action.doExecute(null, request, listener);
+
+        AnomalyResultResponse response = listener.actionGet(10000L);
+        assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
+
+        assertTrue(inProgressLatch.await(10000L, TimeUnit.MILLISECONDS));
+        verify(stateManager, times(1)).setException(eq(detectorId), any(EndRunException.class));
     }
 }


### PR DESCRIPTION
### Description
* Check if indices exist in the presence of empty search results

Previously, CompositeRetriever throws an IllegalArgumentException in the presence of empty results, which gets translated to internal failure and increments AD failure count. When the source index is a regex like blah*, we will get an empty response even if the index does not exist. This PR checks indices exist in the presence of empty search results. If yes, we throw an IndexNotFoundException that ends up being converted to EndRunException; if no, we still throw an IllegalArgumentException.

Testing done:
1. added unit tests
2. reproduced manually and verified the change fixed the issue.

Signed-off-by: Kaituo Li <kaituo@amazon.com>
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
