### PR TITLE
fixed to check if build is a snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,13 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
+        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "1.3.2-SNAPSHOT")
-        plugin_version = opensearch_version.substring(0, opensearch_version.indexOf("-"))
+        if (isSnapshot) {
+            plugin_version = opensearch_version.substring(0, opensearch_version.indexOf("-"))
+        } else {
+            plugin_version = opensearch_version
+        }
         // 1.2.0 -> 1.2.0.0, and 1.2.0-SNAPSHOT -> 1.2.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Fixing AD CI since build doesn't always have `-SNAPSHOT`.

### Issues Resolved
#530

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
