### PR TITLE
Use current time as training data end time

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -694,17 +694,17 @@ public class EntityColdStarter implements MaintenanceState {
      *
      * @param coldstartDatapoints training data generated from cold start
      * @param modelId model Id
-     * @param entityState entity State
+     * @param modelState entity State
      */
-    private void extractTrainSamples(List<double[][]> coldstartDatapoints, String modelId, ModelState<EntityModel> entityState) {
-        if (coldstartDatapoints == null || coldstartDatapoints.size() == 0 || entityState == null) {
+    private void extractTrainSamples(List<double[][]> coldstartDatapoints, String modelId, ModelState<EntityModel> modelState) {
+        if (coldstartDatapoints == null || coldstartDatapoints.size() == 0 || modelState == null) {
             return;
         }
 
-        EntityModel model = entityState.getModel();
+        EntityModel model = modelState.getModel();
         if (model == null) {
             model = new EntityModel(null, new ArrayDeque<>(), null);
-            entityState.setModel(model);
+            modelState.setModel(model);
         }
 
         Queue<double[]> newSamples = new ArrayDeque<>();

--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -21,6 +21,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -46,7 +47,6 @@ import org.opensearch.ad.dataprocessor.Interpolator;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.model.AnomalyDetector;
-import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
 import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
@@ -220,6 +220,22 @@ public class EntityColdStarter implements MaintenanceState {
     ) {
         logger.debug("Trigger cold start for {}", modelId);
 
+        if (modelState == null || entity == null) {
+            listener
+                .onFailure(
+                    new IllegalArgumentException(
+                        String
+                            .format(
+                                Locale.ROOT,
+                                "Cannot have empty model state or entity: model state [%b], entity [%b]",
+                                modelState == null,
+                                entity == null
+                            )
+                    )
+                );
+            return;
+        }
+
         if (lastThrottledColdStartTime.plus(Duration.ofMinutes(coolDownMinutes)).isAfter(clock.instant())) {
             listener.onResponse(null);
             return;
@@ -252,7 +268,7 @@ public class EntityColdStarter implements MaintenanceState {
                 try {
                     if (trainingData.isPresent()) {
                         List<double[][]> dataPoints = trainingData.get();
-                        combineTrainSamples(dataPoints, modelId, modelState);
+                        extractTrainSamples(dataPoints, modelId, modelState);
                         Queue<double[]> samples = modelState.getModel().getSamples();
                         // only train models if we have enough samples
                         if (samples.size() >= numMinSamples) {
@@ -272,7 +288,6 @@ public class EntityColdStarter implements MaintenanceState {
                 } catch (Exception e) {
                     listener.onFailure(e);
                 }
-
             }, exception -> {
                 try {
                     logger.error(new ParameterizedMessage("Error while cold start {}", modelId), exception);
@@ -404,42 +419,23 @@ public class EntityColdStarter implements MaintenanceState {
             ActionListener<Optional<Long>> minTimeListener = ActionListener.wrap(earliest -> {
                 if (earliest.isPresent()) {
                     long startTimeMs = earliest.get().longValue();
-                    nodeStateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(jobOp -> {
-                        if (!jobOp.isPresent()) {
-                            listener.onFailure(new EndRunException(detectorId, "AnomalyDetector job is not available.", false));
-                            return;
-                        }
 
-                        AnomalyDetectorJob job = jobOp.get();
-                        // End time uses milliseconds as start time is assumed to be in milliseconds.
-                        // Opensearch uses a set of preconfigured formats to recognize and parse these strings into a long value
-                        // representing milliseconds-since-the-epoch in UTC.
-                        // More on https://tinyurl.com/wub4fk92
+                    // End time uses milliseconds as start time is assumed to be in milliseconds.
+                    // Opensearch uses a set of preconfigured formats to recognize and parse these
+                    // strings into a long value
+                    // representing milliseconds-since-the-epoch in UTC.
+                    // More on https://tinyurl.com/wub4fk92
 
-                        // Existing samples either predates or coincide with cold start data. In either case,
-                        // combining them without reordering based on time stamps is not ok. We might introduce
-                        // anomalies in the process.
-                        // An ideal solution would be to record time stamps of data points and combine existing
-                        // samples and cold start samples and do interpolation afterwards. Recording time stamps
-                        // requires changes across the board like bwc in checkpoints. A pragmatic solution is to use
-                        // job enabled time as the end time of cold start period as it is easier to combine
-                        // existing samples with cold start data. We just need to appends existing samples after
-                        // cold start data as existing samples all happen after job enabled time. There might
-                        // be some gaps in between the last cold start sample and the first accumulated sample.
-                        // We will need to accept that precision loss in current solution.
-                        long endTimeMs = job.getEnabledTime().toEpochMilli();
-                        Pair<Integer, Integer> params = selectRangeParam(detector);
-                        int stride = params.getLeft();
-                        int numberOfSamples = params.getRight();
+                    long endTimeMs = clock.millis();
+                    Pair<Integer, Integer> params = selectRangeParam(detector);
+                    int stride = params.getLeft();
+                    int numberOfSamples = params.getRight();
 
-                        // we start with round 0
-                        getFeatures(listener, 0, coldStartData, detector, entity, stride, numberOfSamples, startTimeMs, endTimeMs);
-
-                    }, listener::onFailure));
+                    // we start with round 0
+                    getFeatures(listener, 0, coldStartData, detector, entity, stride, numberOfSamples, startTimeMs, endTimeMs);
                 } else {
                     listener.onResponse(Optional.empty());
                 }
-
             }, listener::onFailure);
 
             searchFeatureDao
@@ -694,40 +690,30 @@ public class EntityColdStarter implements MaintenanceState {
     }
 
     /**
-     * Precondition: we don't have enough training data.
-     * Combine training data with existing sample data.
-     * Existing samples either predates or coincide with cold start data.  In either case,
-     * combining them without reordering based on time stamps is not ok. We might introduce
-     * anomalies in the process.
-     * An ideal solution would be to record time stamps of data points and combine existing
-     * samples and cold start samples and do interpolation afterwards. Recording time stamps
-     * requires changes across the board like bwc in checkpoints. A pragmatic solution is to use
-     * job enabled time as the end time of cold start period as it is easier to combine
-     * existing samples with cold start data. We just need to appends existing samples after
-     * cold start data as existing samples all happen after job enabled time. There might
-     * be some gaps in between the last cold start sample and the first accumulated sample.
-     * We will need to accept that precision loss in current solution.
+     * Extract training data and put them into ModelState
      *
      * @param coldstartDatapoints training data generated from cold start
      * @param modelId model Id
      * @param entityState entity State
      */
-    private void combineTrainSamples(List<double[][]> coldstartDatapoints, String modelId, ModelState<EntityModel> entityState) {
-        if (coldstartDatapoints == null || coldstartDatapoints.size() == 0) {
+    private void extractTrainSamples(List<double[][]> coldstartDatapoints, String modelId, ModelState<EntityModel> entityState) {
+        if (coldstartDatapoints == null || coldstartDatapoints.size() == 0 || entityState == null) {
             return;
         }
 
         EntityModel model = entityState.getModel();
         if (model == null) {
             model = new EntityModel(null, new ArrayDeque<>(), null);
+            entityState.setModel(model);
         }
+
         Queue<double[]> newSamples = new ArrayDeque<>();
         for (double[][] consecutivePoints : coldstartDatapoints) {
             for (int i = 0; i < consecutivePoints.length; i++) {
                 newSamples.add(consecutivePoints[i]);
             }
         }
-        newSamples.addAll(model.getSamples());
+
         model.setSamples(newSamples);
     }
 

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
@@ -354,14 +354,8 @@ public class CheckpointReadWorker extends BatchWorker<EntityFeatureRequest, Mult
             ModelState<EntityModel> modelState = modelManager
                 .processEntityCheckpoint(checkpoint, entity, modelId, detectorId, detector.getShingleSize());
 
-            EntityModel entityModel = modelState.getModel();
-
-            ThresholdingResult result = null;
-            if (entityModel.getTrcf().isPresent()) {
-                result = modelManager.score(origRequest.getCurrentFeature(), modelId, modelState);
-            } else {
-                entityModel.addSample(origRequest.getCurrentFeature());
-            }
+            ThresholdingResult result = modelManager
+                .getAnomalyResultForEntity(origRequest.getCurrentFeature(), modelState, modelId, entity, detector.getShingleSize());
 
             if (result != null && result.getRcfScore() > 0) {
                 AnomalyResult resultToSave = result

--- a/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
+++ b/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
@@ -43,6 +43,7 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.transport.AnomalyResultTests;
 import org.opensearch.ad.util.ClientUtil;
@@ -79,6 +80,7 @@ public class NodeStateManagerTests extends AbstractADTest {
     private GetResponse checkpointResponse;
     private ClusterService clusterService;
     private ClusterSettings clusterSettings;
+    private AnomalyDetectorJob jobToCheck;
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -129,6 +131,7 @@ public class NodeStateManagerTests extends AbstractADTest {
         stateManager = new NodeStateManager(client, xContentRegistry(), settings, clientUtil, clock, duration, clusterService);
 
         checkpointResponse = mock(GetResponse.class);
+        jobToCheck = TestHelpers.randomAnomalyDetectorJob(true, Instant.ofEpochMilli(1602401500000L), null);
     }
 
     @Override
@@ -380,5 +383,65 @@ public class NodeStateManagerTests extends AbstractADTest {
         // make isMuted true
         when(clock.millis()).thenReturn(62000L);
         assertTrue(!stateManager.isMuted(nodeId, adId));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String setupJob() throws IOException {
+        String detectorId = jobToCheck.getName();
+
+        doAnswer(invocation -> {
+            GetRequest request = invocation.getArgument(0);
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            if (request.index().equals(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)) {
+                listener.onResponse(TestHelpers.createGetResponse(jobToCheck, detectorId, AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX));
+            }
+            return null;
+        }).when(client).get(any(), any(ActionListener.class));
+
+        return detectorId;
+    }
+
+    public void testGetAnomalyJob() throws IOException, InterruptedException {
+        String detectorId = setupJob();
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        stateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(jobToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test that we caches anomaly detector job definition after the first call
+     * @throws IOException if client throws exception
+     * @throws InterruptedException  if the current thread is interrupted while waiting
+     */
+    @SuppressWarnings("unchecked")
+    public void testRepeatedGetAnomalyJob() throws IOException, InterruptedException {
+        String detectorId = setupJob();
+        final CountDownLatch inProgressLatch = new CountDownLatch(2);
+
+        stateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(jobToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+
+        stateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(jobToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+
+        verify(client, times(1)).get(any(), any(ActionListener.class));
     }
 }

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -227,6 +227,13 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
 
         state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(config.fullModel).build());
         when(modelManager.processEntityCheckpoint(any(), any(), anyString(), anyString(), anyInt())).thenReturn(state);
+        if (config.fullModel) {
+            when(modelManager.getAnomalyResultForEntity(any(), any(), anyString(), any(), anyInt()))
+                .thenReturn(new ThresholdingResult(0, 1, 1));
+        } else {
+            when(modelManager.getAnomalyResultForEntity(any(), any(), anyString(), any(), anyInt()))
+                .thenReturn(new ThresholdingResult(0, 0, 0));
+        }
 
         List<EntityFeatureRequest> requests = new ArrayList<>();
         requests.add(request);


### PR DESCRIPTION
### Description
The bug happens because we use job enabled time as training data end time. But if the historical data before that time is deleted or does not exist at all, cold start might never finish. This PR uses current time as the training data end time so that cold start has a chance to succeed later. This PR also removes the code that combines cold start data and existing samples in EntityColdStartWorker because we don't add samples until cold start succeeds. Combining cold start data and existing samples is thus unnecessary.

Testing done:
1. manually verified the bug is fixed.
2. fixed all related unit tests.

Signed-off-by: Kaituo Li <kaituo@amazon.com>

Note: I found the bug in 1.2, so I started with 1.2 branch. Will forward push to 1.3 and 2.x later.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/540

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
