### PR TITLE
Enabling multi-core execution

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -547,7 +547,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             entityColdStarter,
             featureManager,
-            memoryTracker
+            memoryTracker,
+            settings
         );
 
         MultiEntityResultHandler multiEntityResultHandler = new MultiEntityResultHandler(
@@ -767,7 +768,15 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                     1,
                     // HCAD can be heavy after supporting 1 million entities.
                     // Limit to use at most half of the processors.
-                    Math.max(1, OpenSearchExecutors.allocatedProcessors(settings) / 2),
+                    Math
+                        .min(
+                            OpenSearchExecutors.allocatedProcessors(settings),
+                            Math
+                                .max(
+                                    AnomalyDetectorSettings.NUM_ALLOCATED_PROCESSORS.get(settings),
+                                    OpenSearchExecutors.allocatedProcessors(settings) / 2
+                                )
+                        ),
                     TimeValue.timeValueMinutes(10),
                     AD_THREAD_POOL_PREFIX + AD_THREAD_POOL_NAME
                 ),
@@ -869,7 +878,10 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 // clean resource
                 AnomalyDetectorSettings.DELETE_AD_RESULT_WHEN_DELETE_DETECTOR,
                 // stats/profile API
-                AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE
+                AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE,
+                // Parallel Execution
+                AnomalyDetectorSettings.ENABLE_PARALLEL_EXECUTION,
+                AnomalyDetectorSettings.NUM_ALLOCATED_PROCESSORS
             );
         return unmodifiableList(
             Stream

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -767,7 +767,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                     AD_THREAD_POOL_NAME,
                     1,
                     // HCAD can be heavy after supporting 1 million entities.
-                    // Limit to use at most half of the processors.
+                    // Limit to use at most half of the processors unless user explicitly changes
+                    // the number of cores allocated to greater than half of available cores.
                     Math
                         .min(
                             OpenSearchExecutors.allocatedProcessors(settings),

--- a/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/org/opensearch/ad/ml/EntityColdStarter.java
@@ -93,6 +93,7 @@ public class EntityColdStarter implements MaintenanceState, CleanState {
     private final long rcfSeed;
     private final int maxRoundofColdStart;
     private final double initialAcceptFraction;
+    private Settings settings;
 
     /**
      * Constructor
@@ -160,6 +161,7 @@ public class EntityColdStarter implements MaintenanceState, CleanState {
         this.rcfSeed = rcfSeed;
         this.maxRoundofColdStart = maxRoundofColdStart;
         this.initialAcceptFraction = numMinSamples * 1.0d / rcfSampleSize;
+        this.settings = settings;
     }
 
     public EntityColdStarter(
@@ -346,7 +348,7 @@ public class EntityColdStarter implements MaintenanceState, CleanState {
             .timeDecay(rcfTimeDecay)
             .outputAfter(numMinSamples)
             .initialAcceptFraction(initialAcceptFraction)
-            .parallelExecutionEnabled(false)
+            .parallelExecutionEnabled(AnomalyDetectorSettings.ENABLE_PARALLEL_EXECUTION.get(settings))
             .compact(true)
             .precision(Precision.FLOAT_32)
             .boundingBoxCacheFraction(AnomalyDetectorSettings.REAL_TIME_BOUNDING_BOX_CACHE_RATIO)

--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -40,6 +40,7 @@ import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.common.settings.Settings;
 
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.Precision;
@@ -93,6 +94,7 @@ public class ModelManager implements DetectorModelSize {
 
     private EntityColdStarter entityColdStarter;
     private MemoryTracker memoryTracker;
+    private Settings settings;
 
     private final double initialAcceptFraction;
 
@@ -126,7 +128,8 @@ public class ModelManager implements DetectorModelSize {
         Duration checkpointInterval,
         EntityColdStarter entityColdStarter,
         FeatureManager featureManager,
-        MemoryTracker memoryTracker
+        MemoryTracker memoryTracker,
+        Settings settings
     ) {
         this.checkpointDao = checkpointDao;
         this.clock = clock;
@@ -146,6 +149,7 @@ public class ModelManager implements DetectorModelSize {
         this.featureManager = featureManager;
         this.memoryTracker = memoryTracker;
         this.initialAcceptFraction = rcfNumMinSamples * 1.0d / rcfNumSamplesInTree;
+        this.settings = settings;
     }
 
     /**
@@ -509,7 +513,7 @@ public class ModelManager implements DetectorModelSize {
             .timeDecay(rcfTimeDecay)
             .outputAfter(rcfNumMinSamples)
             .initialAcceptFraction(initialAcceptFraction)
-            .parallelExecutionEnabled(false)
+            .parallelExecutionEnabled(AnomalyDetectorSettings.ENABLE_PARALLEL_EXECUTION.get(settings))
             .compact(true)
             .precision(Precision.FLOAT_32)
             .boundingBoxCacheFraction(AnomalyDetectorSettings.REAL_TIME_BOUNDING_BOX_CACHE_RATIO)

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -771,6 +771,14 @@ public final class AnomalyDetectorSettings {
             Setting.Property.Dynamic
         );
 
+    // ======================================
+    // Multi core execution settings
+    // ======================================
+    public static final Setting<Boolean> ENABLE_PARALLEL_EXECUTION = Setting
+        .boolSetting("plugins.anomaly_detection.enable_parallel_execution", false, Setting.Property.NodeScope, Setting.Property.Final);
+    public static final Setting<Integer> NUM_ALLOCATED_PROCESSORS = Setting
+        .intSetting("plugins.anomaly_detection.num_allocated_processors", 1, 1, Setting.Property.NodeScope, Setting.Property.Final);
+
     // profile API needs to report total entities. We can use cardinality aggregation for a single-category field.
     // But we cannot do that for multi-category fields as it requires scripting to generate run time fields,
     // which is expensive. We work around the problem by using a composite query to find the first 10_000 buckets.

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -250,7 +250,8 @@ public class EntityColdStarterTests extends AbstractADTest {
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             entityColdStarter,
             mock(FeatureManager.class),
-            mock(MemoryTracker.class)
+            mock(MemoryTracker.class),
+            settings
         );
     }
 

--- a/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
@@ -200,6 +200,7 @@ public class ModelManagerTests {
 
         rcf = spy(ThresholdedRandomCutForest.builder().dimensions(numFeatures).sampleSize(numSamples).numberOfTrees(numTrees).build());
         double score = 11.;
+        settings = Settings.EMPTY;
 
         double confidence = 0.091353632;
         double grade = 0.1;
@@ -240,7 +241,8 @@ public class ModelManagerTests {
                 checkpointInterval,
                 entityColdStarter,
                 featureManager,
-                memoryTracker
+                memoryTracker,
+                settings
             )
         );
 
@@ -250,7 +252,11 @@ public class ModelManagerTests {
 
         when(this.modelState.getModel()).thenReturn(this.entityModel);
         when(this.entityModel.getTrcf()).thenReturn(Optional.of(this.trcf));
-        settings = Settings.builder().put("plugins.anomaly_detection.model_max_size_percent", modelMaxSizePercentage).build();
+        settings = Settings
+            .builder()
+            .put("plugins.anomaly_detection.model_max_size_percent", modelMaxSizePercentage)
+            .put("plugins.anomaly_detection.enable_parallel_execution", false)
+            .build();
 
         when(anomalyDetector.getShingleSize()).thenReturn(shingleSize);
     }
@@ -441,7 +447,8 @@ public class ModelManagerTests {
                 checkpointInterval,
                 entityColdStarter,
                 featureManager,
-                memoryTracker
+                memoryTracker,
+                settings
             )
         );
 
@@ -971,7 +978,8 @@ public class ModelManagerTests {
                 checkpointInterval,
                 entityColdStarter,
                 featureManager,
-                memoryTracker
+                memoryTracker,
+                settings
             )
         );
 

--- a/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
@@ -152,7 +152,7 @@ public class EntityResultTransportActionTests extends AbstractADTest {
         now = Instant.now();
         when(clock.instant()).thenReturn(now);
 
-        manager = new ModelManager(null, clock, 0, 0, 0, 0, 0, 0, null, null, mock(EntityColdStarter.class), null, null);
+        manager = new ModelManager(null, clock, 0, 0, 0, 0, 0, 0, null, null, mock(EntityColdStarter.class), null, null, settings);
 
         provider = mock(CacheProvider.class);
         entityCache = mock(EntityCache.class);


### PR DESCRIPTION
### Description

Added two new static settings for AD plugin. These can be configured in `opensearch.yml` before starting an OS cluster. 
- `enable_parallel_execution` is defaulted to false and if changed to true will enable parallel execution on real time detectors.
- `num_allocated_processors` is set as a default to 1 and can be changed to change how many processors are allocated to the AD thread pool.
     - This setting has a caveat since we still want to keep the default to be either 1 or half of the total number of allocated processors. We have no way of knowing if users explicitly set this configuration or if it is just the default number. We also have no way of knowing the total possible processors when initializing in `AnomalyDetectorSettings`. This means that if there is 16 cores available and a user sets the number to 4 than 8 will still be used. However if the user sets the number to 10 then 10 will be used. If the user sets the number to 20, then 16 will be used. This means there will be some inconsistency if user sets a number that is less than half and purposely wants that number to be used. We have never let users change such a setting in the past so we aren't taking away any functionality with this caveat but creating an inconsistency. 
     
     Comment for any other suggestion on how to solve this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
