### PR TITLE
[Forward port to 2.x] Use current time as training data end time (#547)

### DIFF
--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
@@ -354,14 +354,8 @@ public class CheckpointReadWorker extends BatchWorker<EntityFeatureRequest, Mult
             ModelState<EntityModel> modelState = modelManager
                 .processEntityCheckpoint(checkpoint, entity, modelId, detectorId, detector.getShingleSize());
 
-            EntityModel entityModel = modelState.getModel();
-
-            ThresholdingResult result = null;
-            if (entityModel.getTrcf().isPresent()) {
-                result = modelManager.score(origRequest.getCurrentFeature(), modelId, modelState);
-            } else {
-                entityModel.addSample(origRequest.getCurrentFeature());
-            }
+            ThresholdingResult result = modelManager
+                .getAnomalyResultForEntity(origRequest.getCurrentFeature(), modelState, modelId, entity, detector.getShingleSize());
 
             if (result != null && result.getRcfScore() > 0) {
                 AnomalyResult resultToSave = result

--- a/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
+++ b/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
@@ -44,6 +44,7 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.transport.AnomalyResultTests;
 import org.opensearch.ad.util.ClientUtil;
@@ -80,6 +81,7 @@ public class NodeStateManagerTests extends AbstractADTest {
     private GetResponse checkpointResponse;
     private ClusterService clusterService;
     private ClusterSettings clusterSettings;
+    private AnomalyDetectorJob jobToCheck;
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -130,6 +132,7 @@ public class NodeStateManagerTests extends AbstractADTest {
         stateManager = new NodeStateManager(client, xContentRegistry(), settings, clientUtil, clock, duration, clusterService);
 
         checkpointResponse = mock(GetResponse.class);
+        jobToCheck = TestHelpers.randomAnomalyDetectorJob(true, Instant.ofEpochMilli(1602401500000L), null);
     }
 
     @Override
@@ -387,5 +390,65 @@ public class NodeStateManagerTests extends AbstractADTest {
         // make isMuted true
         when(clock.millis()).thenReturn(62000L);
         assertTrue(!stateManager.isMuted(nodeId, adId));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String setupJob() throws IOException {
+        String detectorId = jobToCheck.getName();
+
+        doAnswer(invocation -> {
+            GetRequest request = invocation.getArgument(0);
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            if (request.index().equals(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)) {
+                listener.onResponse(TestHelpers.createGetResponse(jobToCheck, detectorId, AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX));
+            }
+            return null;
+        }).when(client).get(any(), any(ActionListener.class));
+
+        return detectorId;
+    }
+
+    public void testGetAnomalyJob() throws IOException, InterruptedException {
+        String detectorId = setupJob();
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        stateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(jobToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test that we caches anomaly detector job definition after the first call
+     * @throws IOException if client throws exception
+     * @throws InterruptedException  if the current thread is interrupted while waiting
+     */
+    @SuppressWarnings("unchecked")
+    public void testRepeatedGetAnomalyJob() throws IOException, InterruptedException {
+        String detectorId = setupJob();
+        final CountDownLatch inProgressLatch = new CountDownLatch(2);
+
+        stateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(jobToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+
+        stateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(jobToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+
+        verify(client, times(1)).get(any(), any(ActionListener.class));
     }
 }

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -216,6 +216,13 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
 
         state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(config.fullModel).build());
         when(modelManager.processEntityCheckpoint(any(), any(), anyString(), anyString(), anyInt())).thenReturn(state);
+        if (config.fullModel) {
+            when(modelManager.getAnomalyResultForEntity(any(), any(), anyString(), any(), anyInt()))
+                .thenReturn(new ThresholdingResult(0, 1, 1));
+        } else {
+            when(modelManager.getAnomalyResultForEntity(any(), any(), anyString(), any(), anyInt()))
+                .thenReturn(new ThresholdingResult(0, 0, 0));
+        }
 
         List<EntityFeatureRequest> requests = new ArrayList<>();
         requests.add(request);


### PR DESCRIPTION
### Description
* Use current time as training data end time

The bug happens because we use job enabled time as training data end time. But if the historical data before that time is deleted or does not exist at all, cold start might never finish. This PR uses current time as the training data end time so that cold start has a chance to succeed later. This PR also removes the code that combines cold start data and existing samples in EntityColdStartWorker because we don't add samples until cold start succeeds. Combining cold start data and existing samples is thus unnecessary.

Testing done:
1. manually verified the bug is fixed.
2. fixed all related unit tests.

Signed-off-by: Kaituo Li <kaituo@amazon.com>

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/540

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
