### PR TITLE
bump rcf to 3.0-rc3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -626,9 +626,9 @@ dependencies {
     implementation group: 'com.yahoo.datasketches', name: 'memory', version: '0.12.2'
     implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
     implementation group: 'org.apache.commons', name: 'commons-pool2', version: '2.10.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-serialization:3.0-rc2.1'
-    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.0-rc2.1'
-    implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0-rc2.1'
+    implementation 'software.amazon.randomcutforest:randomcutforest-serialization:3.0-rc3'
+    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.0-rc3'
+    implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0-rc3'
 
     // force Jackson version to avoid version conflict issue
     implementation "com.fasterxml.jackson.core:jackson-core:2.13.2"


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Bump RCF version to 3.0-rc3. 
New RCF version has critical bug fix for AD.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
