### PR TITLE
Add support for reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ tasks.withType(Test) {
 tasks.withType(Javadoc) {
     options.encoding = 'UTF-8'
 }
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
### Description
Add support for reproducible builds

As per gradle [docs] add support to remove timestamps and package with same order which is required from
[reproducible] builds

[docs]: https://docs.gradle.org/current/userguide/working_with_files.html#sec:archives
[reproducible]: https://reproducible-builds.org/

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
