### PR TITLE
Increment version to 1.3.4 and fix zip fetching

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,28 +29,28 @@ jobs:
 
       - name: Assemble anomaly-detection
         run: |
-          ./gradlew assemble -Dopensearch.version=1.3.3-SNAPSHOT
-          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.3.0-SNAPSHOT ..."
-          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.3.0-SNAPSHOT
-          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.3.0-SNAPSHOT ..."
+          ./gradlew assemble -Dopensearch.version=1.3.4-SNAPSHOT
+          echo "Creating ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.4.0-SNAPSHOT ..."
+          mkdir -p ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.4.0-SNAPSHOT
+          echo "Copying ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.4.0-SNAPSHOT ..."
           ls ./build/distributions/
-          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.3.0-SNAPSHOT
-          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.3.0-SNAPSHOT ..."
-          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.3.0-SNAPSHOT
+          cp ./build/distributions/*.zip ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.4.0-SNAPSHOT
+          echo "Copied ./build/distributions/*.zip to ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.4.0-SNAPSHOT ..."
+          ls ./src/test/resources/org/opensearch/ad/bwc/anomaly-detection/1.3.4.0-SNAPSHOT
       - name: Build and Run Tests
         run: |
-          ./gradlew build -Dopensearch.version=1.3.3-SNAPSHOT
+          ./gradlew build -Dopensearch.version=1.3.4-SNAPSHOT
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.3.3-SNAPSHOT
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.3.4-SNAPSHOT
       - name: Multi Nodes Integration Testing
         run: |
           ./gradlew integTest -PnumNodes=3
       - name: Pull and Run Docker
         run: |
           plugin=`ls build/distributions/*.zip`
-          version=1.3.3
-          plugin_version=1.3.3.0-SNAPSHOT
+          version=1.3.4
+          plugin_version=1.3.4.0-SNAPSHOT
           echo Using OpenSearch $version with AD $plugin_version
           cd ..
           if docker pull opensearchstaging/opensearch:$version

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     ext {
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "1.3.3-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.4-SNAPSHOT")
         if (isSnapshot) {
             plugin_version = opensearch_version.substring(0, opensearch_version.indexOf("-"))
         } else {
@@ -336,7 +336,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2","1.3.3-SNAPSHOT"]
+            versions = ["7.10.2","1.3.4-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override
@@ -405,15 +405,8 @@ List<Provider<RegularFile>> plugins = [
                 return new RegularFile() {
                     @Override
                     File getAsFile() {
-                        if (new File("$project.rootDir/$bwcFilePath/anomaly-detection/$opensearch_build").exists()) {
-                            project.delete(files("$project.rootDir/$bwcFilePath/anomaly-detection/$opensearch_build"))
-                        }
-                        project.mkdir bwcAnomalyDetectionPath + opensearch_build
-                        ant.get(src: anomaly_detection_build_download,
-                                dest: bwcAnomalyDetectionPath + opensearch_build,
-                                httpusecaches: false)
-                        return fileTree(bwcAnomalyDetectionPath + opensearch_build).getSingleFile()
-                    }
+                    	return fileTree(bwcFilePath + "anomaly-detection/" + project.version).getSingleFile()
+		    }
                 }
             }
         })


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
bumped to 1.3.4
Changed fetching new AD version from gradle assemble instead of from ci.distribution.org

### Issues Resolved
#586

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
