### PR TITLE
fix zip fetching issue on version increment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -445,15 +445,8 @@ List<Provider<RegularFile>> plugins = [
                 return new RegularFile() {
                     @Override
                     File getAsFile() {
-                        if (new File("$project.rootDir/$bwcFilePath/anomaly-detection/$opensearch_build").exists()) {
-                            project.delete(files("$project.rootDir/$bwcFilePath/anomaly-detection/$opensearch_build"))
-                        }
-                        project.mkdir bwcAnomalyDetectionPath + opensearch_build
-                        ant.get(src: anomaly_detection_build_download,
-                                dest: bwcAnomalyDetectionPath + opensearch_build,
-                                httpusecaches: false)
-                        return fileTree(bwcAnomalyDetectionPath + opensearch_build).getSingleFile()
-                    }
+                    	return fileTree(bwcFilePath + "anomaly-detection/" + project.version).getSingleFile()
+		    }
                 }
             }
         })


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
uses newest version snapshot from `gradle assemble` instead of ci.distribution.org in CI because of failure fetching during version increment

### Issues Resolved
resolves #586 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
