### PR TITLE
[Feature/extensions] Remove CommonUtils ThreadContext User from AD user checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -604,6 +604,15 @@ List<String> jacocoExclusions = [
         // https://github.com/opensearch-project/anomaly-detection/issues/241
         'org.opensearch.ad.task.ADBatchTaskRunner',
         'org.opensearch.ad.task.ADTaskManager',
+        
+        // TODO: Removing dependency on Common Utils "User" class by setting it null
+        // means all searches succeed, no failures and reduced coverage on these classes.
+        // See https://github.com/opensearch-project/opensearch-sdk/issues/23
+        // Reenable these once this plugin has a different security model and failed
+        // searches are restored.
+        'org.opensearch.ad.auth.UserIdentity',
+        'org.opensearch.ad.transport.IndexAnomalyDetectorTransportAction',
+        'org.opensearch.ad.transport.handler.ADSearchHandler',
 ]
 
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
@@ -34,6 +34,7 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.InternalFailure;
@@ -66,7 +67,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.InjectSecurity;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
@@ -508,7 +508,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
             IntervalTimeConfiguration windowDelay = (IntervalTimeConfiguration) jobParameter.getWindowDelay();
             Instant dataStartTime = detectionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
             Instant dataEndTime = executionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
-            User user = jobParameter.getUser();
+            UserIdentity user = jobParameter.getUser();
 
             if (response.getError() != null) {
                 log.info("Anomaly result action run successfully for {} with error {}", detectorId, response.getError());
@@ -623,7 +623,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
             IntervalTimeConfiguration windowDelay = (IntervalTimeConfiguration) jobParameter.getWindowDelay();
             Instant dataStartTime = detectionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
             Instant dataEndTime = executionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
-            User user = jobParameter.getUser();
+            UserIdentity user = jobParameter.getUser();
 
             AnomalyResult anomalyResult = new AnomalyResult(
                 detectorId,

--- a/src/main/java/org/opensearch/ad/auth/UserIdentity.java
+++ b/src/main/java/org/opensearch/ad/auth/UserIdentity.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.auth;
+
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.http.util.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.Strings;
+import org.opensearch.common.inject.internal.ToStringBuilder;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
+
+/**
+ * Placeholder class to replace the {@code User} class in common-utils in an extension context. The process of populating the object
+ * from an authenticated user will be developed in the future.
+ * <p>
+ * Actual user name and roles will be removed and replaced by an access token which correlates to the granted roles. Metadata will
+ * replace custom attribute names.
+ * <p>
+ * Gets current Authenticated User - name, odfe roles. If security-plugin is not
+ * installed or disabled, it returns empty for user name and roles.
+ */
+final public class UserIdentity implements Writeable, ToXContent {
+
+    // field name in toXContent
+    public static final String NAME_FIELD = "name";
+    public static final String BACKEND_ROLES_FIELD = "backend_roles";
+    public static final String ROLES_FIELD = "roles";
+    public static final String CUSTOM_ATTRIBUTE_NAMES_FIELD = "custom_attribute_names";
+    public static final String REQUESTED_TENANT_FIELD = "user_requested_tenant";
+
+    private final String name;
+    private final List<String> backendRoles;
+    private final List<String> roles;
+    private final List<String> customAttNames;
+    @Nullable
+    private final String requestedTenant;
+
+    /**
+     * A default user identity with no name, no roles, no custom attributes, and no tenant.
+     */
+    public UserIdentity() {
+        name = "";
+        backendRoles = new ArrayList<>();
+        roles = new ArrayList<>();
+        customAttNames = new ArrayList<>();
+        requestedTenant = null;
+    }
+
+    /**
+     * A user identity with the requested name, backend roles, roles, and custom attributes, but no tenant.
+     *
+     * @param name  The user name.
+     * @param backendRoles  The user's backend roles.
+     * @param roles  The user's roles,
+     * @param customAttNames  A list of custom attribute names.
+     */
+    public UserIdentity(final String name, final List<String> backendRoles, List<String> roles, List<String> customAttNames) {
+        this.name = name;
+        this.backendRoles = backendRoles;
+        this.roles = roles;
+        this.customAttNames = customAttNames;
+        this.requestedTenant = null;
+    }
+
+    /**
+     * A user identity with the requested name, backend roles, roles, custom attributes, and tenant.
+     *
+     * @param name  The user name.
+     * @param backendRoles  The user's backend roles.
+     * @param roles  The user's roles,
+     * @param customAttNames  A list of custom attribute names.
+     * @param requestedTenant  The requested tenant.
+     */
+    public UserIdentity(
+        final String name,
+        final List<String> backendRoles,
+        final List<String> roles,
+        final List<String> customAttNames,
+        @Nullable final String requestedTenant
+    ) {
+        this.name = name;
+        this.backendRoles = backendRoles;
+        this.roles = roles;
+        this.customAttNames = customAttNames;
+        this.requestedTenant = requestedTenant;
+    }
+
+    /**
+     * Response of "GET /_opendistro/_security/authinfo".  This parses the response of a call to the security plugin into a User Identity.
+     *
+     * @param response  The security plugin response.
+     * @throws IOException  If there was an error receiving the response.
+     */
+    public UserIdentity(final Response response) throws IOException {
+        this(EntityUtils.toString(response.getEntity()));
+    }
+
+    /**
+     * A user identity created from a JSON string.
+     *
+     * @param json  The JSON containing the user information.
+     */
+    @SuppressWarnings("unchecked")
+    public UserIdentity(String json) {
+        if (Strings.isNullOrEmpty(json)) {
+            throw new IllegalArgumentException("Response json cannot be null");
+        }
+
+        Map<String, Object> mapValue = XContentHelper.convertToMap(JsonXContent.jsonXContent, json, false);
+        name = (String) mapValue.get("user_name");
+        backendRoles = (List<String>) mapValue.get("backend_roles");
+        roles = (List<String>) mapValue.get("roles");
+        customAttNames = (List<String>) mapValue.get("custom_attribute_names");
+        requestedTenant = (String) mapValue.getOrDefault("user_requested_tenant", null);
+    }
+
+    /**
+     * A user identity created from a stream.
+     *
+     * @param in  The input stream.
+     * @throws IOException  if there was an error reading the stream.
+     */
+    public UserIdentity(StreamInput in) throws IOException {
+        name = in.readString();
+        backendRoles = in.readStringList();
+        roles = in.readStringList();
+        customAttNames = in.readStringList();
+        requestedTenant = in.readOptionalString();
+    }
+
+    /**
+     * Create a user identity from a parser.
+     *
+     * @param parser  The parser containing the identiy.
+     * @return THe user identity.
+     * @throws IOException  If there was an exception parsing.
+     */
+    public static UserIdentity parse(XContentParser parser) throws IOException {
+        String name = "";
+        List<String> backendRoles = new ArrayList<>();
+        List<String> roles = new ArrayList<>();
+        List<String> customAttNames = new ArrayList<>();
+        String requestedTenant = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            switch (fieldName) {
+                case NAME_FIELD:
+                    name = parser.text();
+                    break;
+                case BACKEND_ROLES_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        backendRoles.add(parser.text());
+                    }
+                    break;
+                case ROLES_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        roles.add(parser.text());
+                    }
+                    break;
+                case CUSTOM_ATTRIBUTE_NAMES_FIELD:
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        customAttNames.add(parser.text());
+                    }
+                    break;
+                case REQUESTED_TENANT_FIELD:
+                    requestedTenant = parser.textOrNull();
+                    break;
+                default:
+                    break;
+            }
+        }
+        return new UserIdentity(name, backendRoles, roles, customAttNames, requestedTenant);
+    }
+
+    /**
+     * Create a user identity from a pipe-delimited string.
+     *
+     * @param userString  A string in the format user_name|backendrole1,backendrole2|roles1,role2
+     * @return The user identity.
+     */
+    public static UserIdentity parse(final String userString) {
+        if (Strings.isNullOrEmpty(userString)) {
+            return null;
+        }
+
+        String[] strs = userString.split("\\|");
+        if ((strs.length == 0) || (Strings.isNullOrEmpty(strs[0]))) {
+            return null;
+        }
+
+        String userName = strs[0].trim();
+        List<String> backendRoles = new ArrayList<>();
+        List<String> roles = new ArrayList<>();
+        String requestedTenant = null;
+
+        if ((strs.length > 1) && !Strings.isNullOrEmpty(strs[1])) {
+            backendRoles.addAll(Arrays.asList(strs[1].split(",")));
+        }
+        if ((strs.length > 2) && !Strings.isNullOrEmpty(strs[2])) {
+            roles.addAll(Arrays.asList(strs[2].split(",")));
+        }
+        if ((strs.length > 3) && !Strings.isNullOrEmpty(strs[3])) {
+            requestedTenant = strs[3].trim();
+        }
+        return new UserIdentity(userName, backendRoles, roles, Arrays.asList(), requestedTenant);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject()
+            .field(NAME_FIELD, name)
+            .field(BACKEND_ROLES_FIELD, backendRoles)
+            .field(ROLES_FIELD, roles)
+            .field(CUSTOM_ATTRIBUTE_NAMES_FIELD, customAttNames)
+            .field(REQUESTED_TENANT_FIELD, requestedTenant);
+        return builder.endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeStringCollection(backendRoles);
+        out.writeStringCollection(roles);
+        out.writeStringCollection(customAttNames);
+        out.writeOptionalString(requestedTenant);
+    }
+
+    @Override
+    public String toString() {
+        ToStringBuilder builder = new ToStringBuilder(this.getClass());
+        builder.add(NAME_FIELD, name);
+        builder.add(BACKEND_ROLES_FIELD, backendRoles);
+        builder.add(ROLES_FIELD, roles);
+        builder.add(CUSTOM_ATTRIBUTE_NAMES_FIELD, customAttNames);
+        builder.add(REQUESTED_TENANT_FIELD, requestedTenant);
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof UserIdentity)) {
+            return false;
+        }
+        UserIdentity that = (UserIdentity) obj;
+        return this.name.equals(that.name)
+            && this.getBackendRoles().equals(that.backendRoles)
+            && this.getRoles().equals(that.roles)
+            && this.getCustomAttNames().equals(that.customAttNames)
+            && (Objects.equals(this.requestedTenant, that.requestedTenant));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getBackendRoles() {
+        return backendRoles;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public List<String> getCustomAttNames() {
+        return customAttNames;
+    }
+
+    @Nullable
+    public String getRequestedTenant() {
+        return requestedTenant;
+    }
+}

--- a/src/main/java/org/opensearch/ad/auth/UserIdentity.java
+++ b/src/main/java/org/opensearch/ad/auth/UserIdentity.java
@@ -232,7 +232,8 @@ final public class UserIdentity implements Writeable, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject()
+        builder
+            .startObject()
             .field(NAME_FIELD, name)
             .field(BACKEND_ROLES_FIELD, backendRoles)
             .field(ROLES_FIELD, roles)

--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.time.Instant;
 
 import org.opensearch.ad.annotation.Generated;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -25,7 +26,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 
 import com.google.common.base.Objects;
 
@@ -82,7 +82,7 @@ public class ADTask implements ToXContentObject, Writeable {
     private Entity entity = null;
     private String parentTaskId = null;
     private Integer estimatedMinutesLeft = null;
-    private User user = null;
+    private UserIdentity user = null;
 
     private ADTask() {}
 
@@ -110,7 +110,7 @@ public class ADTask implements ToXContentObject, Writeable {
         this.coordinatingNode = input.readOptionalString();
         this.workerNode = input.readOptionalString();
         if (input.readBoolean()) {
-            this.user = new User(input);
+            this.user = new UserIdentity(input);
         } else {
             user = null;
         }
@@ -226,7 +226,7 @@ public class ADTask implements ToXContentObject, Writeable {
         private Entity entity = null;
         private String parentTaskId;
         private Integer estimatedMinutesLeft;
-        private User user = null;
+        private UserIdentity user = null;
 
         public Builder() {}
 
@@ -340,7 +340,7 @@ public class ADTask implements ToXContentObject, Writeable {
             return this;
         }
 
-        public Builder user(User user) {
+        public Builder user(UserIdentity user) {
             this.user = user;
             return this;
         }
@@ -478,7 +478,7 @@ public class ADTask implements ToXContentObject, Writeable {
         Entity entity = null;
         String parentTaskId = null;
         Integer estimatedMinutesLeft = null;
-        User user = null;
+        UserIdentity user = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -553,7 +553,7 @@ public class ADTask implements ToXContentObject, Writeable {
                     estimatedMinutesLeft = parser.intValue();
                     break;
                 case USER_FIELD:
-                    user = User.parse(parser);
+                    user = UserIdentity.parse(parser);
                     break;
                 default:
                     parser.skipChildren();
@@ -776,7 +776,7 @@ public class ADTask implements ToXContentObject, Writeable {
         return estimatedMinutesLeft;
     }
 
-    public User getUser() {
+    public UserIdentity getUser() {
         return user;
     }
 

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.ad.annotation.Generated;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.common.exception.ADValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
@@ -51,7 +52,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParseException;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 
@@ -114,7 +114,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     private final Integer schemaVersion;
     private final Instant lastUpdateTime;
     private final List<String> categoryFields;
-    private User user;
+    private UserIdentity user;
     private String detectorType;
     private String resultIndex;
 
@@ -162,7 +162,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         Integer schemaVersion,
         Instant lastUpdateTime,
         List<String> categoryFields,
-        User user,
+        UserIdentity user,
         String resultIndex
     ) {
         if (Strings.isBlank(name)) {
@@ -274,7 +274,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.categoryFields = input.readOptionalStringList();
         lastUpdateTime = input.readInstant();
         if (input.readBoolean()) {
-            this.user = new User(input);
+            this.user = new UserIdentity(input);
         } else {
             user = null;
         }
@@ -435,7 +435,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         Integer schemaVersion = CommonValue.NO_SCHEMA_VERSION;
         Map<String, Object> uiMetadata = null;
         Instant lastUpdateTime = null;
-        User user = null;
+        UserIdentity user = null;
         DetectionDateRange detectionDateRange = null;
         String resultIndex = null;
 
@@ -541,7 +541,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
                     categoryField = (List) parser.list();
                     break;
                 case USER_FIELD:
-                    user = User.parse(parser);
+                    user = UserIdentity.parse(parser);
                     break;
                 case DETECTION_DATE_RANGE_FIELD:
                     detectionDateRange = DetectionDateRange.parse(parser);
@@ -725,11 +725,11 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration();
     }
 
-    public User getUser() {
+    public UserIdentity getUser() {
         return user;
     }
 
-    public void setUser(User user) {
+    public void setUser(UserIdentity user) {
         this.user = user;
     }
 

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetectorJob.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetectorJob.java
@@ -17,6 +17,7 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedT
 import java.io.IOException;
 import java.time.Instant;
 
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -26,7 +27,6 @@ import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.spi.schedule.CronSchedule;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
@@ -72,7 +72,7 @@ public class AnomalyDetectorJob implements Writeable, ToXContentObject, Schedule
     private final Instant disabledTime;
     private final Instant lastUpdateTime;
     private final Long lockDurationSeconds;
-    private final User user;
+    private final UserIdentity user;
     private String resultIndex;
 
     public AnomalyDetectorJob(
@@ -84,7 +84,7 @@ public class AnomalyDetectorJob implements Writeable, ToXContentObject, Schedule
         Instant disabledTime,
         Instant lastUpdateTime,
         Long lockDurationSeconds,
-        User user,
+        UserIdentity user,
         String resultIndex
     ) {
         this.name = name;
@@ -113,7 +113,7 @@ public class AnomalyDetectorJob implements Writeable, ToXContentObject, Schedule
         lastUpdateTime = input.readInstant();
         lockDurationSeconds = input.readLong();
         if (input.readBoolean()) {
-            user = new User(input);
+            user = new UserIdentity(input);
         } else {
             user = null;
         }
@@ -177,7 +177,7 @@ public class AnomalyDetectorJob implements Writeable, ToXContentObject, Schedule
         Instant disabledTime = null;
         Instant lastUpdateTime = null;
         Long lockDurationSeconds = DEFAULT_AD_JOB_LOC_DURATION_SECONDS;
-        User user = null;
+        UserIdentity user = null;
         String resultIndex = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -211,7 +211,7 @@ public class AnomalyDetectorJob implements Writeable, ToXContentObject, Schedule
                     lockDurationSeconds = parser.longValue();
                     break;
                 case USER_FIELD:
-                    user = User.parse(parser);
+                    user = UserIdentity.parse(parser);
                     break;
                 case RESULT_INDEX_FIELD:
                     resultIndex = parser.text();
@@ -295,7 +295,7 @@ public class AnomalyDetectorJob implements Writeable, ToXContentObject, Schedule
         return lockDurationSeconds;
     }
 
-    public User getUser() {
+    public UserIdentity getUser() {
         return user;
     }
 

--- a/src/main/java/org/opensearch/ad/model/AnomalyResult.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyResult.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ad.annotation.Generated;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.ml.ThresholdingResult;
 import org.opensearch.ad.util.ParseUtils;
@@ -37,7 +38,6 @@ import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 
 import com.google.common.base.Objects;
 
@@ -87,7 +87,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
     private final Instant executionEndTime;
     private final String error;
     private final Entity entity;
-    private User user;
+    private UserIdentity user;
     private final Integer schemaVersion;
     /*
      * model id for easy aggregations of entities. The front end needs to query
@@ -224,7 +224,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionEndTime,
         String error,
         Entity entity,
-        User user,
+        UserIdentity user,
         Integer schemaVersion,
         String modelId
     ) {
@@ -265,7 +265,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionEndTime,
         String error,
         Entity entity,
-        User user,
+        UserIdentity user,
         Integer schemaVersion,
         String modelId,
         Instant approxAnomalyStartTime,
@@ -336,7 +336,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionEndTime,
         String error,
         Entity entity,
-        User user,
+        UserIdentity user,
         Integer schemaVersion,
         String modelId,
         double[] relevantAttribution,
@@ -469,7 +469,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             this.entity = null;
         }
         if (input.readBoolean()) {
-            this.user = new User(input);
+            this.user = new UserIdentity(input);
         } else {
             user = null;
         }
@@ -601,7 +601,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionEndTime = null;
         String error = null;
         Entity entity = null;
-        User user = null;
+        UserIdentity user = null;
         Integer schemaVersion = CommonValue.NO_SCHEMA_VERSION;
         String taskId = null;
         String modelId = null;
@@ -654,7 +654,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
                     entity = Entity.parse(parser);
                     break;
                 case USER_FIELD:
-                    user = User.parse(parser);
+                    user = UserIdentity.parse(parser);
                     break;
                 case SCHEMA_VERSION_FIELD:
                     schemaVersion = parser.intValue();

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -53,6 +53,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.replication.ReplicationResponse;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.common.exception.ADValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
@@ -77,7 +78,6 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -146,7 +146,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
     protected final TransportService transportService;
     protected final NamedXContentRegistry xContentRegistry;
     protected final ActionListener<T> listener;
-    protected final User user;
+    protected final UserIdentity user;
     protected final ADTaskManager adTaskManager;
     protected final SearchFeatureDao searchFeatureDao;
     protected final boolean isDryRun;
@@ -196,7 +196,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
         Integer maxAnomalyFeatures,
         RestRequest.Method method,
         NamedXContentRegistry xContentRegistry,
-        User user,
+        UserIdentity user,
         ADTaskManager adTaskManager,
         SearchFeatureDao searchFeatureDao,
         String validationType,

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -13,6 +13,7 @@ package org.opensearch.ad.rest.handler;
 
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -22,7 +23,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.transport.TransportService;
 
@@ -73,7 +73,7 @@ public class IndexAnomalyDetectorActionHandler extends AbstractAnomalyDetectorAc
         Integer maxAnomalyFeatures,
         RestRequest.Method method,
         NamedXContentRegistry xContentRegistry,
-        User user,
+        UserIdentity user,
         ADTaskManager adTaskManager,
         SearchFeatureDao searchFeatureDao
     ) {

--- a/src/main/java/org/opensearch/ad/rest/handler/ValidateAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ValidateAnomalyDetectorActionHandler.java
@@ -14,6 +14,7 @@ package org.opensearch.ad.rest.handler;
 import java.time.Clock;
 
 import org.opensearch.action.ActionListener;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -22,7 +23,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.rest.RestRequest;
 
 /**
@@ -62,7 +62,7 @@ public class ValidateAnomalyDetectorActionHandler extends AbstractAnomalyDetecto
         Integer maxAnomalyFeatures,
         RestRequest.Method method,
         NamedXContentRegistry xContentRegistry,
-        User user,
+        UserIdentity user,
         SearchFeatureDao searchFeatureDao,
         String validationType,
         Clock clock

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -102,6 +102,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.ADTaskCancelledException;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
@@ -152,7 +153,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
@@ -287,7 +287,7 @@ public class ADTaskManager {
         String detectorId,
         DetectionDateRange detectionDateRange,
         IndexAnomalyDetectorJobActionHandler handler,
-        User user,
+        UserIdentity user,
         TransportService transportService,
         ThreadContext.StoredContext context,
         ActionListener<AnomalyDetectorJobResponse> listener
@@ -326,7 +326,7 @@ public class ADTaskManager {
     private void startRealtimeOrHistoricalDetection(
         DetectionDateRange detectionDateRange,
         IndexAnomalyDetectorJobActionHandler handler,
-        User user,
+        UserIdentity user,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> listener,
         Optional<AnomalyDetector> detector
@@ -362,7 +362,7 @@ public class ADTaskManager {
     protected void forwardApplyForTaskSlotsRequestToLeadNode(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {
@@ -417,7 +417,7 @@ public class ADTaskManager {
     public void startHistoricalAnalysis(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         int availableTaskSlots,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> listener
@@ -469,7 +469,7 @@ public class ADTaskManager {
     protected void forwardDetectRequestToCoordinatingNode(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         Integer availableTaskSlots,
         ADTaskAction adTaskAction,
         TransportService transportService,
@@ -557,7 +557,7 @@ public class ADTaskManager {
         ADTask adTask,
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         ADTaskAction afterCheckAction,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> listener
@@ -656,7 +656,7 @@ public class ADTaskManager {
         ADTask adTask,
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         ADTaskAction targetActionOfTaskSlotChecking,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> wrappedActionListener,
@@ -740,7 +740,7 @@ public class ADTaskManager {
     public void startDetector(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {
@@ -831,7 +831,7 @@ public class ADTaskManager {
         String detectorId,
         boolean historical,
         IndexAnomalyDetectorJobActionHandler handler,
-        User user,
+        UserIdentity user,
         TransportService transportService,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {
@@ -1231,7 +1231,7 @@ public class ADTaskManager {
     private void stopHistoricalAnalysis(
         String detectorId,
         Optional<ADTask> adTask,
-        User user,
+        UserIdentity user,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {
         if (!adTask.isPresent()) {
@@ -1481,7 +1481,7 @@ public class ADTaskManager {
     private void updateLatestFlagOfOldTasksAndCreateNewTask(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {
         UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest();
@@ -1519,7 +1519,7 @@ public class ADTaskManager {
     private void createNewADTask(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         String coordinatingNode,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.rest.handler.IndexAnomalyDetectorJobActionHandler;
@@ -36,7 +37,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -88,7 +88,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         ActionListener<AnomalyDetectorJobResponse> listener = wrapRestActionListener(actionListener, errorMessage);
 
         // By the time request reaches here, the user permissions are validated by Security plugin.
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(
                 user,
@@ -126,7 +126,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         long primaryTerm,
         String rawPath,
         TimeValue requestTimeout,
-        User user,
+        UserIdentity user,
         ThreadContext.StoredContext context
     ) {
         IndexAnomalyDetectorJobActionHandler handler = new IndexAnomalyDetectorJobActionHandler(

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -15,7 +15,7 @@ import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_START_DETEC
 import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_STOP_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
@@ -88,7 +88,8 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         ActionListener<AnomalyDetectorJobResponse> listener = wrapRestActionListener(actionListener, errorMessage);
 
         // By the time request reaches here, the user permissions are validated by Security plugin.
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always execute detector.
+        UserIdentity user = getNullUser();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(
                 user,

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultResponse.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.opensearch.action.ActionResponse;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.FeatureData;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
@@ -28,7 +29,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.commons.authuser.User;
 
 public class AnomalyResultResponse extends ActionResponse implements ToXContentObject {
     public static final String ANOMALY_GRADE_JSON_KEY = "anomalyGrade";
@@ -341,7 +341,7 @@ public class AnomalyResultResponse extends ActionResponse implements ToXContentO
         Instant executionStartInstant,
         Instant executionEndInstant,
         Integer schemaVersion,
-        User user,
+        UserIdentity user,
         String error
     ) {
         // Detector interval in milliseconds

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -34,6 +34,7 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
@@ -48,7 +49,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
@@ -88,7 +88,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
     protected void doExecute(Task task, DeleteAnomalyDetectorRequest request, ActionListener<DeleteResponse> actionListener) {
         String detectorId = request.getDetectorID();
         LOG.info("Delete anomaly detector job {}", detectorId);
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         ActionListener<DeleteResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_DELETE_DETECTOR);
         // By the time request reaches here, the user permissions are validated by Security plugin.
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -15,7 +15,7 @@ import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_DELETE_DETE
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -88,7 +88,8 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
     protected void doExecute(Task task, DeleteAnomalyDetectorRequest request, ActionListener<DeleteResponse> actionListener) {
         String detectorId = request.getDetectorID();
         LOG.info("Delete anomaly detector job {}", detectorId);
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always execute detector.
+        UserIdentity user = getNullUser();
         ActionListener<DeleteResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_DELETE_DETECTOR);
         // By the time request reaches here, the user permissions are validated by Security plugin.
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -14,7 +14,7 @@ package org.opensearch.ad.transport;
 import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_DELETE_AD_RESULT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;
@@ -61,7 +61,8 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
     }
 
     public void delete(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always validate role.
+        UserIdentity user = getNullUser();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             validateRole(request, user, listener);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -22,12 +22,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
@@ -61,7 +61,7 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
     }
 
     public void delete(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             validateRole(request, user, listener);
         } catch (Exception e) {
@@ -70,7 +70,7 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
         }
     }
 
-    private void validateRole(DeleteByQueryRequest request, User user, ActionListener<BulkByScrollResponse> listener) {
+    private void validateRole(DeleteByQueryRequest request, UserIdentity user, ActionListener<BulkByScrollResponse> listener) {
         if (user == null || !filterEnabled) {
             // Case 1: user == null when 1. Security is disabled. 2. When user is super-admin
             // Case 2: If Security is enabled and filter is disabled, proceed with search as

--- a/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.cluster.ADVersionUtil;
 import org.opensearch.ad.common.exception.ADVersionException;
 import org.opensearch.ad.constant.CommonErrorMessages;
@@ -30,7 +31,6 @@ import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.rest.handler.AnomalyDetectorFunction;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.transport.TransportService;
 
 public class ForwardADTaskRequest extends ActionRequest {
@@ -38,7 +38,7 @@ public class ForwardADTaskRequest extends ActionRequest {
     private ADTask adTask;
     private DetectionDateRange detectionDateRange;
     private List<String> staleRunningEntities;
-    private User user;
+    private UserIdentity user;
     private Integer availableTaskSlots;
     private ADTaskAction adTaskAction;
 
@@ -59,7 +59,7 @@ public class ForwardADTaskRequest extends ActionRequest {
     public ForwardADTaskRequest(
         AnomalyDetector detector,
         DetectionDateRange detectionDateRange,
-        User user,
+        UserIdentity user,
         ADTaskAction adTaskAction,
         Integer availableTaskSlots,
         Version remoteAdVersion
@@ -77,7 +77,7 @@ public class ForwardADTaskRequest extends ActionRequest {
         this.adTaskAction = adTaskAction;
     }
 
-    public ForwardADTaskRequest(AnomalyDetector detector, DetectionDateRange detectionDateRange, User user, ADTaskAction adTaskAction) {
+    public ForwardADTaskRequest(AnomalyDetector detector, DetectionDateRange detectionDateRange, UserIdentity user, ADTaskAction adTaskAction) {
         this.detector = detector;
         this.detectionDateRange = detectionDateRange;
         this.user = user;
@@ -106,7 +106,7 @@ public class ForwardADTaskRequest extends ActionRequest {
         super(in);
         this.detector = new AnomalyDetector(in);
         if (in.readBoolean()) {
-            this.user = new User(in);
+            this.user = new UserIdentity(in);
         }
         this.adTaskAction = in.readEnum(ADTaskAction.class);
         if (in.available() == 0) {
@@ -183,7 +183,7 @@ public class ForwardADTaskRequest extends ActionRequest {
         return detectionDateRange;
     }
 
-    public User getUser() {
+    public UserIdentity getUser() {
         return user;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
@@ -77,7 +77,12 @@ public class ForwardADTaskRequest extends ActionRequest {
         this.adTaskAction = adTaskAction;
     }
 
-    public ForwardADTaskRequest(AnomalyDetector detector, DetectionDateRange detectionDateRange, UserIdentity user, ADTaskAction adTaskAction) {
+    public ForwardADTaskRequest(
+        AnomalyDetector detector,
+        DetectionDateRange detectionDateRange,
+        UserIdentity user,
+        ADTaskAction adTaskAction
+    ) {
         this.detector = detector;
         this.detectionDateRange = detectionDateRange;
         this.user = user;

--- a/src/main/java/org/opensearch/ad/transport/ForwardADTaskTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ForwardADTaskTransportAction.java
@@ -25,6 +25,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.ADTaskAction;
@@ -34,7 +35,6 @@ import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -81,7 +81,7 @@ public class ForwardADTaskTransportAction extends HandledTransportAction<Forward
         DetectionDateRange detectionDateRange = request.getDetectionDateRange();
         String detectorId = detector.getDetectorId();
         ADTask adTask = request.getAdTask();
-        User user = request.getUser();
+        UserIdentity user = request.getUser();
         Integer availableTaskSlots = request.getAvailableTaskSLots();
 
         String entityValue = adTaskManager.convertEntityToString(adTask);

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -17,7 +17,7 @@ import static org.opensearch.ad.model.ADTaskType.ALL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.ad.util.RestHandlerUtils.PROFILE;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
@@ -131,7 +131,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     @Override
     protected void doExecute(Task task, GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> actionListener) {
         String detectorID = request.getDetectorID();
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always execute detector.
+        UserIdentity user = getNullUser();
         ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -46,6 +46,7 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.AnomalyDetectorProfileRunner;
 import org.opensearch.ad.EntityProfileRunner;
 import org.opensearch.ad.Name;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -67,7 +68,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -131,7 +131,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     @Override
     protected void doExecute(Task task, GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> actionListener) {
         String detectorID = request.getDetectorID();
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -29,6 +29,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -43,7 +44,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -87,7 +87,7 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, IndexAnomalyDetectorRequest request, ActionListener<IndexAnomalyDetectorResponse> actionListener) {
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         String detectorId = request.getDetectorID();
         RestRequest.Method method = request.getMethod();
         String errorMessage = method == RestRequest.Method.PUT ? FAIL_TO_UPDATE_DETECTOR : FAIL_TO_CREATE_DETECTOR;
@@ -101,7 +101,7 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
     }
 
     private void resolveUserAndExecute(
-        User requestedUser,
+        UserIdentity requestedUser,
         String detectorId,
         RestRequest.Method method,
         ActionListener<IndexAnomalyDetectorResponse> listener,
@@ -132,7 +132,7 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
 
     protected void adExecute(
         IndexAnomalyDetectorRequest request,
-        User user,
+        UserIdentity user,
         AnomalyDetector currentDetector,
         ThreadContext.StoredContext storedContext,
         ActionListener<IndexAnomalyDetectorResponse> listener
@@ -153,7 +153,7 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         checkIndicesAndExecute(detector.getIndices(), () -> {
             // Don't replace detector's user when update detector
             // Github issue: https://github.com/opensearch-project/anomaly-detection/issues/124
-            User detectorUser = currentDetector == null ? user : currentDetector.getUser();
+            UserIdentity detectorUser = currentDetector == null ? user : currentDetector.getUser();
             IndexAnomalyDetectorActionHandler indexAnomalyDetectorActionHandler = new IndexAnomalyDetectorActionHandler(
                 clusterService,
                 client,

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -16,7 +16,7 @@ import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_UPDATE_DETE
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.ad.util.ParseUtils.getDetector;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import java.util.List;
@@ -87,7 +87,8 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, IndexAnomalyDetectorRequest request, ActionListener<IndexAnomalyDetectorResponse> actionListener) {
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always execute detector.
+        UserIdentity user = getNullUser();
         String detectorId = request.getDetectorID();
         RestRequest.Method method = request.getMethod();
         String errorMessage = method == RestRequest.Method.PUT ? FAIL_TO_UPDATE_DETECTOR : FAIL_TO_CREATE_DETECTOR;

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -15,7 +15,7 @@ import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_PREVIEW_DET
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CONCURRENT_PREVIEW;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -101,7 +101,8 @@ public class PreviewAnomalyDetectorTransportAction extends
         ActionListener<PreviewAnomalyDetectorResponse> actionListener
     ) {
         String detectorId = request.getDetectorId();
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always execute detector.
+        UserIdentity user = getNullUser();
         ActionListener<PreviewAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_PREVIEW_DETECTOR);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -35,6 +35,7 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.AnomalyDetectorRunner;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.ClientException;
@@ -52,7 +53,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -101,7 +101,7 @@ public class PreviewAnomalyDetectorTransportAction extends
         ActionListener<PreviewAnomalyDetectorResponse> actionListener
     ) {
         String detectorId = request.getDetectorId();
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         ActionListener<PreviewAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_PREVIEW_DETECTOR);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.checkFilterByBackendRoles;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 
 import java.time.Clock;
 import java.util.HashMap;
@@ -89,7 +89,8 @@ public class ValidateAnomalyDetectorTransportAction extends
 
     @Override
     protected void doExecute(Task task, ValidateAnomalyDetectorRequest request, ActionListener<ValidateAnomalyDetectorResponse> listener) {
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always execute detector.
+        UserIdentity user = getNullUser();
         AnomalyDetector anomalyDetector = request.getDetector();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(user, listener, () -> validateExecute(request, user, context, listener));

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -27,6 +27,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.common.exception.ADValidationException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.SearchFeatureDao;
@@ -45,7 +46,6 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;
@@ -89,7 +89,7 @@ public class ValidateAnomalyDetectorTransportAction extends
 
     @Override
     protected void doExecute(Task task, ValidateAnomalyDetectorRequest request, ActionListener<ValidateAnomalyDetectorResponse> listener) {
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         AnomalyDetector anomalyDetector = request.getDetector();
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(user, listener, () -> validateExecute(request, user, context, listener));
@@ -100,7 +100,7 @@ public class ValidateAnomalyDetectorTransportAction extends
     }
 
     private void resolveUserAndExecute(
-        User requestedUser,
+        UserIdentity requestedUser,
         ActionListener<ValidateAnomalyDetectorResponse> listener,
         AnomalyDetectorFunction function
     ) {
@@ -119,7 +119,7 @@ public class ValidateAnomalyDetectorTransportAction extends
 
     private void validateExecute(
         ValidateAnomalyDetectorRequest request,
-        User user,
+        UserIdentity user,
         ThreadContext.StoredContext storedContext,
         ActionListener<ValidateAnomalyDetectorResponse> listener
     ) {

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -22,12 +22,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.commons.authuser.User;
 
 /**
  * Handle general search request, check user role and return search response.
@@ -51,7 +51,7 @@ public class ADSearchHandler {
      * @param actionListener action listerner
      */
     public void search(SearchRequest request, ActionListener<SearchResponse> actionListener) {
-        User user = getUserContext(client);
+        UserIdentity user = getUserContext(client);
         ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_SEARCH);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             validateRole(request, user, listener);
@@ -61,7 +61,7 @@ public class ADSearchHandler {
         }
     }
 
-    private void validateRole(SearchRequest request, User user, ActionListener<SearchResponse> listener) {
+    private void validateRole(SearchRequest request, UserIdentity user, ActionListener<SearchResponse> listener) {
         if (user == null || !filterEnabled) {
             // Case 1: user == null when 1. Security is disabled. 2. When user is super-admin
             // Case 2: If Security is enabled and filter is disabled, proceed with search as

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -14,7 +14,7 @@ package org.opensearch.ad.transport.handler;
 import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_SEARCH;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
-import static org.opensearch.ad.util.ParseUtils.getUserContext;
+import static org.opensearch.ad.util.ParseUtils.getNullUser;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;
@@ -51,7 +51,8 @@ public class ADSearchHandler {
      * @param actionListener action listerner
      */
     public void search(SearchRequest request, ActionListener<SearchResponse> actionListener) {
-        UserIdentity user = getUserContext(client);
+        // Temporary null user for AD extension without security. Will always validate role.
+        UserIdentity user = getNullUser();
         ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_SEARCH);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             validateRole(request, user, listener);

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -456,10 +456,26 @@ public final class ParseUtils {
         return searchSourceBuilder;
     }
 
+    /**
+     * @deprecated Extensions will not be using the User from the Thread Context. Temporarily use
+     *     {@link #getNullUser()}.
+     */
+    @Deprecated
     public static UserIdentity getUserContext(Client client) {
         String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         logger.debug("Filtering result by " + userStr);
         return UserIdentity.parse(userStr);
+    }
+
+    /**
+     * Placeholder method for running AD as an extension without security. User == null when security is disabled or user is super-admin.
+     *
+     * @return null.
+     */
+    public static UserIdentity getNullUser() {
+        // The author of this temporary code thinks it's a really bad idea to have a null object default to super-admin privileges.
+        // But that's how it is so here is the infinity gauntlet.
+        return null;
     }
 
     public static void resolveUserAndExecute(

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -59,6 +59,7 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.constant.CommonValue;
@@ -122,7 +123,6 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
@@ -293,7 +293,7 @@ public class TestHelpers {
         boolean withUser,
         List<String> categoryFields
     ) throws IOException {
-        User user = withUser ? randomUser() : null;
+        UserIdentity user = withUser ? randomUser() : null;
         return new AnomalyDetector(
             randomAlphaOfLength(10),
             randomLong(),
@@ -516,7 +516,7 @@ public class TestHelpers {
         private Integer schemaVersion = randomInt();
         private Instant lastUpdateTime = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         private List<String> categoryFields = null;
-        private User user = randomUser();
+        private UserIdentity user = randomUser();
         private String resultIndex = null;
 
         public static AnomalyDetectorBuilder newInstance() throws IOException {
@@ -602,7 +602,7 @@ public class TestHelpers {
             return this;
         }
 
-        public AnomalyDetectorBuilder setUser(User user) {
+        public AnomalyDetectorBuilder setUser(UserIdentity user) {
             this.user = user;
             return this;
         }
@@ -777,8 +777,8 @@ public class TestHelpers {
         return results;
     }
 
-    public static User randomUser() {
-        return new User(
+    public static UserIdentity randomUser() {
+        return new UserIdentity(
             randomAlphaOfLength(8),
             ImmutableList.of(randomAlphaOfLength(10)),
             ImmutableList.of("all_access"),
@@ -824,7 +824,7 @@ public class TestHelpers {
     }
 
     public static AnomalyResult randomAnomalyDetectResult(double score, String error, String taskId, boolean withUser) {
-        User user = withUser ? randomUser() : null;
+        UserIdentity user = withUser ? randomUser() : null;
         List<DataByFeatureId> relavantAttribution = new ArrayList<DataByFeatureId>();
         relavantAttribution.add(new DataByFeatureId(randomAlphaOfLength(5), randomDoubleBetween(0, 1.0, true)));
         relavantAttribution.add(new DataByFeatureId(randomAlphaOfLength(5), randomDoubleBetween(0, 1.0, true)));

--- a/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.rest.handler.IndexAnomalyDetectorJobActionHandler;
@@ -35,7 +36,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -90,7 +90,7 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
         TimeValue requestTimeout = REQUEST_TIMEOUT.get(settings);
         String userStr = "user_name|backendrole1,backendrole2|roles1,role2";
         // By the time request reaches here, the user permissions are validated by Security plugin.
-        User user = User.parse(userStr);
+        UserIdentity user = UserIdentity.parse(userStr);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             resolveUserAndExecute(
                 user,
@@ -125,7 +125,7 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
         long primaryTerm,
         String rawPath,
         TimeValue requestTimeout,
-        User user,
+        UserIdentity user,
         DetectionDateRange detectionDateRange,
         boolean historical
     ) {

--- a/src/test/java/org/opensearch/ad/mock/transport/MockForwardADTaskRequest_1_0.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockForwardADTaskRequest_1_0.java
@@ -17,18 +17,18 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.commons.authuser.User;
 
 public class MockForwardADTaskRequest_1_0 extends ActionRequest {
     private AnomalyDetector detector;
-    private User user;
+    private UserIdentity user;
     private MockADTaskAction_1_0 adTaskAction;
 
-    public MockForwardADTaskRequest_1_0(AnomalyDetector detector, User user, MockADTaskAction_1_0 adTaskAction) {
+    public MockForwardADTaskRequest_1_0(AnomalyDetector detector, UserIdentity user, MockADTaskAction_1_0 adTaskAction) {
         this.detector = detector;
         this.user = user;
         this.adTaskAction = adTaskAction;
@@ -38,7 +38,7 @@ public class MockForwardADTaskRequest_1_0 extends ActionRequest {
         super(in);
         this.detector = new AnomalyDetector(in);
         if (in.readBoolean()) {
-            this.user = new User(in);
+            this.user = new UserIdentity(in);
         }
         this.adTaskAction = in.readEnum(MockADTaskAction_1_0.class);
     }
@@ -74,7 +74,7 @@ public class MockForwardADTaskRequest_1_0 extends ActionRequest {
         return detector;
     }
 
-    public User getUser() {
+    public UserIdentity getUser() {
         return user;
     }
 

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -23,13 +23,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.opensearch.ad.AnomalyDetectorRestTestCase;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.commons.rest.SecureRestClientBuilder;
 import org.opensearch.rest.RestStatus;
 
@@ -209,7 +209,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             aliceDetector.getSchemaVersion(),
             Instant.now(),
             aliceDetector.getCategoryField(),
-            new User(
+            new UserIdentity(
                 randomAlphaOfLength(5),
                 ImmutableList.of("odfe", randomAlphaOfLength(5)),
                 ImmutableList.of(randomAlphaOfLength(5)),

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -82,6 +82,7 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.ad.ADUnitTestCase;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.DuplicateTaskException;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
@@ -116,7 +117,6 @@ import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.ToXContent;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
@@ -1002,7 +1002,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
     public void testStartHistoricalAnalysisWithNoOwningNode() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableList.of());
         DetectionDateRange detectionDateRange = TestHelpers.randomDetectionDateRange();
-        User user = null;
+        UserIdentity user = null;
         int availableTaskSlots = randomIntBetween(1, 10);
         ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
         doAnswer(invocation -> {
@@ -1455,7 +1455,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
     public void testStartDetectorWithException() throws IOException {
         AnomalyDetector detector = randomAnomalyDetector(ImmutableList.of(randomFeature(true)));
         DetectionDateRange detectionDateRange = randomDetectionDateRange();
-        User user = null;
+        UserIdentity user = null;
         ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
         when(detectionIndices.doesDetectorStateIndexExist()).thenReturn(false);
         doThrow(new RuntimeException("test")).when(detectionIndices).initDetectionStateIndex(any());

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -334,17 +334,25 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
         ActionListener<PreviewAnomalyDetectorResponse> responseActionListener = new ActionListener<PreviewAnomalyDetectorResponse>() {
             @Override
             public void onResponse(PreviewAnomalyDetectorResponse response) {
-                Assert.assertTrue(false);
+                // Thread Context User has been replaced with null as part of https://github.com/opensearch-project/opensearch-sdk/issues/23
+                // Previously we expected failure but could get a response here
+                // Assert.assertTrue(false);
             }
 
             @Override
             public void onFailure(Exception e) {
+                // Thread Context User has been replaced with null as part of https://github.com/opensearch-project/opensearch-sdk/issues/23
+                // Previously we expected failure but we should now never get here
+                fail("This should never fail with null (super-admin) user");
                 Assert.assertEquals(OpenSearchStatusException.class, e.getClass());
                 inProgressLatch.countDown();
             }
         };
         previewAction.doExecute(task, request, responseActionListener);
-        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+        // Thread Context User has been replaced with null as part of https://github.com/opensearch-project/opensearch-sdk/issues/23
+        // Countdown latch was never decremented on failure, so we expect failure here
+        // assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+        assertFalse(inProgressLatch.await(100, TimeUnit.SECONDS));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/ad/transport/handler/ADSearchHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/ADSearchHandlerTests.java
@@ -79,7 +79,10 @@ public class ADSearchHandlerTests extends ADUnitTestCase {
 
         searchHandler = new ADSearchHandler(settings, clusterService, client);
         searchHandler.search(request, listener);
-        verify(listener, times(1)).onFailure(any());
+        // Thread Context User has been replaced with null as part of https://github.com/opensearch-project/opensearch-sdk/issues/23
+        // so the search call will always succeed
+        // verify(listener, times(1)).onFailure(any());
+        verify(listener, times(0)).onFailure(any());
     }
 
     public void testFilterEnabled() {

--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -19,6 +19,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.auth.UserIdentity;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Feature;
@@ -26,7 +27,6 @@ import org.opensearch.common.ParsingException;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.commons.authuser.User;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregatorFactories;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -140,7 +140,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
     public void testAddUserRoleFilterWithNullUserBackendRole() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         addUserBackendRolesFilter(
-            new User(randomAlphaOfLength(5), null, ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5))),
+            new UserIdentity(randomAlphaOfLength(5), null, ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5))),
             searchSourceBuilder
         );
         assertEquals(
@@ -154,7 +154,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
     public void testAddUserRoleFilterWithEmptyUserBackendRole() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         addUserBackendRolesFilter(
-            new User(
+            new UserIdentity(
                 randomAlphaOfLength(5),
                 ImmutableList.of(),
                 ImmutableList.of(randomAlphaOfLength(5)),
@@ -175,7 +175,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         String backendRole1 = randomAlphaOfLength(5);
         String backendRole2 = randomAlphaOfLength(5);
         addUserBackendRolesFilter(
-            new User(
+            new UserIdentity(
                 randomAlphaOfLength(5),
                 ImmutableList.of(backendRole1, backendRole2),
                 ImmutableList.of(randomAlphaOfLength(5)),

--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -140,7 +140,12 @@ public class ParseUtilsTests extends OpenSearchTestCase {
     public void testAddUserRoleFilterWithNullUserBackendRole() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         addUserBackendRolesFilter(
-            new UserIdentity(randomAlphaOfLength(5), null, ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5))),
+            new UserIdentity(
+                randomAlphaOfLength(5),
+                null,
+                ImmutableList.of(randomAlphaOfLength(5)),
+                ImmutableList.of(randomAlphaOfLength(5))
+            ),
             searchSourceBuilder
         );
         assertEquals(


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
This copies the `User` class over from the Common Utils into a `UserIdentity` class.   Other than the class rename and addition of javadocs, there are no changes to the class.  This is done primarily to remove the external dependency but also preserve the intention (user and roles) as a placeholder until a replacement security authentication mechanism is implemented, and retains existing functionality.

In places where the User is retrieved from the thread context, a null user is used, as the original designers of this plugin determined that null = super user.  This will not be the path going forward but it is at least very convenient for us now.

Final changes were made to tests to recognize the lack of failed access, and coverage which is reduced by never executing code to respond to failures.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk/issues/23

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
