### PR TITLE
[Feature/extensions] Remove client

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
@@ -66,7 +66,6 @@ import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.commons.InjectSecurity;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
 import org.opensearch.jobscheduler.spi.LockModel;
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
@@ -265,11 +264,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
         String user,
         List<String> roles
     ) {
-
-        try (InjectSecurity injectSecurity = new InjectSecurity(detectorId, settings, client.threadPool().getThreadContext())) {
-            // Injecting user role to verify if the user has permissions for our API.
-            injectSecurity.inject(user, roles);
-
+        try {
             AnomalyResultRequest request = new AnomalyResultRequest(
                 detectorId,
                 detectionStartTime.toEpochMilli(),

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -336,7 +336,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         this.threadPool = threadPool;
         Settings settings = environment.settings();
         Throttler throttler = new Throttler(getClock());
-        this.clientUtil = new ClientUtil(settings, client, throttler, threadPool);
+        this.clientUtil = new ClientUtil(settings, client, throttler);
         this.indexUtils = new IndexUtils(client, clientUtil, clusterService, indexNameExpressionResolver);
         this.nodeFilter = new DiscoveryNodeFilterer(clusterService);
         this.anomalyDetectionIndices = new AnomalyDetectionIndices(

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -59,16 +59,11 @@ public final class AnomalyDetectorRunner {
      * @param detector  anomaly detector instance
      * @param startTime detection period start time
      * @param endTime   detection period end time
-     * @param context   stored thread context
      * @param listener handle anomaly result
      * @throws IOException - if a user gives wrong query input when defining a detector
      */
-    public void executeDetector(
-        AnomalyDetector detector,
-        Instant startTime,
-        Instant endTime,
-        ActionListener<List<AnomalyResult>> listener
-    ) throws IOException {
+    public void executeDetector(AnomalyDetector detector, Instant startTime, Instant endTime, ActionListener<List<AnomalyResult>> listener)
+        throws IOException {
         List<String> categoryField = detector.getCategoryField();
         if (categoryField != null && !categoryField.isEmpty()) {
             featureManager.getPreviewEntities(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(entities -> {

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -36,7 +36,6 @@ import org.opensearch.ad.model.EntityAnomalyResult;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
-import org.opensearch.common.util.concurrent.ThreadContext;
 
 /**
  * Runner to trigger an anomaly detector.
@@ -68,10 +67,8 @@ public final class AnomalyDetectorRunner {
         AnomalyDetector detector,
         Instant startTime,
         Instant endTime,
-        ThreadContext.StoredContext context,
         ActionListener<List<AnomalyResult>> listener
     ) throws IOException {
-        context.restore();
         List<String> categoryField = detector.getCategoryField();
         if (categoryField != null && !categoryField.isEmpty()) {
             featureManager.getPreviewEntities(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(entities -> {

--- a/src/main/java/org/opensearch/ad/cluster/diskcleanup/IndexCleanup.java
+++ b/src/main/java/org/opensearch/ad/cluster/diskcleanup/IndexCleanup.java
@@ -25,7 +25,6 @@ import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
@@ -110,17 +109,14 @@ public class IndexCleanup {
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
             .setRefresh(true);
 
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            clientUtil.execute(DeleteByQueryAction.INSTANCE, deleteRequest, ActionListener.wrap(response -> {
-                long deleted = response.getDeleted();
-                if (deleted > 0) {
-                    // if 0 docs get deleted, it means our query cannot find any matching doc
-                    // or the index does not exist at all
-                    LOG.info("{} docs are deleted for index:{}", deleted, indexName);
-                }
-                listener.onResponse(response.getDeleted());
-            }, listener::onFailure));
-        }
-
+        clientUtil.execute(DeleteByQueryAction.INSTANCE, deleteRequest, ActionListener.wrap(response -> {
+            long deleted = response.getDeleted();
+            if (deleted > 0) {
+                // if 0 docs get deleted, it means our query cannot find any matching doc
+                // or the index does not exist at all
+                LOG.info("{} docs are deleted for index:{}", deleted, indexName);
+            }
+            listener.onResponse(response.getDeleted());
+        }, listener::onFailure));
     }
 }

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -86,7 +86,6 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.commons.InjectSecurity;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
@@ -404,14 +403,11 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
             listener.onFailure(new EndRunException("Result index mapping is not correct", true));
             return;
         }
-        try (InjectSecurity injectSecurity = new InjectSecurity(securityLogId, settings, client.threadPool().getThreadContext())) {
-            injectSecurity.inject(user, roles);
+        try {
             ActionListener<T> wrappedListener = ActionListener.wrap(r -> { listener.onResponse(r); }, e -> {
-                injectSecurity.close();
                 listener.onFailure(e);
             });
             validateCustomResultIndexAndExecute(resultIndex, () -> {
-                injectSecurity.close();
                 function.execute();
             }, wrappedListener);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -404,12 +404,8 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
             return;
         }
         try {
-            ActionListener<T> wrappedListener = ActionListener.wrap(r -> { listener.onResponse(r); }, e -> {
-                listener.onFailure(e);
-            });
-            validateCustomResultIndexAndExecute(resultIndex, () -> {
-                function.execute();
-            }, wrappedListener);
+            ActionListener<T> wrappedListener = ActionListener.wrap(r -> { listener.onResponse(r); }, e -> { listener.onFailure(e); });
+            validateCustomResultIndexAndExecute(resultIndex, () -> { function.execute(); }, wrappedListener);
         } catch (Exception e) {
             logger.error("Failed to validate custom index for backend job " + securityLogId, e);
             listener.onFailure(e);

--- a/src/main/java/org/opensearch/ad/rest/AbstractSearchAction.java
+++ b/src/main/java/org/opensearch/ad/rest/AbstractSearchAction.java
@@ -32,7 +32,6 @@ import org.opensearch.ad.rest.handler.AnomalyDetectorFunction;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -89,7 +88,7 @@ public abstract class AbstractSearchAction<T extends ToXContentObject> extends B
     }
 
     protected void executeWithAdmin(NodeClient client, AnomalyDetectorFunction function, RestChannel channel) {
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             function.execute();
         } catch (Exception e) {
             logger.error("Failed to execute with admin", e);

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -74,7 +74,6 @@ import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
@@ -276,7 +275,7 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
     // if isDryRun is true then this method is being executed through Validation API meaning actual
     // index won't be created, only validation checks will be executed throughout the class
     private void createOrUpdateDetector() {
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             if (!anomalyDetectionIndices.doesAnomalyDetectorIndexExist() && !this.isDryRun) {
                 logger.info("AnomalyDetector Indices do not exist");
                 anomalyDetectionIndices

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -95,7 +95,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.commons.InjectSecurity;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -1157,9 +1156,7 @@ public class ADBatchTaskRunner {
             return;
         }
 
-        try (InjectSecurity injectSecurity = new InjectSecurity(adTask.getTaskId(), settings, client.threadPool().getThreadContext())) {
-            // Injecting user role to verify if the user has permissions to write result to result index.
-            injectSecurity.inject(user, roles);
+        try {
             storeAnomalyResultAndRunNextPiece(
                 adTask,
                 pieceEndTime,
@@ -1169,7 +1166,7 @@ public class ADBatchTaskRunner {
                 internalListener,
                 anomalyResults,
                 resultIndex,
-                () -> injectSecurity.close()
+                null
             );
         } catch (Exception exception) {
             logger.error("Failed to inject user roles", exception);

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -145,7 +145,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContent;
@@ -289,7 +288,6 @@ public class ADTaskManager {
         IndexAnomalyDetectorJobActionHandler handler,
         UserIdentity user,
         TransportService transportService,
-        ThreadContext.StoredContext context,
         ActionListener<AnomalyDetectorJobResponse> listener
     ) {
         // upgrade index mapping of AD default indices
@@ -312,7 +310,6 @@ public class ADTaskManager {
                 startRealtimeOrHistoricalDetection(detectionDateRange, handler, user, transportService, listener, detector);
                 return;
             }
-            context.restore();
             detectionIndices
                 .initCustomResultIndexAndExecute(
                     resultIndex,
@@ -331,7 +328,7 @@ public class ADTaskManager {
         ActionListener<AnomalyDetectorJobResponse> listener,
         Optional<AnomalyDetector> detector
     ) {
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             if (detectionDateRange == null) {
                 // start realtime job
                 handler.startAnomalyDetectorJob(detector.get());

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -279,7 +279,6 @@ public class ADTaskManager {
      * @param handler anomaly detector job action handler
      * @param user user
      * @param transportService transport service
-     * @param context thread context
      * @param listener action listener
      */
     public void startDetector(

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -86,7 +86,6 @@ import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.NetworkExceptionHelper;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.node.NodeClosedException;
@@ -242,7 +241,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
      */
     @Override
     protected void doExecute(Task task, ActionRequest actionRequest, ActionListener<AnomalyResultResponse> listener) {
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             AnomalyResultRequest request = AnomalyResultRequest.fromActionRequest(actionRequest);
             String adID = request.getAdID();
             ActionListener<AnomalyResultResponse> original = listener;

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -46,7 +46,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
@@ -92,7 +91,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
         UserIdentity user = getNullUser();
         ActionListener<DeleteResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_DELETE_DETECTOR);
         // By the time request reaches here, the user permissions are validated by Security plugin.
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             resolveUserAndExecute(
                 user,
                 detectorId,

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -27,7 +27,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
@@ -63,7 +62,7 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
     public void delete(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
         // Temporary null user for AD extension without security. Will always validate role.
         UserIdentity user = getNullUser();
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             validateRole(request, user, listener);
         } catch (Exception e) {
             logger.error(e);

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -65,7 +65,6 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.Strings;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
@@ -134,7 +133,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         // Temporary null user for AD extension without security. Will always execute detector.
         UserIdentity user = getNullUser();
         ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR);
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             resolveUserAndExecute(
                 user,
                 detectorID,

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -120,10 +120,7 @@ public class PreviewAnomalyDetectorTransportAction extends
         }
     }
 
-    void previewExecute(
-        PreviewAnomalyDetectorRequest request,
-        ActionListener<PreviewAnomalyDetectorResponse> listener
-    ) {
+    void previewExecute(PreviewAnomalyDetectorRequest request, ActionListener<PreviewAnomalyDetectorResponse> listener) {
         if (adCircuitBreakerService.isOpen()) {
             listener
                 .onFailure(new LimitExceededException(request.getDetectorId(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG, false));
@@ -149,12 +146,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                         return;
                     }
                     anomalyDetectorRunner
-                        .executeDetector(
-                            detector,
-                            startTime,
-                            endTime,
-                            getPreviewDetectorActionListener(releaseListener, detector)
-                        );
+                        .executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(releaseListener, detector));
                 } else {
                     previewAnomalyDetector(releaseListener, detectorId, detector, startTime, endTime);
                 }
@@ -209,8 +201,7 @@ public class PreviewAnomalyDetectorTransportAction extends
             GetRequest getRequest = new GetRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX).id(detectorId);
             client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime));
         } else {
-            anomalyDetectorRunner
-                .executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(listener, detector));
+            anomalyDetectorRunner.executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(listener, detector));
         }
     }
 

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -50,7 +50,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
@@ -104,13 +103,13 @@ public class PreviewAnomalyDetectorTransportAction extends
         // Temporary null user for AD extension without security. Will always execute detector.
         UserIdentity user = getNullUser();
         ActionListener<PreviewAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_PREVIEW_DETECTOR);
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             resolveUserAndExecute(
                 user,
                 detectorId,
                 filterByEnabled,
                 listener,
-                (anomalyDetector) -> previewExecute(request, context, listener),
+                (anomalyDetector) -> previewExecute(request, listener),
                 client,
                 clusterService,
                 xContentRegistry
@@ -123,7 +122,6 @@ public class PreviewAnomalyDetectorTransportAction extends
 
     void previewExecute(
         PreviewAnomalyDetectorRequest request,
-        ThreadContext.StoredContext context,
         ActionListener<PreviewAnomalyDetectorResponse> listener
     ) {
         if (adCircuitBreakerService.isOpen()) {
@@ -155,11 +153,10 @@ public class PreviewAnomalyDetectorTransportAction extends
                             detector,
                             startTime,
                             endTime,
-                            context,
                             getPreviewDetectorActionListener(releaseListener, detector)
                         );
                 } else {
-                    previewAnomalyDetector(releaseListener, detectorId, detector, startTime, endTime, context);
+                    previewAnomalyDetector(releaseListener, detectorId, detector, startTime, endTime);
                 }
             } catch (Exception e) {
                 logger.error("Fail to preview", e);
@@ -206,23 +203,21 @@ public class PreviewAnomalyDetectorTransportAction extends
         String detectorId,
         AnomalyDetector detector,
         Instant startTime,
-        Instant endTime,
-        ThreadContext.StoredContext context
+        Instant endTime
     ) throws IOException {
         if (!StringUtils.isBlank(detectorId)) {
             GetRequest getRequest = new GetRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX).id(detectorId);
-            client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime, context));
+            client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime));
         } else {
             anomalyDetectorRunner
-                .executeDetector(detector, startTime, endTime, context, getPreviewDetectorActionListener(listener, detector));
+                .executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(listener, detector));
         }
     }
 
     private ActionListener<GetResponse> onGetAnomalyDetectorResponse(
         ActionListener<PreviewAnomalyDetectorResponse> listener,
         Instant startTime,
-        Instant endTime,
-        ThreadContext.StoredContext context
+        Instant endTime
     ) {
         return ActionListener.wrap(new CheckedConsumer<GetResponse, Exception>() {
             @Override
@@ -242,7 +237,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                     AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
                     anomalyDetectorRunner
-                        .executeDetector(detector, startTime, endTime, context, getPreviewDetectorActionListener(listener, detector));
+                        .executeDetector(detector, startTime, endTime, getPreviewDetectorActionListener(listener, detector));
                 } catch (IOException e) {
                     listener.onFailure(e);
                 }

--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
@@ -26,7 +26,6 @@ import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermsQueryBuilder;
@@ -61,7 +60,7 @@ public class SearchAnomalyDetectorInfoTransportAction extends
         String name = request.getName();
         String rawPath = request.getRawPath();
         ActionListener<SearchAnomalyDetectorInfoResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR_INFO);
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             SearchRequest searchRequest = new SearchRequest().indices(ANOMALY_DETECTORS_INDEX);
             if (rawPath.endsWith(RestHandlerUtils.COUNT)) {
                 // Count detectors

--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyResultTransportAction.java
@@ -36,7 +36,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.Aggregations;
@@ -168,8 +167,7 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
         List<String> targetIndices,
         SearchRequest request,
         ActionListener<SearchResponse> listener,
-        boolean finalOnlyQueryCustomResultIndex,
-        ThreadContext.StoredContext context
+        boolean finalOnlyQueryCustomResultIndex
     ) {
         if (targetIndices.size() == 0) {
             // no need to make multi search
@@ -181,7 +179,6 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
             readableIndices.add(ALL_AD_RESULTS_INDEX_PATTERN);
         }
 
-        context.restore();
         // Send multiple search to check which index a user has permission to read. If search all indices directly,
         // search request will throw exception if user has no permission to search any index.
         client
@@ -232,7 +229,7 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
         Set<String> customResultIndices
     ) {
         SearchRequest searchResultIndex = createSingleSearchRequest();
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             // Search result indices of all detectors. User may create index with same prefix of custom result index
             // which not used for AD, so we should avoid searching extra indices which not used by anomaly detectors.
             // Variable used in lambda expression should be final or effectively final, so copy to a final boolean and
@@ -241,7 +238,7 @@ public class SearchAnomalyResultTransportAction extends HandledTransportAction<S
             client.search(searchResultIndex, ActionListener.wrap(allResultIndicesResponse -> {
                 List<String> targetIndices = new ArrayList<>();
                 processSingleSearchResponse(allResultIndicesResponse, request, listener, customResultIndices, targetIndices);
-                multiSearch(targetIndices, request, listener, finalOnlyQueryCustomResultIndex, context);
+                multiSearch(targetIndices, request, listener, finalOnlyQueryCustomResultIndex);
             }, e -> {
                 logger.error("Failed to search result indices for all detectors", e);
                 listener.onFailure(e);

--- a/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -35,7 +35,6 @@ import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
@@ -70,7 +69,7 @@ public class StatsAnomalyDetectorTransportAction extends HandledTransportAction<
     @Override
     protected void doExecute(Task task, ADStatsRequest request, ActionListener<StatsAnomalyDetectorResponse> actionListener) {
         ActionListener<StatsAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_STATS);
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             getStats(client, listener, request);
         } catch (Exception e) {
             logger.error(e);

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -44,7 +44,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
@@ -92,8 +91,8 @@ public class ValidateAnomalyDetectorTransportAction extends
         // Temporary null user for AD extension without security. Will always execute detector.
         UserIdentity user = getNullUser();
         AnomalyDetector anomalyDetector = request.getDetector();
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
-            resolveUserAndExecute(user, listener, () -> validateExecute(request, user, context, listener));
+        try {
+            resolveUserAndExecute(user, listener, () -> validateExecute(request, user, listener));
         } catch (Exception e) {
             logger.error(e);
             listener.onFailure(e);
@@ -121,10 +120,8 @@ public class ValidateAnomalyDetectorTransportAction extends
     private void validateExecute(
         ValidateAnomalyDetectorRequest request,
         UserIdentity user,
-        ThreadContext.StoredContext storedContext,
         ActionListener<ValidateAnomalyDetectorResponse> listener
     ) {
-        storedContext.restore();
         AnomalyDetector detector = request.getDetector();
         ActionListener<ValidateAnomalyDetectorResponse> validateListener = ActionListener.wrap(response -> {
             logger.debug("Result of validation process " + response);

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -27,7 +27,6 @@ import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 
 /**
  * Handle general search request, check user role and return search response.
@@ -54,7 +53,7 @@ public class ADSearchHandler {
         // Temporary null user for AD extension without security. Will always validate role.
         UserIdentity user = getNullUser();
         ActionListener<SearchResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_SEARCH);
-        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+        try {
             validateRole(request, user, listener);
         } catch (Exception e) {
             logger.error(e);

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -62,7 +62,6 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.commons.ConfigConstants;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
@@ -462,9 +461,7 @@ public final class ParseUtils {
      */
     @Deprecated
     public static UserIdentity getUserContext(Client client) {
-        String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-        logger.debug("Filtering result by " + userStr);
-        return UserIdentity.parse(userStr);
+        return getNullUser();
     }
 
     /**

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -12,8 +12,8 @@
 package org.opensearch.action.admin.indices.mapping.get;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -61,7 +61,6 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -76,7 +75,6 @@ import org.opensearch.transport.TransportService;
  */
 public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
     static ThreadPool threadPool;
-    private ThreadContext threadContext;
     private String TEXT_FIELD_TYPE = "text";
     private IndexAnomalyDetectorActionHandler handler;
     private ClusterService clusterService;

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
@@ -12,7 +12,7 @@
 package org.opensearch.action.admin.indices.mapping.get;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -27,7 +27,6 @@ import java.util.Locale;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchResponse;
@@ -49,7 +48,6 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -82,7 +80,6 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     private Client clientMock;
     @Mock
     protected ThreadPool threadPool;
-    protected ThreadContext threadContext;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -117,10 +114,6 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
         method = RestRequest.Method.POST;
         adTaskManager = mock(ADTaskManager.class);
         searchFeatureDao = mock(SearchFeatureDao.class);
-
-        threadContext = new ThreadContext(settings);
-        Mockito.doReturn(threadPool).when(clientMock).threadPool();
-        Mockito.doReturn(threadContext).when(threadPool).getThreadContext();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
+++ b/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -61,7 +61,6 @@ import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.search.SearchModule;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -72,7 +71,6 @@ public class NodeStateManagerTests extends AbstractADTest {
     private Clock clock;
     private Duration duration;
     private Throttler throttler;
-    private ThreadPool context;
     private AnomalyDetector detectorToCheck;
     private Settings settings;
     private String adId = "123";
@@ -111,10 +109,9 @@ public class NodeStateManagerTests extends AbstractADTest {
             .build();
         clock = mock(Clock.class);
         duration = Duration.ofHours(1);
-        context = TestHelpers.createThreadPool();
         throttler = new Throttler(clock);
 
-        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, mock(ThreadPool.class));
+        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler);
         Set<Setting<?>> nodestateSetting = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         nodestateSetting.add(MAX_RETRY_FOR_UNRESPONSIVE_NODE);
         nodestateSetting.add(BACKOFF_MINUTES);
@@ -240,7 +237,7 @@ public class NodeStateManagerTests extends AbstractADTest {
             client,
             xContentRegistry(),
             settings,
-            new ClientUtil(settings, client, throttler, context),
+            new ClientUtil(settings, client, throttler),
             clock,
             duration,
             clusterService

--- a/src/test/java/org/opensearch/ad/cluster/diskcleanup/IndexCleanupTests.java
+++ b/src/test/java/org/opensearch/ad/cluster/diskcleanup/IndexCleanupTests.java
@@ -13,8 +13,8 @@ package org.opensearch.ad.cluster.diskcleanup;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,8 +34,6 @@ import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.client.Client;
 import org.opensearch.client.IndicesAdminClient;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.store.StoreStats;
 
@@ -80,7 +78,6 @@ public class IndexCleanupTests extends AbstractADTest {
         when(shardStats.getStats()).thenReturn(commonStats);
         when(commonStats.getStore()).thenReturn(storeStats);
         when(client.admin().indices()).thenReturn(indicesAdminClient);
-        when(client.threadPool().getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             ActionListener<IndicesStatsResponse> listener = (ActionListener<IndicesStatsResponse>) args[1];

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -115,7 +115,6 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
@@ -147,8 +146,6 @@ public class ADTaskManagerTests extends ADUnitTestCase {
     private AnomalyDetectionIndices detectionIndices;
     private ADTaskCacheManager adTaskCacheManager;
     private HashRing hashRing;
-    private ThreadContext.StoredContext context;
-    private ThreadContext threadContext;
     private TransportService transportService;
     private ADTaskManager adTaskManager;
     private ThreadPool threadPool;
@@ -235,8 +232,6 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         hashRing = mock(HashRing.class);
         transportService = mock(TransportService.class);
         threadPool = mock(ThreadPool.class);
-        threadContext = new ThreadContext(settings);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(client.threadPool()).thenReturn(threadPool);
         indexAnomalyDetectorJobActionHandler = mock(IndexAnomalyDetectorJobActionHandler.class);
         adTaskManager = spy(
@@ -278,9 +273,6 @@ public class ADTaskManagerTests extends ADUnitTestCase {
             Version.CURRENT
         );
         maxRunningEntities = MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS.get(settings).intValue();
-
-        ThreadContext threadContext = new ThreadContext(settings);
-        context = threadContext.stashContext();
     }
 
     private void setupGetDetector(AnomalyDetector detector) {
@@ -384,7 +376,6 @@ public class ADTaskManagerTests extends ADUnitTestCase {
                 indexAnomalyDetectorJobActionHandler,
                 randomUser(),
                 transportService,
-                context,
                 listener
             );
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
@@ -403,7 +394,6 @@ public class ADTaskManagerTests extends ADUnitTestCase {
                 indexAnomalyDetectorJobActionHandler,
                 randomUser(),
                 transportService,
-                context,
                 listener
             );
         verify(adTaskManager, times(1)).forwardRequestToLeadNode(any(), any(), any());

--- a/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
@@ -48,7 +48,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.monitor.jvm.JvmStats;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 public class ADStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
@@ -68,11 +67,10 @@ public class ADStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         Client client = client();
         Clock clock = mock(Clock.class);
         Throttler throttler = new Throttler(clock);
-        ThreadPool threadPool = mock(ThreadPool.class);
         IndexNameExpressionResolver indexNameResolver = mock(IndexNameExpressionResolver.class);
         IndexUtils indexUtils = new IndexUtils(
             client,
-            new ClientUtil(Settings.EMPTY, client, throttler, threadPool),
+            new ClientUtil(Settings.EMPTY, client, throttler),
             clusterService(),
             indexNameResolver
         );

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
@@ -35,12 +35,9 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.commons.ConfigConstants;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
@@ -59,14 +56,8 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
         );
 
-        Settings build = Settings.builder().build();
-        ThreadContext threadContext = new ThreadContext(build);
-        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         Client client = mock(Client.class);
-        org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(mockThreadPool);
-        when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
 
         action = new AnomalyDetectorJobTransportAction(
             mock(TransportService.class),

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -19,27 +19,22 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.anyDouble;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ad.TestHelpers.createIndexBlockedState;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.opensearch.test.OpenSearchTestCase.randomBoolean;
-import static org.opensearch.test.OpenSearchTestCase.randomDouble;
-import static org.opensearch.test.OpenSearchTestCase.randomDoubleBetween;
-import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -130,9 +125,9 @@ import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
-import test.org.opensearch.ad.util.JsonDeserializer;
-
 import com.google.gson.JsonElement;
+
+import test.org.opensearch.ad.util.JsonDeserializer;
 
 public class AnomalyResultTests extends AbstractADTest {
     private Settings settings;
@@ -256,11 +251,7 @@ public class AnomalyResultTests extends AbstractADTest {
         adCircuitBreakerService = mock(ADCircuitBreakerService.class);
         when(adCircuitBreakerService.isOpen()).thenReturn(false);
 
-        ThreadPool threadPool = mock(ThreadPool.class);
         client = mock(Client.class);
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(client.threadPool().getThreadContext()).thenReturn(threadContext);
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             assertTrue(

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -125,9 +125,9 @@ import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
-import com.google.gson.JsonElement;
-
 import test.org.opensearch.ad.util.JsonDeserializer;
+
+import com.google.gson.JsonElement;
 
 public class AnomalyResultTests extends AbstractADTest {
     private Settings settings;

--- a/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
@@ -51,14 +51,11 @@ import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.commons.ConfigConstants;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableMap;
@@ -195,12 +192,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
     @Test
     public void testIndexTransportActionWithUserAndFilterOn() {
         Settings settings = Settings.builder().put(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.getKey(), true).build();
-        ThreadContext threadContext = new ThreadContext(settings);
-        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(mockThreadPool);
-        when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
 
         IndexAnomalyDetectorTransportAction transportAction = new IndexAnomalyDetectorTransportAction(
             mock(TransportService.class),
@@ -220,12 +212,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
     @Test
     public void testIndexTransportActionWithUserAndFilterOff() {
         Settings settings = Settings.builder().build();
-        ThreadContext threadContext = new ThreadContext(settings);
-        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(mockThreadPool);
-        when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
 
         IndexAnomalyDetectorTransportAction transportAction = new IndexAnomalyDetectorTransportAction(
             mock(TransportService.class),

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -15,8 +15,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -130,10 +130,10 @@ import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
+import com.google.common.collect.ImmutableList;
+
 import test.org.opensearch.ad.util.MLUtil;
 import test.org.opensearch.ad.util.RandomModelStateConfig;
-
-import com.google.common.collect.ImmutableList;
 
 public class MultiEntityResultTests extends AbstractADTest {
     private AnomalyResultTransportAction action;
@@ -210,11 +210,6 @@ public class MultiEntityResultTests extends AbstractADTest {
         transportService = mock(TransportService.class);
 
         client = mock(Client.class);
-        ThreadContext threadContext = new ThreadContext(settings);
-        mockThreadPool = mock(ThreadPool.class);
-        setUpADThreadPool(mockThreadPool);
-        when(client.threadPool()).thenReturn(mockThreadPool);
-        when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
 
         featureQuery = mock(FeatureManager.class);
 

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -130,10 +130,10 @@ import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
-import com.google.common.collect.ImmutableList;
-
 import test.org.opensearch.ad.util.MLUtil;
 import test.org.opensearch.ad.util.RandomModelStateConfig;
+
+import com.google.common.collect.ImmutableList;
 
 public class MultiEntityResultTests extends AbstractADTest {
     private AnomalyResultTransportAction action;

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -66,15 +66,12 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.commons.ConfigConstants;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
-import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableMap;
@@ -291,11 +288,6 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
         Settings settings = Settings.builder().put(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.getKey(), true).build();
         Client client = mock(Client.class);
-        ThreadContext threadContext = new ThreadContext(settings);
-        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
-        org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(mockThreadPool);
-        when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
         PreviewAnomalyDetectorTransportAction previewAction = new PreviewAnomalyDetectorTransportAction(
             settings,
             mock(TransportService.class),

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -53,7 +52,6 @@ public class SearchAnomalyDetectorInfoActionTests extends OpenSearchIntegTestCas
     private ClusterService clusterService;
     private Client client;
     private ThreadPool threadPool;
-    ThreadContext threadContext;
     private PlainActionFuture<SearchAnomalyDetectorInfoResponse> future;
 
     @Override
@@ -86,8 +84,6 @@ public class SearchAnomalyDetectorInfoActionTests extends OpenSearchIntegTestCas
         threadPool = mock(ThreadPool.class);
         when(client.threadPool()).thenReturn(threadPool);
         Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -50,7 +50,6 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.Aggregations;
@@ -68,7 +67,6 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
     private SearchAnomalyResultTransportAction action;
     private TransportService transportService;
     private ThreadPool threadPool;
-    private ThreadContext threadContext;
     private Client client;
     private ClusterService clusterService;
     private ActionFilters actionFilters;
@@ -104,11 +102,6 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
         );
 
         client = mock(Client.class);
-        threadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(threadPool);
-        Settings settings = Settings.builder().build();
-        threadContext = new ThreadContext(settings);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         actionFilters = mock(ActionFilters.class);
         searchHandler = mock(ADSearchHandler.class);
@@ -225,8 +218,7 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
                 Arrays.asList("test"),
                 mock(SearchRequest.class),
                 mock(PlainActionFuture.class),
-                false,
-                threadContext.stashContext()
+                false
             );
 
         verify(client).multiSearch(any(), any());

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -213,13 +213,7 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
 
     @Test
     public void testMultiSearch_NoOnlyQueryCustomResultIndex() {
-        action
-            .multiSearch(
-                Arrays.asList("test"),
-                mock(SearchRequest.class),
-                mock(PlainActionFuture.class),
-                false
-            );
+        action.multiSearch(Arrays.asList("test"), mock(SearchRequest.class), mock(PlainActionFuture.class), false);
 
         verify(client).multiSearch(any(), any());
     }

--- a/src/test/java/org/opensearch/ad/transport/handler/ADSearchHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/ADSearchHandlerTests.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.opensearch.ad.TestHelpers.matchAllRequest;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 
@@ -29,9 +28,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.commons.ConfigConstants;
-import org.opensearch.threadpool.ThreadPool;
 
 public class ADSearchHandlerTests extends ADUnitTestCase {
 
@@ -55,13 +51,6 @@ public class ADSearchHandlerTests extends ADUnitTestCase {
         clusterService = new ClusterService(settings, clusterSettings, null);
         client = mock(Client.class);
         searchHandler = new ADSearchHandler(settings, clusterService, client);
-
-        ThreadContext threadContext = new ThreadContext(settings);
-        threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
-        org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(mockThreadPool);
-        when(client.threadPool().getThreadContext()).thenReturn(threadContext);
-        when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
 
         request = mock(SearchRequest.class);
         listener = mock(ActionListener.class);

--- a/src/test/java/org/opensearch/ad/transport/handler/AbstractIndexHandlerTest.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/AbstractIndexHandlerTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractIndexHandlerTest extends AbstractADTest {
         MockitoAnnotations.initMocks(this);
         setWriteBlockAdResultIndex(false);
         context = TestHelpers.createThreadPool();
-        clientUtil = new ClientUtil(settings, client, throttler, context);
+        clientUtil = new ClientUtil(settings, client, throttler);
         indexUtil = new IndexUtils(client, clientUtil, clusterService, indexNameResolver);
     }
 

--- a/src/test/java/org/opensearch/ad/transport/handler/AnomalyResultBulkIndexHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/AnomalyResultBulkIndexHandlerTests.java
@@ -66,8 +66,7 @@ public class AnomalyResultBulkIndexHandlerTests extends ADUnitTestCase {
         Settings settings = Settings.EMPTY;
         Clock clock = mock(Clock.class);
         Throttler throttler = new Throttler(clock);
-        ThreadPool threadpool = mock(ThreadPool.class);
-        ClientUtil clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, threadpool);
+        ClientUtil clientUtil = new ClientUtil(Settings.EMPTY, client, throttler);
         indexUtils = mock(IndexUtils.class);
         ClusterService clusterService = mock(ClusterService.class);
         ThreadPool threadPool = mock(ThreadPool.class);

--- a/src/test/java/org/opensearch/ad/util/IndexUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/IndexUtilsTests.java
@@ -18,12 +18,10 @@ import java.time.Clock;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.ad.TestHelpers;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.threadpool.ThreadPool;
 
 public class IndexUtilsTests extends OpenSearchIntegTestCase {
 
@@ -36,8 +34,7 @@ public class IndexUtilsTests extends OpenSearchIntegTestCase {
         Client client = client();
         Clock clock = mock(Clock.class);
         Throttler throttler = new Throttler(clock);
-        ThreadPool context = TestHelpers.createThreadPool();
-        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, context);
+        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler);
         indexNameResolver = mock(IndexNameExpressionResolver.class);
     }
 


### PR DESCRIPTION
### Description
This PR removes all dependencies on the Common Utils Thread Context.  It was initially used for users and roles, with most of the user code removed in #617.  This cleans up the remaining (useless/unused) fetching of the thread context from the code.

The thread context was pulled from the ThreadPool, which is also no longer needed or desired in an extension and has been removed in most code.  

There is still a remaining threadpool parameter in the `createComponents()` method which inherits/overrides `Plugin` and saves it as a field in the runner object, but it is okay to ignore that and not use it in later code; eventually that will no longer be needed.  A thread pool is also part of the `Client` constructor and there is a `threadpool()` getter from it.  While it may be harmless to keep that method around I think having it throw an exception as unused, or be deprecated, would be preferable.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk/issues/22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
