### PR TITLE
make 1M1min possible

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -464,7 +464,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             checkpoint,
             CommonName.CHECKPOINT_INDEX_NAME,
             AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
-            getClock()
+            getClock(),
+            clusterService,
+            settings
         );
 
         CheckpointWriteWorker checkpointWriteQueue = new CheckpointWriteWorker(
@@ -522,7 +524,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             threadPool,
             checkpointWriteQueue,
             AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            checkpointMaintainQueue
+            checkpointMaintainQueue,
+            settings,
+            AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ
         );
 
         cacheProvider.set(cache);
@@ -580,7 +584,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
             entityColdStarter,
             featureManager,
-            memoryTracker
+            memoryTracker,
+            settings,
+            clusterService
         );
 
         MultiEntityResultHandler multiEntityResultHandler = new MultiEntityResultHandler(
@@ -613,56 +619,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             stateManager,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE
         );
-
-        CheckpointReadWorker checkpointReadQueue = new CheckpointReadWorker(
-            heapSizeBytes,
-            AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
-            clusterService,
-            random,
-            adCircuitBreakerService,
-            threadPool,
-            settings,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
-            getClock(),
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
-            modelManager,
-            checkpoint,
-            coldstartQueue,
-            resultWriteQueue,
-            stateManager,
-            anomalyDetectionIndices,
-            cacheProvider,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            checkpointWriteQueue
-        );
-
-        ColdEntityWorker coldEntityQueue = new ColdEntityWorker(
-            heapSizeBytes,
-            AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
-            clusterService,
-            random,
-            adCircuitBreakerService,
-            threadPool,
-            settings,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
-            getClock(),
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            checkpointReadQueue,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            stateManager
-        );
-
-        ADDataMigrator dataMigrator = new ADDataMigrator(client, clusterService, xContentRegistry, anomalyDetectionIndices);
-        HashRing hashRing = new HashRing(nodeFilter, getClock(), settings, client, clusterService, dataMigrator, modelManager);
-
-        anomalyDetectorRunner = new AnomalyDetectorRunner(modelManager, featureManager, AnomalyDetectorSettings.MAX_PREVIEW_RESULTS);
 
         Map<String, ADStat<?>> stats = ImmutableMap
             .<String, ADStat<?>>builder()
@@ -702,9 +658,61 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             .put(StatNames.AD_TOTAL_BATCH_TASK_EXECUTION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_BATCH_TASK_FAILURE_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.MODEL_COUNT.getName(), new ADStat<>(false, new ModelsOnNodeCountSupplier(modelManager, cacheProvider)))
+            .put(StatNames.MODEL_CORRUTPION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .build();
 
         adStats = new ADStats(stats);
+
+        CheckpointReadWorker checkpointReadQueue = new CheckpointReadWorker(
+            heapSizeBytes,
+            AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            getClock(),
+            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            modelManager,
+            checkpoint,
+            coldstartQueue,
+            resultWriteQueue,
+            stateManager,
+            anomalyDetectionIndices,
+            cacheProvider,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            checkpointWriteQueue,
+            adStats
+        );
+
+        ColdEntityWorker coldEntityQueue = new ColdEntityWorker(
+            heapSizeBytes,
+            AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            getClock(),
+            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            checkpointReadQueue,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            stateManager
+        );
+
+        ADDataMigrator dataMigrator = new ADDataMigrator(client, clusterService, xContentRegistry, anomalyDetectionIndices);
+        HashRing hashRing = new HashRing(nodeFilter, getClock(), settings, client, clusterService, dataMigrator, modelManager);
+
+        anomalyDetectorRunner = new AnomalyDetectorRunner(modelManager, featureManager, AnomalyDetectorSettings.MAX_PREVIEW_RESULTS);
 
         adTaskCacheManager = new ADTaskCacheManager(settings, clusterService, memoryTracker);
         adTaskManager = new ADTaskManager(
@@ -764,7 +772,16 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ADClusterEventListener(clusterService, hashRing),
                 adCircuitBreakerService,
                 adStats,
-                new ClusterManagerEventListener(clusterService, threadPool, client, getClock(), clientUtil, nodeFilter),
+                new ClusterManagerEventListener(
+                    clusterService,
+                    threadPool,
+                    client,
+                    getClock(),
+                    clientUtil,
+                    nodeFilter,
+                    AnomalyDetectorSettings.CHECKPOINT_TTL,
+                    settings
+                ),
                 nodeFilter,
                 multiEntityResultHandler,
                 checkpoint,
@@ -892,8 +909,10 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
                 AnomalyDetectorSettings.CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
                 AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
-                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS,
-                AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS,
+                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
+                AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_MILLISECS,
+                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
+                AnomalyDetectorSettings.CHECKPOINT_TTL,
                 // query limit
                 LegacyOpenDistroAnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY,
                 LegacyOpenDistroAnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW,

--- a/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
@@ -32,8 +32,12 @@ import org.opensearch.ad.MemoryTracker.Origin;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.InitProgressProfile;
+import org.opensearch.ad.ratelimit.CheckpointMaintainRequest;
+import org.opensearch.ad.ratelimit.CheckpointMaintainWorker;
 import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
 import org.opensearch.ad.ratelimit.RequestPriority;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.util.DateUtils;
 
 /**
  * We use a layered cache to manage active entities’ states.  We have a two-level
@@ -75,7 +79,9 @@ public class CacheBuffer implements ExpiringState {
     private final PriorityTracker priorityTracker;
     private final Clock clock;
     private final CheckpointWriteWorker checkpointWriteQueue;
+    private final CheckpointMaintainWorker checkpointMaintainQueue;
     private final Random random;
+    private final int checkpointIntervalHrs;
 
     public CacheBuffer(
         int minimumCapacity,
@@ -86,7 +92,8 @@ public class CacheBuffer implements ExpiringState {
         Duration modelTtl,
         String detectorId,
         CheckpointWriteWorker checkpointWriteQueue,
-        Random random
+        Random random,
+        CheckpointMaintainWorker checkpointMaintainQueue
     ) {
         this.memoryConsumptionPerEntity = memoryConsumptionPerEntity;
         setMinimumCapacity(minimumCapacity);
@@ -102,6 +109,8 @@ public class CacheBuffer implements ExpiringState {
         this.priorityTracker = new PriorityTracker(clock, intervalSecs, clock.instant().getEpochSecond(), MAX_TRACKING_ENTITIES);
         this.checkpointWriteQueue = checkpointWriteQueue;
         this.random = random;
+        this.checkpointMaintainQueue = checkpointMaintainQueue;
+        this.checkpointIntervalHrs = AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ.toHoursPart();
     }
 
     /**
@@ -182,6 +191,26 @@ public class CacheBuffer implements ExpiringState {
     }
 
     /**
+     * Retrieve the ModelState associated with the model Id or null if the CacheBuffer
+     * contains no mapping for the model Id. Compared to get method, the method won't
+     * increment entity priority. Used in cache buffer maintenance.
+     *
+     * @param key the model Id
+     * @return the Model state to which the specified model Id is mapped, or null
+     * if this CacheBuffer contains no mapping for the model Id
+     */
+    public ModelState<EntityModel> getWithoutUpdatePriority(String key) {
+        // We can get an item that is to be removed soon due to race condition.
+        // This is acceptable as it won't cause any corruption and exception.
+        // And this item is used for scoring one last time.
+        ModelState<EntityModel> node = items.get(key);
+        if (node == null) {
+            return null;
+        }
+        return node;
+    }
+
+    /**
      *
      * @return whether there is one item that can be removed from shared cache
      */
@@ -220,6 +249,18 @@ public class CacheBuffer implements ExpiringState {
      * is no associated ModelState for the key
      */
     public ModelState<EntityModel> remove(String keyToRemove) {
+        return remove(keyToRemove, true);
+    }
+
+    /**
+     * Remove everything associated with the key and make a checkpoint if input specified so.
+     *
+     * @param keyToRemove The key to remove
+     * @param saveCheckpoint Whether saving checkpoint or not
+     * @return the associated ModelState associated with the key, or null if there
+     * is no associated ModelState for the key
+     */
+    public ModelState<EntityModel> remove(String keyToRemove, boolean saveCheckpoint) {
         priorityTracker.removePriority(keyToRemove);
 
         // if shared cache is empty, we are using reserved memory
@@ -235,11 +276,13 @@ public class CacheBuffer implements ExpiringState {
 
             EntityModel modelRemoved = valueRemoved.getModel();
             if (modelRemoved != null) {
-                // null model has only samples. For null model we save a checkpoint
-                // regardless of last checkpoint time. whether If we don't save,
-                // we throw the new samples and might never be able to initialize the model
-                boolean isNullModel = !modelRemoved.getTrcf().isPresent();
-                checkpointWriteQueue.write(valueRemoved, isNullModel, RequestPriority.MEDIUM);
+                if (saveCheckpoint) {
+                    // null model has only samples. For null model we save a checkpoint
+                    // regardless of last checkpoint time. whether If we don't save,
+                    // we throw the new samples and might never be able to initialize the model
+                    boolean isNullModel = !modelRemoved.getTrcf().isPresent();
+                    checkpointWriteQueue.write(valueRemoved, isNullModel, RequestPriority.MEDIUM);
+                }
 
                 modelRemoved.clear();
             }
@@ -304,13 +347,16 @@ public class CacheBuffer implements ExpiringState {
      * @return removed states
      */
     public List<ModelState<EntityModel>> maintenance() {
-        List<ModelState<EntityModel>> modelsToSave = new ArrayList<>();
+        List<CheckpointMaintainRequest> modelsToSave = new ArrayList<>();
         List<ModelState<EntityModel>> removedStates = new ArrayList<>();
+        Instant now = clock.instant();
+        int currentHour = DateUtils.getHourOfDay(now);
+        int currentSlot = currentHour % checkpointIntervalHrs;
         items.entrySet().stream().forEach(entry -> {
             String entityModelId = entry.getKey();
             try {
                 ModelState<EntityModel> modelState = entry.getValue();
-                Instant now = clock.instant();
+
                 if (modelState.getLastUsedTime().plus(modelTtl).isBefore(now)) {
                     // race conditions can happen between the put and one of the following operations:
                     // remove: not a problem as all of the data structures are concurrent.
@@ -322,7 +368,7 @@ public class CacheBuffer implements ExpiringState {
                     // already in the cache
                     // remove method saves checkpoint as well
                     removedStates.add(remove(entityModelId));
-                } else if (random.nextInt(6) == 0) {
+                } else if (Math.abs(entityModelId.hashCode()) % checkpointIntervalHrs == currentSlot) {
                     // checkpoint is relatively big compared to other queued requests
                     // save checkpoints with 1/6 probability as we expect to save
                     // all every 6 hours statistically
@@ -350,7 +396,16 @@ public class CacheBuffer implements ExpiringState {
                     // is stale (i.e., we don't recover from the freshest model in disaster.).
                     //
                     // All in all, randomness is mostly due to performance and easy maintenance.
-                    modelsToSave.add(modelState);
+                    modelsToSave
+                        .add(
+                            new CheckpointMaintainRequest(
+                                // the request expires when the next maintainance starts
+                                System.currentTimeMillis() + modelTtl.toMillis(),
+                                detectorId,
+                                RequestPriority.LOW,
+                                entityModelId
+                            )
+                        );
                 }
 
             } catch (Exception e) {
@@ -358,7 +413,7 @@ public class CacheBuffer implements ExpiringState {
             }
         });
 
-        checkpointWriteQueue.writeAll(modelsToSave, detectorId, false, RequestPriority.MEDIUM);
+        checkpointMaintainQueue.putAll(modelsToSave);
         return removedStates;
     }
 

--- a/src/main/java/org/opensearch/ad/caching/CacheProvider.java
+++ b/src/main/java/org/opensearch/ad/caching/CacheProvider.java
@@ -22,12 +22,16 @@ import org.opensearch.common.inject.Provider;
 public class CacheProvider implements Provider<EntityCache> {
     private EntityCache cache;
 
-    public CacheProvider(EntityCache cache) {
-        this.cache = cache;
+    public CacheProvider() {
+
     }
 
     @Override
     public EntityCache get() {
         return cache;
+    }
+
+    public void set(EntityCache cache) {
+        this.cache = cache;
     }
 }

--- a/src/main/java/org/opensearch/ad/caching/DoorKeeper.java
+++ b/src/main/java/org/opensearch/ad/caching/DoorKeeper.java
@@ -15,6 +15,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.ExpiringState;
 import org.opensearch.ad.MaintenanceState;
 
@@ -29,6 +31,7 @@ import com.google.common.hash.Funnels;
  *
  */
 public class DoorKeeper implements MaintenanceState, ExpiringState {
+    private final Logger LOG = LogManager.getLogger(DoorKeeper.class);
     // stores entity's model id
     private BloomFilter<String> bloomFilter;
     // the number of expected insertions to the constructed BloomFilter<T>; must be positive
@@ -65,6 +68,7 @@ public class DoorKeeper implements MaintenanceState, ExpiringState {
     @Override
     public void maintenance() {
         if (bloomFilter == null || lastMaintenanceTime.plus(resetInterval).isBefore(clock.instant())) {
+            LOG.debug("maintaining for doorkeeper");
             bloomFilter = BloomFilter.create(Funnels.stringFunnel(Charsets.US_ASCII), expectedInsertions, fpp);
             lastMaintenanceTime = clock.instant();
         }

--- a/src/main/java/org/opensearch/ad/caching/EntityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/EntityCache.java
@@ -139,4 +139,19 @@ public interface EntityCache extends MaintenanceState, CleanState, DetectorModel
      * @return the entity's memory size
      */
     Optional<ModelProfile> getModelProfile(String detectorId, String entityModelId);
+
+    /**
+     * Get a model state without incurring priority update. Used in maintenance.
+     * @param detectorId Detector Id
+     * @param modelId Model Id
+     * @return Model state
+     */
+    Optional<ModelState<EntityModel>> getForMaintainance(String detectorId, String modelId);
+
+    /**
+     * Remove entity model from active entity buffer and delete checkpoint. Used to clean corrupted model.
+     * @param detectorId Detector Id
+     * @param entityModelId Model Id
+     */
+    void removeEntityModel(String detectorId, String entityModelId);
 }

--- a/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
@@ -67,6 +67,7 @@ public class CompositeRetriever extends AbstractRetriever {
     private final NamedXContentRegistry xContent;
     private final Client client;
     private int totalResults;
+    // we can process at most maxEntities entities
     private int maxEntities;
     private final int pageSize;
     private long expirationEpochMs;
@@ -174,11 +175,13 @@ public class CompositeRetriever extends AbstractRetriever {
         private Map<String, Object> afterKey;
         // number of iterations so far
         private int iterations;
+        private long startMs;
 
         public PageIterator(SearchSourceBuilder source) {
             this.source = source;
             this.afterKey = null;
             this.iterations = 0;
+            this.startMs = clock.millis();
         }
 
         /**
@@ -210,13 +213,10 @@ public class CompositeRetriever extends AbstractRetriever {
                 }
 
                 Page page = analyzePage(response);
-                // we can process at most maxEntities entities
-                if (totalResults <= maxEntities && afterKey != null) {
+                if (afterKey != null) {
                     updateCompositeAfterKey(response, source);
-                    listener.onResponse(page);
-                } else {
-                    listener.onResponse(null);
                 }
+                listener.onResponse(page);
             } catch (Exception ex) {
                 listener.onFailure(ex);
             }
@@ -342,7 +342,14 @@ public class CompositeRetriever extends AbstractRetriever {
          * @return true if the iteration has more pages.
          */
         public boolean hasNext() {
-            return (iterations == 0 || (totalResults > 0 && afterKey != null)) && expirationEpochMs > clock.millis();
+            long now = clock.millis();
+            if (expirationEpochMs <= now) {
+                LOG.info("Time is up, afterKey: " + afterKey + " " + expirationEpochMs + " " + now);
+            }
+            if ((iterations > 0 && afterKey == null) || totalResults > maxEntities) {
+                LOG.info("Finished in " + (now - startMs) + " msecs. ");
+            }
+            return (iterations == 0 || (totalResults > 0 && afterKey != null)) && expirationEpochMs > now && totalResults <= maxEntities;
         }
 
         @Override

--- a/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -344,10 +345,18 @@ public class CompositeRetriever extends AbstractRetriever {
         public boolean hasNext() {
             long now = clock.millis();
             if (expirationEpochMs <= now) {
-                LOG.info("Time is up, afterKey: " + afterKey + " " + expirationEpochMs + " " + now);
+                LOG
+                    .debug(
+                        new ParameterizedMessage(
+                            "Time is up, afterKey: [{}], expirationEpochMs: [{}], now [{}]",
+                            afterKey,
+                            expirationEpochMs,
+                            now
+                        )
+                    );
             }
             if ((iterations > 0 && afterKey == null) || totalResults > maxEntities) {
-                LOG.info("Finished in " + (now - startMs) + " msecs. ");
+                LOG.debug(new ParameterizedMessage("Finished in [{}] msecs. ", (now - startMs)));
             }
             return (iterations == 0 || (totalResults > 0 && afterKey != null)) && expirationEpochMs > now && totalResults <= maxEntities;
         }

--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
 import org.opensearch.ad.DetectorModelSize;
 import org.opensearch.ad.MemoryTracker;
@@ -721,7 +722,17 @@ public class ModelManager implements DetectorModelSize {
                 result = toResult(trcf.getForest(), trcf.process(feature, 0));
             }
         } catch (Exception e) {
-            logger.error("Fail to score", e);
+            logger
+                .error(
+                    new ParameterizedMessage(
+                        "Fail to score for [{}]: model Id [{}], feature [{}]",
+                        modelState.getModel().getEntity(),
+                        modelId,
+                        Arrays.toString(feature)
+                    ),
+                    e
+                );
+            throw e;
         } finally {
             modelState.setLastUsedTime(clock.instant());
         }

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckPointMaintainRequestAdapter.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckPointMaintainRequestAdapter.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.ad.caching.CacheProvider;
+import org.opensearch.ad.ml.CheckpointDao;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.common.Strings;
+
+public class CheckPointMaintainRequestAdapter {
+    private static final Logger LOG = LogManager.getLogger(CheckPointMaintainRequestAdapter.class);
+    private CacheProvider cache;
+    private CheckpointDao checkpointDao;
+    private String indexName;
+    private Duration checkpointInterval;
+    private Clock clock;
+
+    public CheckPointMaintainRequestAdapter(
+        CacheProvider cache,
+        CheckpointDao checkpointDao,
+        String indexName,
+        Duration checkpointInterval,
+        Clock clock
+    ) {
+        this.cache = cache;
+        this.checkpointDao = checkpointDao;
+        this.indexName = indexName;
+        this.checkpointInterval = checkpointInterval;
+        this.clock = clock;
+    }
+
+    public Optional<CheckpointWriteRequest> convert(CheckpointMaintainRequest request) {
+        String detectorId = request.getDetectorId();
+        String modelId = request.getEntityModelId();
+
+        Optional<ModelState<EntityModel>> stateToMaintain = cache.get().getForMaintainance(detectorId, modelId);
+        if (!stateToMaintain.isEmpty()) {
+            ModelState<EntityModel> state = stateToMaintain.get();
+            Instant instant = state.getLastCheckpointTime();
+            if (!checkpointDao.shouldSave(instant, false, checkpointInterval, clock)) {
+                return Optional.empty();
+            }
+
+            try {
+                Map<String, Object> source = checkpointDao.toIndexSource(state);
+
+                // the model state is bloated or empty (empty samples and models), skip
+                if (source == null || source.isEmpty() || Strings.isEmpty(modelId)) {
+                    return Optional.empty();
+                }
+
+                return Optional
+                    .of(
+                        new CheckpointWriteRequest(
+                            request.getExpirationEpochMs(),
+                            detectorId,
+                            request.getPriority(),
+                            // If the document does not already exist, the contents of the upsert element
+                            // are inserted as a new document.
+                            // If the document exists, update fields in the map
+                            new UpdateRequest(indexName, modelId).docAsUpsert(true).doc(source)
+                        )
+                    );
+            } catch (Exception e) {
+                // Example exception:
+                // ConcurrentModificationException when calling toIndexSource
+                // and updating rcf model at the same time. To prevent this,
+                // we need to have a deep copy of models or have a lock. Both
+                // options are costly.
+                // As we are gonna retry serializing either when the entity is
+                // evicted out of cache or during the next maintenance period,
+                // don't do anything when the exception happens.
+                LOG.error(new ParameterizedMessage("Exception while serializing models for [{}]", modelId), e);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainRequest.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainRequest.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+public class CheckpointMaintainRequest extends QueuedRequest {
+    private String entityModelId;
+
+    public CheckpointMaintainRequest(long expirationEpochMs, String detectorId, RequestPriority priority, String entityModelId) {
+        super(expirationEpochMs, detectorId, priority);
+        this.entityModelId = entityModelId;
+    }
+
+    public String getEntityModelId() {
+        return entityModelId;
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorker.java
@@ -12,7 +12,7 @@
 package org.opensearch.ad.ratelimit;
 
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_MILLISECS;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -79,10 +79,14 @@ public class CheckpointMaintainWorker extends ScheduledWorker<CheckpointMaintain
         this.batchSize = CHECKPOINT_WRITE_QUEUE_BATCH_SIZE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(CHECKPOINT_WRITE_QUEUE_BATCH_SIZE, it -> this.batchSize = it);
 
-        this.expectedExecutionTimeInSecsPerRequest = AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS.get(settings);
+        this.expectedExecutionTimeInMilliSecsPerRequest = AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_MILLISECS
+            .get(settings);
         clusterService
             .getClusterSettings()
-            .addSettingsUpdateConsumer(EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS, it -> this.expectedExecutionTimeInSecsPerRequest = it);
+            .addSettingsUpdateConsumer(
+                EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_MILLISECS,
+                it -> this.expectedExecutionTimeInMilliSecsPerRequest = it
+            );
         this.adapter = adapter;
     }
 

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorker.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+
+public class CheckpointMaintainWorker extends ScheduledWorker<CheckpointMaintainRequest, CheckpointWriteRequest> {
+    private static final Logger LOG = LogManager.getLogger(CheckpointMaintainWorker.class);
+    public static final String WORKER_NAME = "checkpoint-maintain";
+
+    private CheckPointMaintainRequestAdapter adapter;
+
+    public CheckpointMaintainWorker(
+        long heapSizeInBytes,
+        int singleRequestSizeInBytes,
+        Setting<Float> maxHeapPercentForQueueSetting,
+        ClusterService clusterService,
+        Random random,
+        ADCircuitBreakerService adCircuitBreakerService,
+        ThreadPool threadPool,
+        Settings settings,
+        float maxQueuedTaskRatio,
+        Clock clock,
+        float mediumSegmentPruneRatio,
+        float lowSegmentPruneRatio,
+        int maintenanceFreqConstant,
+        CheckpointWriteWorker checkpointWriteQueue,
+        Duration stateTtl,
+        NodeStateManager nodeStateManager,
+        CheckPointMaintainRequestAdapter adapter
+    ) {
+        super(
+            WORKER_NAME,
+            heapSizeInBytes,
+            singleRequestSizeInBytes,
+            maxHeapPercentForQueueSetting,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            maxQueuedTaskRatio,
+            clock,
+            mediumSegmentPruneRatio,
+            lowSegmentPruneRatio,
+            maintenanceFreqConstant,
+            checkpointWriteQueue,
+            stateTtl,
+            nodeStateManager
+        );
+
+        this.batchSize = CHECKPOINT_WRITE_QUEUE_BATCH_SIZE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(CHECKPOINT_WRITE_QUEUE_BATCH_SIZE, it -> this.batchSize = it);
+
+        this.expectedExecutionTimeInSecsPerRequest = AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS, it -> this.expectedExecutionTimeInSecsPerRequest = it);
+        this.adapter = adapter;
+    }
+
+    @Override
+    protected List<CheckpointWriteRequest> transformRequests(List<CheckpointMaintainRequest> requests) {
+        List<CheckpointWriteRequest> allRequests = new ArrayList<>();
+        for (CheckpointMaintainRequest request : requests) {
+            Optional<CheckpointWriteRequest> converted = adapter.convert(request);
+            if (!converted.isEmpty()) {
+                allRequests.add(converted.get());
+            }
+        }
+        return allRequests;
+    }
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
@@ -152,7 +152,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
      */
     public void write(ModelState<EntityModel> modelState, boolean forceWrite, RequestPriority priority) {
         Instant instant = modelState.getLastCheckpointTime();
-        if (!shouldSave(instant, forceWrite)) {
+        if (!checkpoint.shouldSave(instant, forceWrite, checkpointInterval, clock)) {
             return;
         }
 
@@ -227,7 +227,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
                 List<CheckpointWriteRequest> allRequests = new ArrayList<>();
                 for (ModelState<EntityModel> state : modelStates) {
                     Instant instant = state.getLastCheckpointTime();
-                    if (!shouldSave(instant, forceWrite)) {
+                    if (!checkpoint.shouldSave(instant, forceWrite, checkpointInterval, clock)) {
                         continue;
                     }
 
@@ -270,16 +270,5 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
         }, exception -> { LOG.error(new ParameterizedMessage("fail to get detector [{}]", detectorId), exception); });
 
         nodeStateManager.getAnomalyDetector(detectorId, onGetForAll);
-    }
-
-    /**
-     * Should we save the checkpoint or not
-     * @param lastCheckpointTIme Last checkpoint time
-     * @param forceWrite Save no matter what
-     * @return true when forceWrite is true or we haven't saved checkpoint in the
-     *  last checkpoint interval; false otherwise
-     */
-    private boolean shouldSave(Instant lastCheckpointTIme, boolean forceWrite) {
-        return (lastCheckpointTIme != Instant.MIN && lastCheckpointTIme.plus(checkpointInterval).isBefore(clock.instant())) || forceWrite;
     }
 }

--- a/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
@@ -20,16 +20,12 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.ThreadPool;
 
 /**
@@ -47,15 +43,8 @@ import org.opensearch.threadpool.ThreadPool;
  * entity requests. 
  *
  */
-public class ColdEntityWorker extends RateLimitedRequestWorker<EntityFeatureRequest> {
-    private static final Logger LOG = LogManager.getLogger(ColdEntityWorker.class);
+public class ColdEntityWorker extends ScheduledWorker<EntityFeatureRequest, EntityFeatureRequest> {
     public static final String WORKER_NAME = "cold-entity";
-
-    private volatile int batchSize;
-    private final CheckpointReadWorker checkpointReadQueue;
-    // indicate whether a future pull over cold entity queues is scheduled
-    private boolean scheduled;
-    private volatile int expectedExecutionTimeInSecsPerRequest;
 
     public ColdEntityWorker(
         long heapSizeInBytes,
@@ -90,6 +79,7 @@ public class ColdEntityWorker extends RateLimitedRequestWorker<EntityFeatureRequ
             mediumSegmentPruneRatio,
             lowSegmentPruneRatio,
             maintenanceFreqConstant,
+            checkpointReadQueue,
             stateTtl,
             nodeStateManager
         );
@@ -97,82 +87,15 @@ public class ColdEntityWorker extends RateLimitedRequestWorker<EntityFeatureRequ
         this.batchSize = CHECKPOINT_READ_QUEUE_BATCH_SIZE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(CHECKPOINT_READ_QUEUE_BATCH_SIZE, it -> this.batchSize = it);
 
-        this.checkpointReadQueue = checkpointReadQueue;
-        this.scheduled = false;
-
         this.expectedExecutionTimeInSecsPerRequest = AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS.get(settings);
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS, it -> this.expectedExecutionTimeInSecsPerRequest = it);
     }
 
-    private void pullRequests() {
-        int pulledRequestSize = 0;
-        int filteredRequestSize = 0;
-        try {
-            List<EntityFeatureRequest> requests = getRequests(batchSize);
-            if (requests == null || requests.isEmpty()) {
-                return;
-            }
-            // pulledRequestSize > batchSize means there are more requests in the queue
-            pulledRequestSize = requests.size();
-            // guarantee we only send low priority requests
-            List<EntityFeatureRequest> filteredRequests = requests
-                .stream()
-                .filter(request -> request.priority == RequestPriority.LOW)
-                .collect(Collectors.toList());
-            if (!filteredRequests.isEmpty()) {
-                checkpointReadQueue.putAll(filteredRequests);
-                filteredRequestSize = filteredRequests.size();
-            }
-        } catch (Exception e) {
-            LOG.error("Error enqueuing cold entity requests", e);
-        } finally {
-            if (pulledRequestSize < batchSize) {
-                scheduled = false;
-            } else {
-                // there might be more to fetch
-                // schedule a pull from queue every few seconds.
-                scheduled = true;
-                if (filteredRequestSize == 0) {
-                    pullRequests();
-                } else {
-                    schedulePulling(getScheduleDelay(filteredRequestSize));
-                }
-            }
-        }
-    }
-
-    private synchronized void schedulePulling(TimeValue delay) {
-        try {
-            threadPool.schedule(this::pullRequests, delay, AnomalyDetectorPlugin.AD_THREAD_POOL_NAME);
-        } catch (Exception e) {
-            LOG.error("Fail to schedule cold entity pulling", e);
-        }
-    }
-
-    /**
-     * only pull requests to process when there's no other scheduled run
-     */
     @Override
-    protected void triggerProcess() {
-        if (false == scheduled) {
-            pullRequests();
-        }
-    }
-
-    /**
-     * The method calculates the delay we have to set to control the rate of cold
-     * entity processing. We wait longer if the requestSize is larger to give the
-     * system more time to processing requests.  We ddd randomness to cope with the
-     * case that we want to execute at least 1 request every few seconds, but
-     * cannot guarantee that.
-     * @param requestSize requests to process
-     * @return the delay for the next scheduled run
-     */
-    private TimeValue getScheduleDelay(int requestSize) {
-        int expectedSingleRequestExecutionMillis = 1000 * expectedExecutionTimeInSecsPerRequest;
-        int waitMilliSeconds = requestSize * expectedSingleRequestExecutionMillis;
-        return TimeValue.timeValueMillis(waitMilliSeconds + random.nextInt(waitMilliSeconds));
+    protected List<EntityFeatureRequest> transformRequests(List<EntityFeatureRequest> requests) {
+        // guarantee we only send low priority requests
+        return requests.stream().filter(request -> request.priority == RequestPriority.LOW).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
@@ -12,7 +12,7 @@
 package org.opensearch.ad.ratelimit;
 
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_BATCH_SIZE;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -87,10 +87,14 @@ public class ColdEntityWorker extends ScheduledWorker<EntityFeatureRequest, Enti
         this.batchSize = CHECKPOINT_READ_QUEUE_BATCH_SIZE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(CHECKPOINT_READ_QUEUE_BATCH_SIZE, it -> this.batchSize = it);
 
-        this.expectedExecutionTimeInSecsPerRequest = AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS.get(settings);
+        this.expectedExecutionTimeInMilliSecsPerRequest = AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS
+            .get(settings);
         clusterService
             .getClusterSettings()
-            .addSettingsUpdateConsumer(EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS, it -> this.expectedExecutionTimeInSecsPerRequest = it);
+            .addSettingsUpdateConsumer(
+                EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
+                it -> this.expectedExecutionTimeInMilliSecsPerRequest = it
+            );
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/ratelimit/RateLimitedRequestWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/RateLimitedRequestWorker.java
@@ -324,6 +324,7 @@ public abstract class RateLimitedRequestWorker<RequestType extends QueuedRequest
                 int maxQueueSize = (int) (maxQueuedTaskRatio * threadPool.info(name).getQueueSize().singles());
                 // in case that users set queue size to -1 (unbounded)
                 if (maxQueueSize > 0 && stats.getQueue() > maxQueueSize) {
+                    LOG.info(new ParameterizedMessage("Queue [{}] size [{}], reached limit [{}]", name, stats.getQueue(), maxQueueSize));
                     setCoolDownStart();
                     break;
                 }

--- a/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.threadpool.ThreadPool;
+
+public abstract class ScheduledWorker<RequestType extends QueuedRequest, TransformedRequestType extends QueuedRequest> extends
+    RateLimitedRequestWorker<RequestType> {
+    private static final Logger LOG = LogManager.getLogger(ColdEntityWorker.class);
+
+    // the number of requests forwarded to the target queue
+    protected volatile int batchSize;
+    private final RateLimitedRequestWorker<TransformedRequestType> targetQueue;
+    // indicate whether a future pull over cold entity queues is scheduled
+    private boolean scheduled;
+    protected volatile int expectedExecutionTimeInSecsPerRequest;
+
+    public ScheduledWorker(
+        String workerName,
+        long heapSizeInBytes,
+        int singleRequestSizeInBytes,
+        Setting<Float> maxHeapPercentForQueueSetting,
+        ClusterService clusterService,
+        Random random,
+        ADCircuitBreakerService adCircuitBreakerService,
+        ThreadPool threadPool,
+        Settings settings,
+        float maxQueuedTaskRatio,
+        Clock clock,
+        float mediumSegmentPruneRatio,
+        float lowSegmentPruneRatio,
+        int maintenanceFreqConstant,
+        RateLimitedRequestWorker<TransformedRequestType> targetQueue,
+        Duration stateTtl,
+        NodeStateManager nodeStateManager
+    ) {
+        super(
+            workerName,
+            heapSizeInBytes,
+            singleRequestSizeInBytes,
+            maxHeapPercentForQueueSetting,
+            clusterService,
+            random,
+            adCircuitBreakerService,
+            threadPool,
+            settings,
+            maxQueuedTaskRatio,
+            clock,
+            mediumSegmentPruneRatio,
+            lowSegmentPruneRatio,
+            maintenanceFreqConstant,
+            stateTtl,
+            nodeStateManager
+        );
+
+        this.targetQueue = targetQueue;
+        this.scheduled = false;
+    }
+
+    private void pullRequests() {
+        int pulledRequestSize = 0;
+        int filteredRequestSize = 0;
+        try {
+            List<RequestType> requests = getRequests(batchSize);
+            if (requests == null || requests.isEmpty()) {
+                return;
+            }
+            pulledRequestSize = requests.size();
+            List<TransformedRequestType> filteredRequests = transformRequests(requests);
+            if (!filteredRequests.isEmpty()) {
+                targetQueue.putAll(filteredRequests);
+                filteredRequestSize = filteredRequests.size();
+            }
+        } catch (Exception e) {
+            LOG.error("Error enqueuing cold entity requests", e);
+        } finally {
+            if (pulledRequestSize < batchSize) {
+                scheduled = false;
+            } else {
+                // there might be more to fetch
+                // schedule a pull from queue every few seconds.
+                scheduled = true;
+                if (filteredRequestSize == 0) {
+                    pullRequests();
+                } else {
+                    schedulePulling(getScheduleDelay(filteredRequestSize));
+                }
+            }
+        }
+    }
+
+    private synchronized void schedulePulling(TimeValue delay) {
+        try {
+            threadPool.schedule(this::pullRequests, delay, AnomalyDetectorPlugin.AD_THREAD_POOL_NAME);
+        } catch (Exception e) {
+            LOG.error("Fail to schedule cold entity pulling", e);
+        }
+    }
+
+    /**
+     * only pull requests to process when there's no other scheduled run
+     */
+    @Override
+    protected void triggerProcess() {
+        if (false == scheduled) {
+            pullRequests();
+        }
+    }
+
+    /**
+     * The method calculates the delay we have to set to control the rate of cold
+     * entity processing. We wait longer if the requestSize is larger to give the
+     * system more time to processing requests.  We ddd randomness to cope with the
+     * case that we want to execute at least 1 request every few seconds, but
+     * cannot guarantee that.
+     * @param requestSize requests to process
+     * @return the delay for the next scheduled run
+     */
+    private TimeValue getScheduleDelay(int requestSize) {
+        int expectedSingleRequestExecutionMillis = 1000 * expectedExecutionTimeInSecsPerRequest;
+        int waitMilliSeconds = requestSize * expectedSingleRequestExecutionMillis;
+        return TimeValue.timeValueMillis(waitMilliSeconds + random.nextInt(waitMilliSeconds));
+    }
+
+    /**
+     * Transform requests before forwarding to another queue
+     * @param requests requests to be transformed
+     *
+     * @return processed requests
+     */
+    protected abstract List<TransformedRequestType> transformRequests(List<RequestType> requests);
+}

--- a/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
@@ -133,16 +133,14 @@ public abstract class ScheduledWorker<RequestType extends QueuedRequest, Transfo
     /**
      * The method calculates the delay we have to set to control the rate of cold
      * entity processing. We wait longer if the requestSize is larger to give the
-     * system more time to processing requests.  We ddd randomness to cope with the
-     * case that we want to execute at least 1 request every few seconds, but
-     * cannot guarantee that.
+     * system more time to processing requests.
      * @param requestSize requests to process
      * @return the delay for the next scheduled run
      */
     private TimeValue getScheduleDelay(int requestSize) {
         int expectedSingleRequestExecutionMillis = 1000 * expectedExecutionTimeInSecsPerRequest;
         int waitMilliSeconds = requestSize * expectedSingleRequestExecutionMillis;
-        return TimeValue.timeValueMillis(waitMilliSeconds + random.nextInt(waitMilliSeconds));
+        return TimeValue.timeValueMillis(waitMilliSeconds);
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
@@ -36,7 +36,7 @@ public abstract class ScheduledWorker<RequestType extends QueuedRequest, Transfo
     private final RateLimitedRequestWorker<TransformedRequestType> targetQueue;
     // indicate whether a future pull over cold entity queues is scheduled
     private boolean scheduled;
-    protected volatile int expectedExecutionTimeInSecsPerRequest;
+    protected volatile int expectedExecutionTimeInMilliSecsPerRequest;
 
     public ScheduledWorker(
         String workerName,
@@ -138,9 +138,7 @@ public abstract class ScheduledWorker<RequestType extends QueuedRequest, Transfo
      * @return the delay for the next scheduled run
      */
     private TimeValue getScheduleDelay(int requestSize) {
-        int expectedSingleRequestExecutionMillis = 1000 * expectedExecutionTimeInSecsPerRequest;
-        int waitMilliSeconds = requestSize * expectedSingleRequestExecutionMillis;
-        return TimeValue.timeValueMillis(waitMilliSeconds);
+        return TimeValue.timeValueMillis(requestSize * expectedExecutionTimeInMilliSecsPerRequest);
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -185,9 +185,21 @@ public final class AnomalyDetectorSettings {
     // In each hour, we roughly need to save 2400 models. Since each model saving can
     // take about 1 seconds (default value of AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS)
     // we can use up to 2400 seconds to finish saving checkpoints.
-    public static final Duration CHECKPOINT_SAVING_FREQ = Duration.ofHours(12);
+    public static final Setting<TimeValue> CHECKPOINT_SAVING_FREQ = Setting
+        .positiveTimeSetting(
+            "plugins.anomaly_detection.checkpoint_saving_freq",
+            TimeValue.timeValueHours(12),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 
-    public static final Duration CHECKPOINT_TTL = Duration.ofDays(7);
+    public static final Setting<TimeValue> CHECKPOINT_TTL = Setting
+        .positiveTimeSetting(
+            "plugins.anomaly_detection.checkpoint_ttl",
+            TimeValue.timeValueDays(7),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 
     // ======================================
     // ML parameters
@@ -525,12 +537,12 @@ public final class AnomalyDetectorSettings {
     // expected execution time per cold entity request. This setting controls
     // the speed of cold entity requests execution. The larger, the faster, and
     // the more performance impact to customers' workload.
-    public static final Setting<Integer> EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS = Setting
+    public static final Setting<Integer> EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS = Setting
         .intSetting(
-            "plugins.anomaly_detection.expected_cold_entity_execution_time_in_secs",
-            3,
+            "plugins.anomaly_detection.expected_cold_entity_execution_time_in_millisecs",
+            3000,
             0,
-            3600,
+            3600000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
@@ -538,12 +550,12 @@ public final class AnomalyDetectorSettings {
     // expected execution time per checkpoint maintain request. This setting controls
     // the speed of checkpoint maintenance execution. The larger, the faster, and
     // the more performance impact to customers' workload.
-    public static final Setting<Integer> EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS = Setting
+    public static final Setting<Integer> EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_MILLISECS = Setting
         .intSetting(
-            "plugins.anomaly_detection.expected_checkpoint_maintain_time_in_secs",
-            1,
+            "plugins.anomaly_detection.expected_checkpoint_maintain_time_in_millisecs",
+            1000,
             0,
-            3600,
+            3600000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -180,10 +180,14 @@ public final class AnomalyDetectorSettings {
 
     public static final Duration HOURLY_MAINTENANCE = Duration.ofHours(1);
 
-    // saving checkpoint every 6 hours.
-    public static final Duration CHECKPOINT_SAVING_FREQ = Duration.ofHours(6);
+    // saving checkpoint every 12 hours.
+    // To support 1 million entities in 36 data nodes, each node has roughly 28K models.
+    // In each hour, we roughly need to save 2400 models. Since each model saving can
+    // take about 1 seconds (default value of AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS)
+    // we can use up to 2400 seconds to finish saving checkpoints.
+    public static final Duration CHECKPOINT_SAVING_FREQ = Duration.ofHours(12);
 
-    public static final Duration CHECKPOINT_TTL = Duration.ofDays(3);
+    public static final Duration CHECKPOINT_TTL = Duration.ofDays(7);
 
     // ======================================
     // ML parameters
@@ -537,7 +541,7 @@ public final class AnomalyDetectorSettings {
     public static final Setting<Integer> EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS = Setting
         .intSetting(
             "plugins.anomaly_detection.expected_checkpoint_maintain_time_in_secs",
-            10,
+            1,
             0,
             3600,
             Setting.Property.NodeScope,

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -180,6 +180,9 @@ public final class AnomalyDetectorSettings {
 
     public static final Duration HOURLY_MAINTENANCE = Duration.ofHours(1);
 
+    // saving checkpoint every 6 hours.
+    public static final Duration CHECKPOINT_SAVING_FREQ = Duration.ofHours(6);
+
     public static final Duration CHECKPOINT_TTL = Duration.ofDays(3);
 
     // ======================================
@@ -367,9 +370,6 @@ public final class AnomalyDetectorSettings {
     // max entity value's length
     public static int MAX_ENTITY_LENGTH = 256;
 
-    // max number of index checkpoint requests in one bulk
-    public static int MAX_BULK_CHECKPOINT_SIZE = 1000;
-
     // number of bulk checkpoints per second
     public static double CHECKPOINT_BULK_PER_SECOND = 0.02;
 
@@ -509,6 +509,15 @@ public final class AnomalyDetectorSettings {
             Setting.Property.Dynamic
         );
 
+    public static final Setting<Float> CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT = Setting
+        .floatSetting(
+            "plugins.anomaly_detection.checkpoint_maintain_queue_max_heap_percent",
+            0.001f,
+            0.0f,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     // expected execution time per cold entity request. This setting controls
     // the speed of cold entity requests execution. The larger, the faster, and
     // the more performance impact to customers' workload.
@@ -516,6 +525,19 @@ public final class AnomalyDetectorSettings {
         .intSetting(
             "plugins.anomaly_detection.expected_cold_entity_execution_time_in_secs",
             3,
+            0,
+            3600,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    // expected execution time per checkpoint maintain request. This setting controls
+    // the speed of checkpoint maintenance execution. The larger, the faster, and
+    // the more performance impact to customers' workload.
+    public static final Setting<Integer> EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS = Setting
+        .intSetting(
+            "plugins.anomaly_detection.expected_checkpoint_maintain_time_in_secs",
+            10,
             0,
             3600,
             Setting.Property.NodeScope,
@@ -572,6 +594,18 @@ public final class AnomalyDetectorSettings {
      * 10^ 7 / 2.0 * 10^5 = 50
      */
     public static int CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES = 200_000;
+
+    /**
+     * CheckpointMaintainRequest has model Id (roughly 256 bytes), and QueuedRequest
+     * fields including detector Id(roughly 128 bytes), expirationEpochMs (long,
+     *  8 bytes), and priority (12 bytes).
+     * Plus Java object size (12 bytes), we have roughly 416 bytes per request.
+     * We don't want the total size exceeds 0.1% of the heap.
+     * We can have at most 0.1% heap / 416 = heap / 416,000.
+     * For t3.small, 0.1% heap is of 1MB. The queue's size is up to
+     * 10^ 6 / 416 = 2403
+     */
+    public static int CHECKPOINT_MAINTAIN_REQUEST_SIZE_IN_BYTES = 416;
 
     /**
      * Max concurrent entity cold starts per node
@@ -710,7 +744,7 @@ public final class AnomalyDetectorSettings {
     // within an interval, how many percents are used to process requests.
     // 1.0 means we use all of the detection interval to process requests.
     // to ensure we don't block next interval, it is better to set it less than 1.0.
-    public static final float INTERVAL_RATIO_FOR_REQUESTS = 0.8f;
+    public static final float INTERVAL_RATIO_FOR_REQUESTS = 0.9f;
 
     // ======================================
     // preview setting

--- a/src/main/java/org/opensearch/ad/stats/StatNames.java
+++ b/src/main/java/org/opensearch/ad/stats/StatNames.java
@@ -36,7 +36,8 @@ public enum StatNames {
     AD_CANCELED_BATCH_TASK_COUNT("ad_canceled_batch_task_count"),
     AD_TOTAL_BATCH_TASK_EXECUTION_COUNT("ad_total_batch_task_execution_count"),
     AD_BATCH_TASK_FAILURE_COUNT("ad_batch_task_failure_count"),
-    MODEL_COUNT("model_count");
+    MODEL_COUNT("model_count"),
+    MODEL_CORRUTPION_COUNT("model_corruption_count");
 
     private String name;
 

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -741,6 +741,9 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
             // we can have OpenSearchTimeoutException when a node tries to load RCF or
             // threshold model
             failure.set(new InternalFailure(adID, causeException));
+        } else if (causeException instanceof IllegalArgumentException) {
+            // we can have IllegalArgumentException when a model is corrupted
+            failure.set(new InternalFailure(adID, causeException));
         } else {
             // some unexpected bug occurred or cluster is unstable (e.g., ClusterBlockException) or index is red (e.g.
             // NoShardAvailableActionException) while predicting anomaly

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -46,6 +46,7 @@ import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.ratelimit.CheckpointReadWorker;
 import org.opensearch.ad.ratelimit.ColdEntityWorker;
+import org.opensearch.ad.ratelimit.EntityColdStartWorker;
 import org.opensearch.ad.ratelimit.EntityFeatureRequest;
 import org.opensearch.ad.ratelimit.RequestPriority;
 import org.opensearch.ad.ratelimit.ResultWriteRequest;
@@ -88,6 +89,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
     private CheckpointReadWorker checkpointReadQueue;
     private ColdEntityWorker coldEntityQueue;
     private ThreadPool threadPool;
+    private EntityColdStartWorker entityColdStartWorker;
 
     @Inject
     public EntityResultTransportAction(
@@ -101,7 +103,8 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         ResultWriteWorker resultWriteQueue,
         CheckpointReadWorker checkpointReadQueue,
         ColdEntityWorker coldEntityQueue,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        EntityColdStartWorker entityColdStartWorker
     ) {
         super(EntityResultAction.NAME, transportService, actionFilters, EntityResultRequest::new);
         this.modelManager = manager;
@@ -113,6 +116,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         this.checkpointReadQueue = checkpointReadQueue;
         this.coldEntityQueue = coldEntityQueue;
         this.threadPool = threadPool;
+        this.entityColdStartWorker = entityColdStartWorker;
     }
 
     @Override
@@ -158,14 +162,14 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
     ) {
         return ActionListener.wrap(detectorOptional -> {
             if (!detectorOptional.isPresent()) {
-                listener.onFailure(new EndRunException(detectorId, "AnomalyDetector is not available.", true));
+                listener.onFailure(new EndRunException(detectorId, "AnomalyDetector is not available.", false));
                 return;
             }
 
             AnomalyDetector detector = detectorOptional.get();
 
             if (request.getEntities() == null) {
-                listener.onResponse(null);
+                listener.onFailure(new EndRunException(detectorId, "Fail to get any entities from request.", false));
                 return;
             }
 
@@ -174,7 +178,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
             for (Entry<Entity, double[]> entityEntry : request.getEntities().entrySet()) {
                 Entity categoricalValues = entityEntry.getKey();
 
-                if (isEntityeFromOldNodeMsg(categoricalValues)
+                if (isEntityFromOldNodeMsg(categoricalValues)
                     && detector.getCategoryField() != null
                     && detector.getCategoryField().size() == 1) {
                     Map<String, String> attrValues = categoricalValues.getAttributes();
@@ -196,35 +200,51 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
                     cacheMissEntities.put(categoricalValues, datapoint);
                     continue;
                 }
-                ThresholdingResult result = modelManager
-                    .getAnomalyResultForEntity(datapoint, entityModel, modelId, categoricalValues, detector.getShingleSize());
-                // result.getRcfScore() = 0 means the model is not initialized
-                // result.getGrade() = 0 means it is not an anomaly
-                // So many OpenSearchRejectedExecutionException if we write no matter what
-                if (result.getRcfScore() > 0) {
-                    AnomalyResult resultToSave = result
-                        .toAnomalyResult(
-                            detector,
-                            Instant.ofEpochMilli(request.getStart()),
-                            Instant.ofEpochMilli(request.getEnd()),
-                            executionStartTime,
-                            Instant.now(),
-                            ParseUtils.getFeatureData(datapoint, detector),
-                            categoricalValues,
-                            indexUtil.getSchemaVersion(ADIndex.RESULT),
-                            modelId,
-                            null,
-                            null
-                        );
+                try {
+                    ThresholdingResult result = modelManager
+                        .getAnomalyResultForEntity(datapoint, entityModel, modelId, categoricalValues, detector.getShingleSize());
+                    // result.getRcfScore() = 0 means the model is not initialized
+                    // result.getGrade() = 0 means it is not an anomaly
+                    // So many OpenSearchRejectedExecutionException if we write no matter what
+                    if (result.getRcfScore() > 0) {
+                        AnomalyResult resultToSave = result
+                            .toAnomalyResult(
+                                detector,
+                                Instant.ofEpochMilli(request.getStart()),
+                                Instant.ofEpochMilli(request.getEnd()),
+                                executionStartTime,
+                                Instant.now(),
+                                ParseUtils.getFeatureData(datapoint, detector),
+                                categoricalValues,
+                                indexUtil.getSchemaVersion(ADIndex.RESULT),
+                                modelId,
+                                null,
+                                null
+                            );
 
-                    resultWriteQueue
+                        resultWriteQueue
+                            .put(
+                                new ResultWriteRequest(
+                                    System.currentTimeMillis() + detector.getDetectorIntervalInMilliseconds(),
+                                    detectorId,
+                                    result.getGrade() > 0 ? RequestPriority.HIGH : RequestPriority.MEDIUM,
+                                    resultToSave,
+                                    detector.getResultIndex()
+                                )
+                            );
+                    }
+                } catch (IllegalArgumentException e) {
+                    // fail to score likely due to model corruption. Re-cold start to recover.
+                    cache.get().removeEntityModel(detectorId, modelId);
+                    entityColdStartWorker
                         .put(
-                            new ResultWriteRequest(
+                            new EntityFeatureRequest(
                                 System.currentTimeMillis() + detector.getDetectorIntervalInMilliseconds(),
                                 detectorId,
-                                result.getGrade() > 0 ? RequestPriority.HIGH : RequestPriority.MEDIUM,
-                                resultToSave,
-                                detector.getResultIndex()
+                                RequestPriority.MEDIUM,
+                                categoricalValues,
+                                datapoint,
+                                request.getStart()
                             )
                         );
                 }
@@ -318,7 +338,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
      * @param categoricalValues deserialized Entity from inbound message.
      * @return Whether the received entity comes from an node that doesn't support multi-category fields.
      */
-    private boolean isEntityeFromOldNodeMsg(Entity categoricalValues) {
+    private boolean isEntityFromOldNodeMsg(Entity categoricalValues) {
         Map<String, String> attrValues = categoricalValues.getAttributes();
         return (attrValues != null && attrValues.containsKey(CommonName.EMPTY_FIELD));
     }

--- a/src/main/java/org/opensearch/ad/util/DateUtils.java
+++ b/src/main/java/org/opensearch/ad/util/DateUtils.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.util;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+
+public class DateUtils {
+    public static final ZoneId UTC = ZoneId.of("Z");
+
+    /**
+     * Get hour of day of the input time in UTC
+     * @param instant input time
+     *
+     * @return Hour of day
+     */
+    public static int getHourOfDay(Instant instant) {
+        ZonedDateTime time = ZonedDateTime.ofInstant(instant, UTC);
+        return time.get(ChronoField.HOUR_OF_DAY);
+    }
+}

--- a/src/main/java/org/opensearch/ad/util/DateUtils.java
+++ b/src/main/java/org/opensearch/ad/util/DateUtils.java
@@ -11,10 +11,13 @@
 
 package org.opensearch.ad.util;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
+
+import org.opensearch.common.unit.TimeValue;
 
 public class DateUtils {
     public static final ZoneId UTC = ZoneId.of("Z");
@@ -25,8 +28,12 @@ public class DateUtils {
      *
      * @return Hour of day
      */
-    public static int getHourOfDay(Instant instant) {
+    public static int getUTCHourOfDay(Instant instant) {
         ZonedDateTime time = ZonedDateTime.ofInstant(instant, UTC);
         return time.get(ChronoField.HOUR_OF_DAY);
+    }
+
+    public static Duration toDuration(TimeValue timeValue) {
+        return Duration.ofMillis(timeValue.millis());
     }
 }

--- a/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
+++ b/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
@@ -97,8 +97,8 @@ public class AbstractCacheTest extends AbstractADTest {
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             detectorId,
             checkpointWriteQueue,
-            new Random(42),
-            checkpointMaintainQueue
+            checkpointMaintainQueue,
+            Duration.ofHours(12).toHoursPart()
         );
 
         initialPriority = cacheBuffer.getPriorityTracker().getUpdatedPriority(0);

--- a/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
+++ b/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
@@ -29,6 +29,7 @@ import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
+import org.opensearch.ad.ratelimit.CheckpointMaintainWorker;
 import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 
@@ -45,6 +46,7 @@ public class AbstractCacheTest extends AbstractADTest {
     protected long memoryPerEntity;
     protected MemoryTracker memoryTracker;
     protected CheckpointWriteWorker checkpointWriteQueue;
+    protected CheckpointMaintainWorker checkpointMaintainQueue;
     protected Random random;
     protected int shingleSize;
 
@@ -84,6 +86,7 @@ public class AbstractCacheTest extends AbstractADTest {
         memoryTracker = mock(MemoryTracker.class);
 
         checkpointWriteQueue = mock(CheckpointWriteWorker.class);
+        checkpointMaintainQueue = mock(CheckpointMaintainWorker.class);
 
         cacheBuffer = new CacheBuffer(
             1,
@@ -94,7 +97,8 @@ public class AbstractCacheTest extends AbstractADTest {
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             detectorId,
             checkpointWriteQueue,
-            new Random(42)
+            new Random(42),
+            checkpointMaintainQueue
         );
 
         initialPriority = cacheBuffer.getPriorityTracker().getUpdatedPriority(0);

--- a/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
@@ -18,7 +18,9 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -67,7 +69,7 @@ import org.opensearch.threadpool.ThreadPool;
 public class PriorityCacheTests extends AbstractCacheTest {
     private static final Logger LOG = LogManager.getLogger(PriorityCacheTests.class);
 
-    EntityCache cacheProvider;
+    EntityCache entityCache;
     CheckpointDao checkpoint;
     ModelManager modelManager;
 
@@ -121,10 +123,13 @@ public class PriorityCacheTests extends AbstractCacheTest {
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             threadPool,
             checkpointWriteQueue,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            checkpointMaintainQueue
         );
 
-        cacheProvider = new CacheProvider(cache).get();
+        CacheProvider cacheProvider = new CacheProvider();
+        cacheProvider.set(cache);
+        entityCache = cacheProvider.get();
 
         when(memoryTracker.estimateTRCFModelSize(anyInt(), anyInt(), anyDouble(), anyInt(), anyBoolean())).thenReturn(memoryPerEntity);
         when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(true);
@@ -171,19 +176,22 @@ public class PriorityCacheTests extends AbstractCacheTest {
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             threadPool,
             checkpointWriteQueue,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            checkpointMaintainQueue
         );
 
-        cacheProvider = new CacheProvider(cache).get();
+        CacheProvider cacheProvider = new CacheProvider();
+        cacheProvider.set(cache);
+        entityCache = cacheProvider.get();
 
         // cache miss due to door keeper
-        assertEquals(null, cacheProvider.get(modelState1.getModelId(), detector));
+        assertEquals(null, entityCache.get(modelState1.getModelId(), detector));
         // cache miss due to empty cache
-        assertEquals(null, cacheProvider.get(modelState1.getModelId(), detector));
-        cacheProvider.hostIfPossible(detector, modelState1);
-        assertEquals(1, cacheProvider.getTotalActiveEntities());
-        assertEquals(1, cacheProvider.getAllModels().size());
-        ModelState<EntityModel> hitState = cacheProvider.get(modelState1.getModelId(), detector);
+        assertEquals(null, entityCache.get(modelState1.getModelId(), detector));
+        entityCache.hostIfPossible(detector, modelState1);
+        assertEquals(1, entityCache.getTotalActiveEntities());
+        assertEquals(1, entityCache.getAllModels().size());
+        ModelState<EntityModel> hitState = entityCache.get(modelState1.getModelId(), detector);
         assertEquals(detectorId, hitState.getDetectorId());
         EntityModel model = hitState.getModel();
         assertEquals(false, model.getTrcf().isPresent());
@@ -210,37 +218,37 @@ public class PriorityCacheTests extends AbstractCacheTest {
     public void testInActiveCache() {
         // make modelId1 has enough priority
         for (int i = 0; i < 10; i++) {
-            cacheProvider.get(modelId1, detector);
+            entityCache.get(modelId1, detector);
         }
-        assertTrue(cacheProvider.hostIfPossible(detector, modelState1));
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        assertTrue(entityCache.hostIfPossible(detector, modelState1));
+        assertEquals(1, entityCache.getActiveEntities(detectorId));
         when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
         for (int i = 0; i < 2; i++) {
-            assertEquals(null, cacheProvider.get(modelId2, detector));
+            assertEquals(null, entityCache.get(modelId2, detector));
         }
-        assertTrue(false == cacheProvider.hostIfPossible(detector, modelState2));
+        assertTrue(false == entityCache.hostIfPossible(detector, modelState2));
         // modelId2 gets put to inactive cache due to nothing in shared cache
         // and it cannot replace modelId1
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        assertEquals(1, entityCache.getActiveEntities(detectorId));
     }
 
     public void testSharedCache() {
         // make modelId1 has enough priority
         for (int i = 0; i < 10; i++) {
-            cacheProvider.get(modelId1, detector);
+            entityCache.get(modelId1, detector);
         }
-        cacheProvider.hostIfPossible(detector, modelState1);
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        entityCache.hostIfPossible(detector, modelState1);
+        assertEquals(1, entityCache.getActiveEntities(detectorId));
         when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
         for (int i = 0; i < 2; i++) {
-            cacheProvider.get(modelId2, detector);
+            entityCache.get(modelId2, detector);
         }
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState2);
         // modelId2 should be in shared cache
-        assertEquals(2, cacheProvider.getActiveEntities(detectorId));
+        assertEquals(2, entityCache.getActiveEntities(detectorId));
 
         for (int i = 0; i < 10; i++) {
-            cacheProvider.get(modelId3, detector2);
+            entityCache.get(modelId3, detector2);
         }
         modelState3 = new ModelState<>(
             new EntityModel(entity3, new ArrayDeque<>(), null),
@@ -251,12 +259,12 @@ public class PriorityCacheTests extends AbstractCacheTest {
             0
         );
 
-        cacheProvider.hostIfPossible(detector2, modelState3);
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId2));
+        entityCache.hostIfPossible(detector2, modelState3);
+        assertEquals(1, entityCache.getActiveEntities(detectorId2));
         when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
         for (int i = 0; i < 4; i++) {
             // replace modelId2 in shared cache
-            cacheProvider.get(modelId4, detector2);
+            entityCache.get(modelId4, detector2);
         }
         modelState4 = new ModelState<>(
             new EntityModel(entity4, new ArrayDeque<>(), null),
@@ -266,68 +274,68 @@ public class PriorityCacheTests extends AbstractCacheTest {
             clock,
             0
         );
-        cacheProvider.hostIfPossible(detector2, modelState4);
-        assertEquals(2, cacheProvider.getActiveEntities(detectorId2));
-        assertEquals(3, cacheProvider.getTotalActiveEntities());
-        assertEquals(3, cacheProvider.getAllModels().size());
+        entityCache.hostIfPossible(detector2, modelState4);
+        assertEquals(2, entityCache.getActiveEntities(detectorId2));
+        assertEquals(3, entityCache.getTotalActiveEntities());
+        assertEquals(3, entityCache.getAllModels().size());
 
         when(memoryTracker.memoryToShed()).thenReturn(memoryPerEntity);
-        cacheProvider.maintenance();
-        assertEquals(2, cacheProvider.getTotalActiveEntities());
-        assertEquals(2, cacheProvider.getAllModels().size());
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId2));
+        entityCache.maintenance();
+        assertEquals(2, entityCache.getTotalActiveEntities());
+        assertEquals(2, entityCache.getAllModels().size());
+        assertEquals(1, entityCache.getActiveEntities(detectorId2));
     }
 
     public void testReplace() {
         for (int i = 0; i < 2; i++) {
-            cacheProvider.get(modelState1.getModelId(), detector);
+            entityCache.get(modelState1.getModelId(), detector);
         }
 
-        cacheProvider.hostIfPossible(detector, modelState1);
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        entityCache.hostIfPossible(detector, modelState1);
+        assertEquals(1, entityCache.getActiveEntities(detectorId));
         when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
         ModelState<EntityModel> state = null;
 
         for (int i = 0; i < 4; i++) {
-            cacheProvider.get(modelId2, detector);
+            entityCache.get(modelId2, detector);
         }
 
         // emptyState2 replaced emptyState2
-        cacheProvider.hostIfPossible(detector, modelState2);
-        state = cacheProvider.get(modelId2, detector);
+        entityCache.hostIfPossible(detector, modelState2);
+        state = entityCache.get(modelId2, detector);
 
         assertEquals(modelId2, state.getModelId());
-        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        assertEquals(1, entityCache.getActiveEntities(detectorId));
     }
 
     public void testCannotAllocateBuffer() {
         when(memoryTracker.canAllocateReserved(anyLong())).thenReturn(false);
-        expectThrows(LimitExceededException.class, () -> cacheProvider.get(modelId1, detector));
+        expectThrows(LimitExceededException.class, () -> entityCache.get(modelId1, detector));
     }
 
     public void testExpiredCacheBuffer() {
         when(clock.instant()).thenReturn(Instant.MIN);
         when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
         for (int i = 0; i < 3; i++) {
-            cacheProvider.get(modelId1, detector);
+            entityCache.get(modelId1, detector);
         }
         for (int i = 0; i < 3; i++) {
-            cacheProvider.get(modelId2, detector);
+            entityCache.get(modelId2, detector);
         }
 
-        cacheProvider.hostIfPossible(detector, modelState1);
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState1);
+        entityCache.hostIfPossible(detector, modelState2);
 
-        assertEquals(2, cacheProvider.getTotalActiveEntities());
-        assertEquals(2, cacheProvider.getAllModels().size());
+        assertEquals(2, entityCache.getTotalActiveEntities());
+        assertEquals(2, entityCache.getAllModels().size());
         when(clock.instant()).thenReturn(Instant.now());
-        cacheProvider.maintenance();
-        assertEquals(0, cacheProvider.getTotalActiveEntities());
-        assertEquals(0, cacheProvider.getAllModels().size());
+        entityCache.maintenance();
+        assertEquals(0, entityCache.getTotalActiveEntities());
+        assertEquals(0, entityCache.getAllModels().size());
 
         for (int i = 0; i < 2; i++) {
             // doorkeeper should have been reset
-            assertEquals(null, cacheProvider.get(modelId2, detector));
+            assertEquals(null, entityCache.get(modelId2, detector));
         }
     }
 
@@ -336,56 +344,56 @@ public class PriorityCacheTests extends AbstractCacheTest {
 
         for (int i = 0; i < 3; i++) {
             // make modelId1 have higher priority
-            cacheProvider.get(modelId1, detector);
+            entityCache.get(modelId1, detector);
         }
 
         for (int i = 0; i < 2; i++) {
-            cacheProvider.get(modelId2, detector);
+            entityCache.get(modelId2, detector);
         }
 
-        cacheProvider.hostIfPossible(detector, modelState1);
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState1);
+        entityCache.hostIfPossible(detector, modelState2);
 
-        assertEquals(2, cacheProvider.getTotalActiveEntities());
-        assertTrue(cacheProvider.isActive(detectorId, modelId1));
-        assertEquals(0, cacheProvider.getTotalUpdates(detectorId));
+        assertEquals(2, entityCache.getTotalActiveEntities());
+        assertTrue(entityCache.isActive(detectorId, modelId1));
+        assertEquals(0, entityCache.getTotalUpdates(detectorId));
         modelState1.getModel().addSample(point);
-        assertEquals(1, cacheProvider.getTotalUpdates(detectorId));
-        assertEquals(1, cacheProvider.getTotalUpdates(detectorId, modelId1));
-        cacheProvider.clear(detectorId);
-        assertEquals(0, cacheProvider.getTotalActiveEntities());
+        assertEquals(1, entityCache.getTotalUpdates(detectorId));
+        assertEquals(1, entityCache.getTotalUpdates(detectorId, modelId1));
+        entityCache.clear(detectorId);
+        assertEquals(0, entityCache.getTotalActiveEntities());
 
         for (int i = 0; i < 2; i++) {
             // doorkeeper should have been reset
-            assertEquals(null, cacheProvider.get(modelId2, detector));
+            assertEquals(null, entityCache.get(modelId2, detector));
         }
     }
 
     class CleanRunnable implements Runnable {
         @Override
         public void run() {
-            cacheProvider.maintenance();
+            entityCache.maintenance();
         }
     }
 
     private void setUpConcurrentMaintenance() {
         when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
         for (int i = 0; i < 2; i++) {
-            cacheProvider.get(modelId1, detector);
+            entityCache.get(modelId1, detector);
         }
         for (int i = 0; i < 2; i++) {
-            cacheProvider.get(modelId2, detector);
+            entityCache.get(modelId2, detector);
         }
         for (int i = 0; i < 2; i++) {
-            cacheProvider.get(modelId3, detector);
+            entityCache.get(modelId3, detector);
         }
 
-        cacheProvider.hostIfPossible(detector, modelState1);
-        cacheProvider.hostIfPossible(detector, modelState2);
-        cacheProvider.hostIfPossible(detector, modelState3);
+        entityCache.hostIfPossible(detector, modelState1);
+        entityCache.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState3);
 
         when(memoryTracker.memoryToShed()).thenReturn(memoryPerEntity);
-        assertEquals(3, cacheProvider.getTotalActiveEntities());
+        assertEquals(3, entityCache.getTotalActiveEntities());
     }
 
     public void testSuccessfulConcurrentMaintenance() {
@@ -405,7 +413,7 @@ public class PriorityCacheTests extends AbstractCacheTest {
         // both maintenance call will be blocked until schedule gets called
         new Thread(new CleanRunnable()).start();
 
-        cacheProvider.maintenance();
+        entityCache.maintenance();
 
         verify(threadPool, times(1)).schedule(any(), any(), any());
     }
@@ -420,7 +428,7 @@ public class PriorityCacheTests extends AbstractCacheTest {
         @Override
         public void run() {
             try {
-                cacheProvider.maintenance();
+                entityCache.maintenance();
             } catch (Exception e) {
                 // maintenance can throw AnomalyDetectionException, catch it here
                 singalThreadToStart.countDown();
@@ -452,7 +460,7 @@ public class PriorityCacheTests extends AbstractCacheTest {
             // both maintenance call will be blocked until schedule gets called
             new Thread(new FailedCleanRunnable(scheduledThreadCountDown)).start();
 
-            cacheProvider.maintenance();
+            entityCache.maintenance();
         } catch (AnomalyDetectionException e) {
             scheduledThreadCountDown.countDown();
         }
@@ -476,11 +484,11 @@ public class PriorityCacheTests extends AbstractCacheTest {
     private void selectTestCommon(int entityFreq) {
         for (int i = 0; i < entityFreq; i++) {
             // bypass doorkeeper
-            cacheProvider.get(entity1.getModelId(detectorId).get(), detector);
+            entityCache.get(entity1.getModelId(detectorId).get(), detector);
         }
         Collection<Entity> cacheMissEntities = new ArrayList<>();
         cacheMissEntities.add(entity1);
-        Pair<List<Entity>, List<Entity>> selectedAndOther = cacheProvider.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
+        Pair<List<Entity>, List<Entity>> selectedAndOther = entityCache.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
         List<Entity> selected = selectedAndOther.getLeft();
         assertEquals(1, selected.size());
         assertEquals(entity1, selected.get(0));
@@ -494,12 +502,12 @@ public class PriorityCacheTests extends AbstractCacheTest {
     public void testSelectToSharedCache() {
         for (int i = 0; i < 2; i++) {
             // bypass doorkeeper
-            cacheProvider.get(entity2.getModelId(detectorId).get(), detector);
+            entityCache.get(entity2.getModelId(detectorId).get(), detector);
         }
         when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
 
         // fill in dedicated cache
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState2);
         selectTestCommon(2);
         verify(memoryTracker, times(1)).canAllocate(anyLong());
     }
@@ -507,12 +515,12 @@ public class PriorityCacheTests extends AbstractCacheTest {
     public void testSelectToReplaceInCache() {
         for (int i = 0; i < 2; i++) {
             // bypass doorkeeper
-            cacheProvider.get(entity2.getModelId(detectorId).get(), detector);
+            entityCache.get(entity2.getModelId(detectorId).get(), detector);
         }
         when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
 
         // fill in dedicated cache
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState2);
         // make entity1 have enough priority to replace entity2
         selectTestCommon(10);
         verify(memoryTracker, times(1)).canAllocate(anyLong());
@@ -540,20 +548,20 @@ public class PriorityCacheTests extends AbstractCacheTest {
 
         for (int i = 0; i < 3; i++) {
             // bypass doorkeeper and leave room for lower frequency entity in testSelectToCold
-            cacheProvider.get(entity5.getModelId(detectorId2).get(), detector2);
-            cacheProvider.get(entity6.getModelId(detectorId2).get(), detector2);
+            entityCache.get(entity5.getModelId(detectorId2).get(), detector2);
+            entityCache.get(entity6.getModelId(detectorId2).get(), detector2);
         }
         for (int i = 0; i < 10; i++) {
             // entity1 cannot replace entity2 due to frequency
-            cacheProvider.get(entity2.getModelId(detectorId).get(), detector);
+            entityCache.get(entity2.getModelId(detectorId).get(), detector);
         }
         // put modelState5 in dedicated and modelState6 in shared cache
         when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
-        cacheProvider.hostIfPossible(detector2, modelState5);
-        cacheProvider.hostIfPossible(detector2, modelState6);
+        entityCache.hostIfPossible(detector2, modelState5);
+        entityCache.hostIfPossible(detector2, modelState6);
 
         // fill in dedicated cache
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState2);
 
         // don't allow to use shared cache afterwards
         when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
@@ -574,11 +582,11 @@ public class PriorityCacheTests extends AbstractCacheTest {
 
         for (int i = 0; i < 2; i++) {
             // bypass doorkeeper
-            cacheProvider.get(entity1.getModelId(detectorId).get(), detector);
+            entityCache.get(entity1.getModelId(detectorId).get(), detector);
         }
         Collection<Entity> cacheMissEntities = new ArrayList<>();
         cacheMissEntities.add(entity1);
-        Pair<List<Entity>, List<Entity>> selectedAndOther = cacheProvider.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
+        Pair<List<Entity>, List<Entity>> selectedAndOther = entityCache.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
         List<Entity> cold = selectedAndOther.getRight();
         assertEquals(1, cold.size());
         assertEquals(entity1, cold.get(0));
@@ -595,40 +603,40 @@ public class PriorityCacheTests extends AbstractCacheTest {
     public void testClearMemory() {
         for (int i = 0; i < 2; i++) {
             // bypass doorkeeper
-            cacheProvider.get(entity2.getModelId(detectorId).get(), detector);
+            entityCache.get(entity2.getModelId(detectorId).get(), detector);
         }
 
         for (int i = 0; i < 10; i++) {
             // bypass doorkeeper and make entity1 have higher frequency
-            cacheProvider.get(entity1.getModelId(detectorId).get(), detector);
+            entityCache.get(entity1.getModelId(detectorId).get(), detector);
         }
 
         // put modelState5 in dedicated and modelState6 in shared cache
         when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
-        cacheProvider.hostIfPossible(detector, modelState1);
-        cacheProvider.hostIfPossible(detector, modelState2);
+        entityCache.hostIfPossible(detector, modelState1);
+        entityCache.hostIfPossible(detector, modelState2);
 
         // two entities get inserted to cache
-        assertTrue(null != cacheProvider.get(entity1.getModelId(detectorId).get(), detector));
-        assertTrue(null != cacheProvider.get(entity2.getModelId(detectorId).get(), detector));
+        assertTrue(null != entityCache.get(entity1.getModelId(detectorId).get(), detector));
+        assertTrue(null != entityCache.get(entity2.getModelId(detectorId).get(), detector));
 
         Entity entity5 = Entity.createSingleAttributeEntity("attributeName1", "attributeVal5");
         when(memoryTracker.memoryToShed()).thenReturn(memoryPerEntity);
         for (int i = 0; i < 2; i++) {
             // bypass doorkeeper, CacheBuffer created, and trigger clearMemory
-            cacheProvider.get(entity5.getModelId(detectorId2).get(), detector2);
+            entityCache.get(entity5.getModelId(detectorId2).get(), detector2);
         }
 
-        assertTrue(null != cacheProvider.get(entity1.getModelId(detectorId).get(), detector));
+        assertTrue(null != entityCache.get(entity1.getModelId(detectorId).get(), detector));
         // entity 2 removed
-        assertTrue(null == cacheProvider.get(entity2.getModelId(detectorId).get(), detector));
-        assertTrue(null == cacheProvider.get(entity5.getModelId(detectorId2).get(), detector));
+        assertTrue(null == entityCache.get(entity2.getModelId(detectorId).get(), detector));
+        assertTrue(null == entityCache.get(entity5.getModelId(detectorId2).get(), detector));
     }
 
     public void testSelectEmpty() {
         Collection<Entity> cacheMissEntities = new ArrayList<>();
         cacheMissEntities.add(entity1);
-        Pair<List<Entity>, List<Entity>> selectedAndOther = cacheProvider.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
+        Pair<List<Entity>, List<Entity>> selectedAndOther = entityCache.selectUpdateCandidate(cacheMissEntities, detectorId, detector);
         assertEquals(0, selectedAndOther.getLeft().size());
         assertEquals(0, selectedAndOther.getRight().size());
     }
@@ -640,16 +648,74 @@ public class PriorityCacheTests extends AbstractCacheTest {
         when(detector.getDetectionIntervalDuration()).thenReturn(Duration.ofHours(12));
         String modelId = entity1.getModelId(detectorId).get();
         // record last access time 1000
-        cacheProvider.get(modelId, detector);
-        assertEquals(-1, cacheProvider.getLastActiveMs(detectorId, modelId));
+        entityCache.get(modelId, detector);
+        assertEquals(-1, entityCache.getLastActiveMs(detectorId, modelId));
         // 2 hour = 7200 seconds have passed
         long currentTimeEpoch = 8200;
         when(clock.instant()).thenReturn(Instant.ofEpochSecond(currentTimeEpoch));
         // door keeper should not be expired since we reclaim space every 60 intervals
-        cacheProvider.maintenance();
+        entityCache.maintenance();
         // door keeper still has the record and won't blocks entity state being created
-        cacheProvider.get(modelId, detector);
+        entityCache.get(modelId, detector);
         // * 1000 to convert to milliseconds
-        assertEquals(currentTimeEpoch * 1000, cacheProvider.getLastActiveMs(detectorId, modelId));
+        assertEquals(currentTimeEpoch * 1000, entityCache.getLastActiveMs(detectorId, modelId));
+    }
+
+    public void testGetNoPriorityUpdate() {
+        for (int i = 0; i < 3; i++) {
+            // bypass doorkeeper
+            entityCache.get(entity2.getModelId(detectorId).get(), detector);
+        }
+
+        // fill in dedicated cache
+        entityCache.hostIfPossible(detector, modelState2);
+
+        // don't allow to use shared cache afterwards
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
+
+        for (int i = 0; i < 2; i++) {
+            // bypass doorkeeper
+            entityCache.get(entity1.getModelId(detectorId).get(), detector);
+        }
+        for (int i = 0; i < 10; i++) {
+            // won't increase frequency
+            entityCache.getForMaintainance(detectorId, entity1.getModelId(detectorId).get());
+        }
+
+        entityCache.hostIfPossible(detector, modelState1);
+
+        // entity1 does not replace entity2
+        assertTrue(null == entityCache.get(entity1.getModelId(detectorId).get(), detector));
+        assertTrue(null != entityCache.get(entity2.getModelId(detectorId).get(), detector));
+
+        for (int i = 0; i < 10; i++) {
+            // increase frequency
+            entityCache.get(entity1.getModelId(detectorId).get(), detector);
+        }
+
+        entityCache.hostIfPossible(detector, modelState1);
+
+        // entity1 replace entity2
+        assertTrue(null != entityCache.get(entity1.getModelId(detectorId).get(), detector));
+        assertTrue(null == entityCache.get(entity2.getModelId(detectorId).get(), detector));
+    }
+
+    public void testRemoveEntityModel() {
+        for (int i = 0; i < 3; i++) {
+            // bypass doorkeeper
+            entityCache.get(entity2.getModelId(detectorId).get(), detector);
+        }
+
+        // fill in dedicated cache
+        entityCache.hostIfPossible(detector, modelState2);
+
+        assertTrue(null != entityCache.get(entity2.getModelId(detectorId).get(), detector));
+
+        entityCache.removeEntityModel(detectorId, entity2.getModelId(detectorId).get());
+
+        assertTrue(null == entityCache.get(entity2.getModelId(detectorId).get(), detector));
+
+        verify(checkpoint, times(1)).deleteModelCheckpoint(eq(entity2.getModelId(detectorId).get()), any());
+        verify(checkpointWriteQueue, never()).write(any(), anyBoolean(), any());
     }
 }

--- a/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/org/opensearch/ad/caching/PriorityCacheTests.java
@@ -99,7 +99,9 @@ public class PriorityCacheTests extends AbstractCacheTest {
                             .asList(
                                 AnomalyDetectorSettings.DEDICATED_CACHE_SIZE,
                                 AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE,
-                                AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE
+                                AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE,
+                                AnomalyDetectorSettings.CHECKPOINT_TTL,
+                                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ
                             )
                     )
                 )
@@ -124,7 +126,9 @@ public class PriorityCacheTests extends AbstractCacheTest {
             threadPool,
             checkpointWriteQueue,
             AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            checkpointMaintainQueue
+            checkpointMaintainQueue,
+            Settings.EMPTY,
+            AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ
         );
 
         CacheProvider cacheProvider = new CacheProvider();
@@ -177,7 +181,9 @@ public class PriorityCacheTests extends AbstractCacheTest {
             threadPool,
             checkpointWriteQueue,
             AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            checkpointMaintainQueue
+            checkpointMaintainQueue,
+            Settings.EMPTY,
+            AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ
         );
 
         CacheProvider cacheProvider = new CacheProvider();

--- a/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
+++ b/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.Month;
 import java.time.OffsetDateTime;
@@ -1084,5 +1085,14 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             assertEquals(descriptor.getRCFScore(), scores.get(i), 1e-9);
             assertEquals(descriptor.getAnomalyGrade(), grade.get(i), 1e-9);
         }
+    }
+
+    public void testShouldSave() {
+        assertTrue(!checkpointDao.shouldSave(Instant.MIN, false, null, clock));
+        assertTrue(checkpointDao.shouldSave(Instant.ofEpochMilli(Instant.now().toEpochMilli()), true, Duration.ofHours(6), clock));
+        // now + 6 hrs > Instant.now
+        assertTrue(!checkpointDao.shouldSave(Instant.ofEpochMilli(Instant.now().toEpochMilli()), false, Duration.ofHours(6), clock));
+        // 1658863778000L + 6 hrs < Instant.now
+        assertTrue(checkpointDao.shouldSave(Instant.ofEpochMilli(1658863778000L), false, Duration.ofHours(6), clock));
     }
 }

--- a/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
@@ -34,6 +34,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -78,6 +79,7 @@ import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.threadpool.ThreadPool;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -160,6 +162,7 @@ public class ModelManagerTests {
     private double[] attribution;
     private double[] point;
     private DiVector attributionVec;
+    private ClusterSettings clusterSettings;
 
     @Mock
     private ActionListener<ThresholdingResult> rcfResultListener;
@@ -226,6 +229,19 @@ public class ModelManagerTests {
         memoryTracker = mock(MemoryTracker.class);
         when(memoryTracker.isHostingAllowed(anyString(), any())).thenReturn(true);
 
+        clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ)))
+        );
+        clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        settings = Settings
+            .builder()
+            .put("plugins.anomaly_detection.model_max_size_percent", modelMaxSizePercentage)
+            .put("plugins.anomaly_detection.checkpoint_saving_freq", TimeValue.timeValueHours(12))
+            .build();
+
         modelManager = spy(
             new ModelManager(
                 checkpointDao,
@@ -237,10 +253,12 @@ public class ModelManagerTests {
                 thresholdMinPvalue,
                 minPreviewSize,
                 modelTtl,
-                checkpointInterval,
+                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
                 entityColdStarter,
                 featureManager,
-                memoryTracker
+                memoryTracker,
+                settings,
+                clusterService
             )
         );
 
@@ -250,7 +268,6 @@ public class ModelManagerTests {
 
         when(this.modelState.getModel()).thenReturn(this.entityModel);
         when(this.entityModel.getTrcf()).thenReturn(Optional.of(this.trcf));
-        settings = Settings.builder().put("plugins.anomaly_detection.model_max_size_percent", modelMaxSizePercentage).build();
 
         when(anomalyDetector.getShingleSize()).thenReturn(shingleSize);
     }
@@ -410,7 +427,7 @@ public class ModelManagerTests {
         final Set<Setting<?>> settingsSet = Stream
             .concat(
                 ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
-                Sets.newHashSet(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE).stream()
+                Sets.newHashSet(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE, AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ).stream()
             )
             .collect(Collectors.toSet());
         ClusterSettings clusterSettings = new ClusterSettings(settings, settingsSet);
@@ -438,10 +455,12 @@ public class ModelManagerTests {
                 thresholdMinPvalue,
                 minPreviewSize,
                 modelTtl,
-                checkpointInterval,
+                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
                 entityColdStarter,
                 featureManager,
-                memoryTracker
+                memoryTracker,
+                settings,
+                clusterService
             )
         );
 
@@ -968,10 +987,12 @@ public class ModelManagerTests {
                 thresholdMinPvalue,
                 minPreviewSize,
                 modelTtl,
-                checkpointInterval,
+                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
                 entityColdStarter,
                 featureManager,
-                memoryTracker
+                memoryTracker,
+                settings,
+                clusterService
             )
         );
 

--- a/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
@@ -1073,4 +1073,20 @@ public class ModelManagerTests {
             result
         );
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void score_throw() {
+        AnomalyDescriptor anomalyDescriptor = new AnomalyDescriptor(point, 0);
+        anomalyDescriptor.setRCFScore(2);
+        anomalyDescriptor.setAnomalyGrade(1);
+        // input dimension is 5
+        anomalyDescriptor.setRelevantAttribution(new double[] { 0, 0, 0, 0, 0 });
+        RandomCutForest rcf = mock(RandomCutForest.class);
+        when(rcf.getShingleSize()).thenReturn(8);
+        when(rcf.getDimensions()).thenReturn(40);
+        when(this.trcf.getForest()).thenReturn(rcf);
+        doThrow(new IllegalArgumentException()).when(trcf).process(any(), anyLong());
+        when(this.entityModel.getSamples()).thenReturn(new ArrayDeque<>(Arrays.asList(this.point)));
+        modelManager.score(this.point, this.detectorId, this.modelState);
+    }
 }

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckPointMaintainRequestAdapterTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckPointMaintainRequestAdapterTests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.ad.caching.CacheProvider;
+import org.opensearch.ad.caching.EntityCache;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.ml.CheckpointDao;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+
+import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
+
+public class CheckPointMaintainRequestAdapterTests extends AbstractRateLimitingTest {
+    private CacheProvider cache;
+    private CheckpointDao checkpointDao;
+    private String indexName;
+    private Duration checkpointInterval;
+    private CheckPointMaintainRequestAdapter adapter;
+    private ModelState<EntityModel> state;
+    private CheckpointMaintainRequest request;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        cache = mock(CacheProvider.class);
+        checkpointDao = mock(CheckpointDao.class);
+        indexName = CommonName.CHECKPOINT_INDEX_NAME;
+        checkpointInterval = AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ;
+        EntityCache entityCache = mock(EntityCache.class);
+        when(cache.get()).thenReturn(entityCache);
+        state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
+        when(entityCache.getForMaintainance(anyString(), anyString())).thenReturn(Optional.of(state));
+        adapter = new CheckPointMaintainRequestAdapter(cache, checkpointDao, indexName, checkpointInterval, clock);
+        request = new CheckpointMaintainRequest(Integer.MAX_VALUE, detectorId, RequestPriority.MEDIUM, entity.getModelId(detectorId).get());
+
+    }
+
+    public void testShouldNotSave() {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(false);
+        assertTrue(adapter.convert(request).isEmpty());
+    }
+
+    public void testIndexSourceNull() throws IOException {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(true);
+        when(checkpointDao.toIndexSource(any())).thenReturn(null);
+        assertTrue(adapter.convert(request).isEmpty());
+    }
+
+    public void testIndexSourceEmpty() throws IOException {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(true);
+        when(checkpointDao.toIndexSource(any())).thenReturn(new HashMap<String, Object>());
+        assertTrue(adapter.convert(request).isEmpty());
+    }
+
+    public void testModelIdEmpty() throws IOException {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(true);
+        Map<String, Object> content = new HashMap<String, Object>();
+        content.put("a", "b");
+        when(checkpointDao.toIndexSource(any())).thenReturn(content);
+        assertTrue(adapter.convert(new CheckpointMaintainRequest(Integer.MAX_VALUE, detectorId, RequestPriority.MEDIUM, null)).isEmpty());
+    }
+
+    public void testNormal() throws IOException {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(true);
+        Map<String, Object> content = new HashMap<String, Object>();
+        content.put("a", "b");
+        when(checkpointDao.toIndexSource(any())).thenReturn(content);
+        Optional<CheckpointWriteRequest> converted = adapter.convert(request);
+        assertTrue(!converted.isEmpty());
+        UpdateRequest updateRequest = converted.get().getUpdateRequest();
+        UpdateRequest expectedRequest = new UpdateRequest(indexName, entity.getModelId(detectorId).get()).docAsUpsert(true).doc(content);
+        assertEquals(updateRequest.docAsUpsert(), expectedRequest.docAsUpsert());
+        assertEquals(updateRequest.detectNoop(), expectedRequest.detectNoop());
+        assertEquals(updateRequest.fetchSource(), expectedRequest.fetchSource());
+    }
+
+    public void testIndexSourceException() throws IOException {
+        doThrow(IllegalArgumentException.class).when(checkpointDao).toIndexSource(any());
+        assertTrue(adapter.convert(request).isEmpty());
+    }
+}

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorkerTests.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.caching.CacheProvider;
+import org.opensearch.ad.caching.EntityCache;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.ml.CheckpointDao;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+
+import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
+
+public class CheckpointMaintainWorkerTests extends AbstractRateLimitingTest {
+    ClusterService clusterService;
+    CheckpointMaintainWorker cpMaintainWorker;
+    CheckpointWriteWorker writeWorker;
+    CheckpointMaintainRequest request;
+    CheckpointMaintainRequest request2;
+    List<CheckpointMaintainRequest> requests;
+    CheckpointDao checkpointDao;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clusterService = mock(ClusterService.class);
+        Settings settings = Settings.builder().put(AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE.getKey(), 1).build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Collections
+                .unmodifiableSet(
+                    new HashSet<>(
+                        Arrays
+                            .asList(
+                                AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS,
+                                AnomalyDetectorSettings.CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE
+                            )
+                    )
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        writeWorker = mock(CheckpointWriteWorker.class);
+
+        CacheProvider cache = mock(CacheProvider.class);
+        checkpointDao = mock(CheckpointDao.class);
+        String indexName = CommonName.CHECKPOINT_INDEX_NAME;
+        Duration checkpointInterval = AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ;
+        EntityCache entityCache = mock(EntityCache.class);
+        when(cache.get()).thenReturn(entityCache);
+        ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
+        when(entityCache.getForMaintainance(anyString(), anyString())).thenReturn(Optional.of(state));
+        CheckPointMaintainRequestAdapter adapter = new CheckPointMaintainRequestAdapter(
+            cache,
+            checkpointDao,
+            indexName,
+            checkpointInterval,
+            clock
+        );
+
+        // Integer.MAX_VALUE makes a huge heap
+        cpMaintainWorker = new CheckpointMaintainWorker(
+            Integer.MAX_VALUE,
+            AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
+            clusterService,
+            new Random(42),
+            mock(ADCircuitBreakerService.class),
+            threadPool,
+            settings,
+            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            clock,
+            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            writeWorker,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            nodeStateManager,
+            adapter
+        );
+
+        request = new CheckpointMaintainRequest(Integer.MAX_VALUE, detectorId, RequestPriority.LOW, entity.getModelId(detectorId).get());
+        request2 = new CheckpointMaintainRequest(Integer.MAX_VALUE, detectorId, RequestPriority.LOW, entity2.getModelId(detectorId).get());
+
+        requests = new ArrayList<>();
+        requests.add(request);
+        requests.add(request2);
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+
+            TimeValue value = invocation.getArgument(1);
+            // since we have only 1 request each time
+            long expectedExecutionPerRequestMilli = 1000 * AnomalyDetectorSettings.EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_SECS
+                .getDefault(Settings.EMPTY);
+            long delay = value.getMillis();
+            assertTrue(delay >= expectedExecutionPerRequestMilli);
+            assertTrue(delay <= expectedExecutionPerRequestMilli * 2);
+            return null;
+        }).when(threadPool).schedule(any(), any(), any());
+    }
+
+    public void testPutRequests() throws IOException {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(true);
+        Map<String, Object> content = new HashMap<String, Object>();
+        content.put("a", "b");
+        when(checkpointDao.toIndexSource(any())).thenReturn(content);
+
+        cpMaintainWorker.putAll(requests);
+
+        verify(writeWorker, times(2)).putAll(any());
+        verify(threadPool, times(2)).schedule(any(), any(), any());
+    }
+
+    public void testFailtoPut() throws IOException {
+        when(checkpointDao.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(false);
+
+        cpMaintainWorker.putAll(requests);
+
+        verify(writeWorker, never()).putAll(any());
+        verify(threadPool, never()).schedule(any(), any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +62,10 @@ import org.opensearch.ad.ml.ThresholdingResult;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.stats.ADStat;
+import org.opensearch.ad.stats.ADStats;
+import org.opensearch.ad.stats.StatNames;
+import org.opensearch.ad.stats.suppliers.CounterSupplier;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -94,6 +99,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
     EntityCache entityCache;
     EntityFeatureRequest request, request2, request3;
     ClusterSettings clusterSettings;
+    ADStats adStats;
 
     @Override
     public void setUp() throws Exception {
@@ -137,6 +143,14 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         when(cacheProvider.get()).thenReturn(entityCache);
         when(entityCache.hostIfPossible(any(), any())).thenReturn(true);
 
+        Map<String, ADStat<?>> statsMap = new HashMap<String, ADStat<?>>() {
+            {
+                put(StatNames.MODEL_CORRUTPION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()));
+            }
+        };
+
+        adStats = new ADStats(statsMap);
+
         // Integer.MAX_VALUE makes a huge heap
         worker = new CheckpointReadWorker(
             Integer.MAX_VALUE,
@@ -161,7 +175,8 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             anomalyDetectionIndices,
             cacheProvider,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            checkpointWriteQueue
+            checkpointWriteQueue,
+            adStats
         );
 
         request = new EntityFeatureRequest(Integer.MAX_VALUE, detectorId, RequestPriority.MEDIUM, entity, new double[] { 0 }, 0);
@@ -539,7 +554,8 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             anomalyDetectionIndices,
             cacheProvider,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            checkpointWriteQueue
+            checkpointWriteQueue,
+            adStats
         );
 
         regularTestSetUp(new RegularSetUpConfig.Builder().build());
@@ -590,7 +606,8 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             anomalyDetectionIndices,
             cacheProvider,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            checkpointWriteQueue
+            checkpointWriteQueue,
+            adStats
         );
 
         List<EntityFeatureRequest> requests = new ArrayList<>();
@@ -642,7 +659,8 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             anomalyDetectionIndices,
             cacheProvider,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            checkpointWriteQueue
+            checkpointWriteQueue,
+            adStats
         );
 
         List<EntityFeatureRequest> requests = new ArrayList<>();
@@ -783,5 +801,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         verify(resultWriteQueue, never()).put(any());
         verify(checkpointWriteQueue, never()).write(any(), anyBoolean(), any());
         verify(coldstartQueue, times(1)).put(any());
+        Object val = adStats.getStat(StatNames.MODEL_CORRUTPION_COUNT.getName()).getValue();
+        assertEquals(1L, ((Long) val).longValue());
     }
 }

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointWriteWorkerTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.ad.ratelimit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -99,6 +100,7 @@ public class CheckpointWriteWorkerTests extends AbstractRateLimitingTest {
         Map<String, Object> checkpointMap = new HashMap<>();
         checkpointMap.put(CheckpointDao.FIELD_MODEL, "a");
         when(checkpoint.toIndexSource(any())).thenReturn(checkpointMap);
+        when(checkpoint.shouldSave(any(), anyBoolean(), any(), any())).thenReturn(true);
 
         // Integer.MAX_VALUE makes a huge heap
         worker = new CheckpointWriteWorker(

--- a/src/test/java/org/opensearch/ad/ratelimit/ColdEntityWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ColdEntityWorkerTests.java
@@ -53,7 +53,7 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS,
+                                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
                                 AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_BATCH_SIZE
                             )
@@ -99,11 +99,10 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
 
             TimeValue value = invocation.getArgument(1);
             // since we have only 1 request each time
-            long expectedExecutionPerRequestMilli = 1000 * AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS
+            long expectedExecutionPerRequestMilli = AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS
                 .getDefault(Settings.EMPTY);
             long delay = value.getMillis();
-            assertTrue(delay >= expectedExecutionPerRequestMilli);
-            assertTrue(delay <= expectedExecutionPerRequestMilli * 2);
+            assertTrue(delay == expectedExecutionPerRequestMilli);
             return null;
         }).when(threadPool).schedule(any(), any(), any());
     }
@@ -144,7 +143,7 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS,
+                                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
                                 AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_BATCH_SIZE
                             )

--- a/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
+++ b/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
@@ -114,7 +114,7 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
                             AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
                             AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
                             AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
-                            AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_SECS,
+                            AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
                             AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY,
                             AnomalyDetectorSettings.PAGE_SIZE
                         )

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.anyDouble;
 import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -36,10 +35,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ad.TestHelpers.createIndexBlockedState;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.opensearch.test.OpenSearchTestCase.randomBoolean;
-import static org.opensearch.test.OpenSearchTestCase.randomDouble;
-import static org.opensearch.test.OpenSearchTestCase.randomDoubleBetween;
-import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -350,7 +345,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             normalModelManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
 
@@ -471,7 +467,8 @@ public class AnomalyResultTests extends AbstractADTest {
             testNodes[1].transportService,
             normalModelManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
 
         TransportService realTransportService = testNodes[0].transportService;
@@ -524,7 +521,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             rcfManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
 
@@ -567,7 +565,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             rcfManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
 
@@ -684,7 +683,14 @@ public class AnomalyResultTests extends AbstractADTest {
         when(hashRing.getNodeByAddress(any(TransportAddress.class))).thenReturn(discoveryNode);
         // register handlers on testNodes[1]
         ActionFilters actionFilters = new ActionFilters(Collections.emptySet());
-        new RCFResultTransportAction(actionFilters, testNodes[1].transportService, normalModelManager, adCircuitBreakerService, hashRing);
+        new RCFResultTransportAction(
+            actionFilters,
+            testNodes[1].transportService,
+            normalModelManager,
+            adCircuitBreakerService,
+            hashRing,
+            adStats
+        );
         new ThresholdResultTransportAction(actionFilters, testNodes[1].transportService, normalModelManager);
 
         TransportService realTransportService = testNodes[0].transportService;
@@ -727,7 +733,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             normalModelManager,
             breakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
 
@@ -796,7 +803,8 @@ public class AnomalyResultTests extends AbstractADTest {
             exceptionTransportService,
             normalModelManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
 
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
@@ -883,7 +891,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             normalModelManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         Optional<DiscoveryNode> localNode = Optional.of(clusterService.state().nodes().getLocalNode());
 
@@ -1416,7 +1425,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             normalModelManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
 
@@ -1627,7 +1637,8 @@ public class AnomalyResultTests extends AbstractADTest {
             transportService,
             rcfManager,
             adCircuitBreakerService,
-            hashRing
+            hashRing,
+            adStats
         );
         new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
 

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -253,6 +253,7 @@ public class MultiEntityResultTests extends AbstractADTest {
                 put(StatNames.AD_EXECUTE_FAIL_COUNT.getName(), new ADStat<>(false, new CounterSupplier()));
                 put(StatNames.AD_HC_EXECUTE_REQUEST_COUNT.getName(), new ADStat<>(false, new CounterSupplier()));
                 put(StatNames.AD_HC_EXECUTE_FAIL_COUNT.getName(), new ADStat<>(false, new CounterSupplier()));
+                put(StatNames.MODEL_CORRUTPION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()));
             }
         };
         adStats = new ADStats(statsMap);
@@ -409,7 +410,8 @@ public class MultiEntityResultTests extends AbstractADTest {
             checkpointReadQueue,
             coldEntityQueue,
             threadPool,
-            entityColdStartQueue
+            entityColdStartQueue,
+            adStats
         );
 
         when(normalModelManager.getAnomalyResultForEntity(any(), any(), any(), any(), anyInt()))
@@ -778,7 +780,8 @@ public class MultiEntityResultTests extends AbstractADTest {
             checkpointReadQueue,
             coldEntityQueue,
             threadPool,
-            entityColdStartQueue
+            entityColdStartQueue,
+            adStats
         );
 
         CountDownLatch inProgress = new CountDownLatch(1);
@@ -961,7 +964,8 @@ public class MultiEntityResultTests extends AbstractADTest {
             checkpointReadQueue,
             coldEntityQueue,
             threadPool,
-            entityColdStartQueue
+            entityColdStartQueue,
+            adStats
         );
 
         CountDownLatch modelNodeInProgress = new CountDownLatch(1);

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -90,6 +91,7 @@ import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
 import org.opensearch.ad.ratelimit.CheckpointReadWorker;
 import org.opensearch.ad.ratelimit.ColdEntityWorker;
+import org.opensearch.ad.ratelimit.EntityColdStartWorker;
 import org.opensearch.ad.ratelimit.EntityFeatureRequest;
 import org.opensearch.ad.ratelimit.ResultWriteWorker;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
@@ -159,6 +161,7 @@ public class MultiEntityResultTests extends AbstractADTest {
     private AnomalyDetectionIndices indexUtil;
     private ResultWriteWorker resultWriteQueue;
     private CheckpointReadWorker checkpointReadQueue;
+    private EntityColdStartWorker entityColdStartQueue;
     private ColdEntityWorker coldEntityQueue;
     private String app0 = "app_0";
     private String server1 = "server_1";
@@ -296,6 +299,7 @@ public class MultiEntityResultTests extends AbstractADTest {
         indexUtil = mock(AnomalyDetectionIndices.class);
         resultWriteQueue = mock(ResultWriteWorker.class);
         checkpointReadQueue = mock(CheckpointReadWorker.class);
+        entityColdStartQueue = mock(EntityColdStartWorker.class);
 
         coldEntityQueue = mock(ColdEntityWorker.class);
 
@@ -404,7 +408,8 @@ public class MultiEntityResultTests extends AbstractADTest {
             resultWriteQueue,
             checkpointReadQueue,
             coldEntityQueue,
-            threadPool
+            threadPool,
+            entityColdStartQueue
         );
 
         when(normalModelManager.getAnomalyResultForEntity(any(), any(), any(), any(), anyInt()))
@@ -579,7 +584,7 @@ public class MultiEntityResultTests extends AbstractADTest {
         return new SearchResponse(emptySections, null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, Clusters.EMPTY);
     }
 
-    private CountDownLatch setUpSearchResponse() throws IOException {
+    private void setUpSearchResponse() throws IOException {
         detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(serviceField, hostField));
         // set up a non-empty response
         CompositeAggregation composite = mock(CompositeAggregation.class);
@@ -618,29 +623,25 @@ public class MultiEntityResultTests extends AbstractADTest {
         SearchResponseSections sections = new SearchResponseSections(SearchHits.empty(), aggs, null, false, null, null, 1);
         SearchResponse response = new SearchResponse(sections, null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, Clusters.EMPTY);
 
-        CountDownLatch inProgress = new CountDownLatch(2);
         AtomicBoolean firstCalled = new AtomicBoolean();
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             if (firstCalled.get()) {
                 listener.onResponse(createEmptyResponse());
-                inProgress.countDown();
             } else {
                 // set firstCalled to be true before returning in case that listener return
                 // and the 2nd call comes in before firstCalled is set to true. Then we
                 // have the 2nd response.
                 firstCalled.set(true);
                 listener.onResponse(response);
-                inProgress.countDown();
             }
             return null;
         }).when(client).search(any(), any());
-
-        return inProgress;
     }
 
     private <T extends TransportResponse> void setUpTransportInterceptor(
-        Function<TransportResponseHandler<T>, TransportResponseHandler<T>> interceptor
+        Function<TransportResponseHandler<T>, TransportResponseHandler<T>> interceptor,
+        NodeStateManager nodeStateManager
     ) {
         entityResultInterceptor = new TransportInterceptor() {
             @Override
@@ -684,7 +685,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             realTransportService,
             settings,
             client,
-            stateManager,
+            nodeStateManager,
             featureQuery,
             normalModelManager,
             hashRing,
@@ -698,13 +699,27 @@ public class MultiEntityResultTests extends AbstractADTest {
         );
     }
 
+    private <T extends TransportResponse> void setUpTransportInterceptor(
+        Function<TransportResponseHandler<T>, TransportResponseHandler<T>> interceptor
+    ) {
+        setUpTransportInterceptor(interceptor, stateManager);
+    }
+
     public void testNonEmptyFeatures() throws InterruptedException, IOException {
-        CountDownLatch inProgress = setUpSearchResponse();
+        setUpSearchResponse();
         setUpTransportInterceptor(this::entityResultHandler);
         // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
             .thenReturn(Optional.of(testNodes[1].discoveryNode()));
         setUpEntityResult(1);
+
+        CountDownLatch modelNodeInProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            if (modelNodeInProgress.getCount() == 1) {
+                modelNodeInProgress.countDown();
+            }
+            return null;
+        }).when(coldEntityQueue).putAll(any());
 
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 
@@ -713,7 +728,7 @@ public class MultiEntityResultTests extends AbstractADTest {
         AnomalyResultResponse response = listener.actionGet(10000L);
         assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
 
-        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+        assertTrue(modelNodeInProgress.await(10000L, TimeUnit.MILLISECONDS));
 
         // since we have 3 results in the first page
         verify(resultWriteQueue, times(3)).put(any());
@@ -738,32 +753,17 @@ public class MultiEntityResultTests extends AbstractADTest {
             clusterService
         );
 
-        action = new AnomalyResultTransportAction(
-            new ActionFilters(Collections.emptySet()),
-            transportService,
-            settings,
-            client,
-            stateManager,
-            featureQuery,
-            normalModelManager,
-            hashRing,
-            clusterService,
-            indexNameResolver,
-            adCircuitBreakerService,
-            adStats,
-            mockThreadPool,
-            xContentRegistry(),
-            adTaskManager
-        );
+        NodeStateManager spyStateManager = spy(stateManager);
 
-        CountDownLatch inProgress = setUpSearchResponse();
-        setUpTransportInterceptor(this::entityResultHandler);
+        setUpSearchResponse();
+        setUpTransportInterceptor(this::entityResultHandler, spyStateManager);
         // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
             .thenReturn(Optional.of(testNodes[1].discoveryNode()));
 
         ADCircuitBreakerService openBreaker = mock(ADCircuitBreakerService.class);
         when(openBreaker.isOpen()).thenReturn(true);
+
         // register entity result action
         new EntityResultTransportAction(
             new ActionFilters(Collections.emptySet()),
@@ -772,13 +772,24 @@ public class MultiEntityResultTests extends AbstractADTest {
             normalModelManager,
             openBreaker,
             provider,
-            stateManager,
+            spyStateManager,
             indexUtil,
             resultWriteQueue,
             checkpointReadQueue,
             coldEntityQueue,
-            threadPool
+            threadPool,
+            entityColdStartQueue
         );
+
+        CountDownLatch inProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            Exception exp = invocation.getArgument(1);
+
+            stateManager.setException(id, exp);
+            inProgress.countDown();
+            return null;
+        }).when(spyStateManager).setException(any(), any());
 
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
         action.doExecute(null, request, listener);
@@ -793,12 +804,18 @@ public class MultiEntityResultTests extends AbstractADTest {
     }
 
     public void testNotAck() throws InterruptedException, IOException {
-        CountDownLatch inProgress = setUpSearchResponse();
+        setUpSearchResponse();
         setUpTransportInterceptor(this::unackEntityResultHandler);
         // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
             .thenReturn(Optional.of(testNodes[1].discoveryNode()));
         setUpEntityResult(1);
+
+        CountDownLatch inProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            inProgress.countDown();
+            return null;
+        }).when(stateManager).addPressure(anyString(), anyString());
 
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 
@@ -813,7 +830,7 @@ public class MultiEntityResultTests extends AbstractADTest {
     }
 
     public void testMultipleNode() throws InterruptedException, IOException {
-        CountDownLatch inProgress = setUpSearchResponse();
+        setUpSearchResponse();
         setUpTransportInterceptor(this::entityResultHandler);
 
         Entity entity1 = Entity.createEntityByReordering(attrs1);
@@ -834,6 +851,12 @@ public class MultiEntityResultTests extends AbstractADTest {
             setUpEntityResult(i);
         }
 
+        CountDownLatch modelNodeInProgress = new CountDownLatch(3);
+        doAnswer(invocation -> {
+            modelNodeInProgress.countDown();
+            return null;
+        }).when(coldEntityQueue).putAll(any());
+
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 
         action.doExecute(null, request, listener);
@@ -841,14 +864,14 @@ public class MultiEntityResultTests extends AbstractADTest {
         AnomalyResultResponse response = listener.actionGet(10000L);
         assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
 
-        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+        assertTrue(modelNodeInProgress.await(10000L, TimeUnit.MILLISECONDS));
 
         // since we have 3 results in the first page
         verify(resultWriteQueue, times(3)).put(any());
     }
 
     public void testCacheSelectionError() throws IOException, InterruptedException {
-        CountDownLatch inProgress = setUpSearchResponse();
+        setUpSearchResponse();
         setUpTransportInterceptor(this::entityResultHandler);
         setUpEntityResult(1);
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
@@ -870,11 +893,19 @@ public class MultiEntityResultTests extends AbstractADTest {
 
         when(entityCache.selectUpdateCandidate(any(), any(), any())).thenReturn(Pair.of(hotEntities, coldEntities));
 
+        CountDownLatch modelNodeInProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            if (modelNodeInProgress.getCount() == 1) {
+                modelNodeInProgress.countDown();
+            }
+            return null;
+        }).when(coldEntityQueue).putAll(any());
+
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 
         action.doExecute(null, request, listener);
 
-        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+        assertTrue(modelNodeInProgress.await(10000L, TimeUnit.MILLISECONDS));
         // size 0 because cacheMissEntities has no record of these entities
         verify(checkpointReadQueue).putAll(argThat(new ArgumentMatcher<List<EntityFeatureRequest>>() {
 
@@ -898,7 +929,7 @@ public class MultiEntityResultTests extends AbstractADTest {
     }
 
     public void testCacheSelection() throws IOException, InterruptedException {
-        CountDownLatch inProgress = setUpSearchResponse();
+        setUpSearchResponse();
         setUpTransportInterceptor(this::entityResultHandler);
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
             .thenReturn(Optional.of(testNodes[1].discoveryNode()));
@@ -929,14 +960,23 @@ public class MultiEntityResultTests extends AbstractADTest {
             resultWriteQueue,
             checkpointReadQueue,
             coldEntityQueue,
-            threadPool
+            threadPool,
+            entityColdStartQueue
         );
+
+        CountDownLatch modelNodeInProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            if (modelNodeInProgress.getCount() == 1) {
+                modelNodeInProgress.countDown();
+            }
+            return null;
+        }).when(coldEntityQueue).putAll(any());
 
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 
         action.doExecute(null, request, listener);
 
-        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+        assertTrue(modelNodeInProgress.await(10000L, TimeUnit.MILLISECONDS));
         verify(checkpointReadQueue).putAll(argThat(new ArgumentMatcher<List<EntityFeatureRequest>>() {
 
             @Override
@@ -1053,21 +1093,30 @@ public class MultiEntityResultTests extends AbstractADTest {
         // set up an empty response
         SearchResponse emptyResponse = createEmptyResponse();
 
-        CountDownLatch inProgress = new CountDownLatch(3);
+        CountDownLatch coordinatingNodeinProgress = new CountDownLatch(3);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            if (inProgress.getCount() == 3) {
-                inProgress.countDown();
+            if (coordinatingNodeinProgress.getCount() == 3) {
+                coordinatingNodeinProgress.countDown();
                 listener.onResponse(emptyNonNullResponse);
-            } else if (inProgress.getCount() == 2) {
-                inProgress.countDown();
+            } else if (coordinatingNodeinProgress.getCount() == 2) {
+                coordinatingNodeinProgress.countDown();
                 listener.onResponse(nonEmptyResponse);
             } else {
-                inProgress.countDown();
+                coordinatingNodeinProgress.countDown();
                 listener.onResponse(emptyResponse);
             }
             return null;
         }).when(client).search(any(), any());
+
+        // only the EntityResultRequest from nonEmptyResponse will reach model node
+        CountDownLatch modelNodeInProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            if (modelNodeInProgress.getCount() == 1) {
+                modelNodeInProgress.countDown();
+            }
+            return null;
+        }).when(coldEntityQueue).putAll(any());
 
         setUpTransportInterceptor(this::entityResultHandler);
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
@@ -1081,7 +1130,11 @@ public class MultiEntityResultTests extends AbstractADTest {
         AnomalyResultResponse response = listener.actionGet(10000L);
         assertEquals(Double.NaN, response.getAnomalyGrade(), 0.01);
 
-        assertTrue(inProgress.await(10000L, TimeUnit.MILLISECONDS));
+        // since coordinating node and model node run in async model (i.e., coordinating node
+        // does not need sync response to proceed next page, we have to make sure both
+        // coordinating node and model node finishes before checking assertions)
+        assertTrue(coordinatingNodeinProgress.await(10000L, TimeUnit.MILLISECONDS));
+        assertTrue(modelNodeInProgress.await(10000L, TimeUnit.MILLISECONDS));
 
         // since we have 3 results in the first page
         verify(resultWriteQueue, times(1)).put(any());
@@ -1136,27 +1189,41 @@ public class MultiEntityResultTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Pair<NodeStateManager, CountDownLatch> setUpTestExceptionTestingInModelNode() throws IOException {
-        CountDownLatch inProgress = setUpSearchResponse();
+    private NodeStateManager setUpTestExceptionTestingInModelNode() throws IOException {
+        setUpSearchResponse();
         setUpTransportInterceptor(this::entityResultHandler);
         // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
         when(hashRing.getOwningNodeWithSameLocalAdVersionForRealtimeAD(any(String.class)))
             .thenReturn(Optional.of(testNodes[1].discoveryNode()));
 
         NodeStateManager modelNodeStateManager = mock(NodeStateManager.class);
+        CountDownLatch modelNodeInProgress = new CountDownLatch(1);
         // make sure parameters are not null, otherwise this mock won't get invoked
         doAnswer(invocation -> {
             ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
             listener.onResponse(Optional.of(detector));
+            modelNodeInProgress.countDown();
             return null;
         }).when(modelNodeStateManager).getAnomalyDetector(anyString(), any(ActionListener.class));
-        return Pair.of(modelNodeStateManager, inProgress);
+        return modelNodeStateManager;
     }
 
     public void testEndRunNowInModelNode() throws InterruptedException, IOException {
-        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
-        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
-        CountDownLatch inProgress = preparedFixture.getRight();
+        NodeStateManager modelNodeStateManager = setUpTestExceptionTestingInModelNode();
+
+        CountDownLatch inProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            inProgress.countDown();
+            return Optional
+                .of(
+                    new EndRunException(
+                        detectorId,
+                        CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                        new NoSuchElementException("No value present"),
+                        true
+                    )
+                );
+        }).when(modelNodeStateManager).fetchExceptionAndClear(anyString());
 
         when(modelNodeStateManager.fetchExceptionAndClear(anyString()))
             .thenReturn(
@@ -1187,9 +1254,7 @@ public class MultiEntityResultTests extends AbstractADTest {
     }
 
     public void testEndRunNowFalseInModelNode() throws InterruptedException, IOException {
-        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
-        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
-        CountDownLatch inProgress = preparedFixture.getRight();
+        NodeStateManager modelNodeStateManager = setUpTestExceptionTestingInModelNode();
 
         when(modelNodeStateManager.fetchExceptionAndClear(anyString()))
             .thenReturn(
@@ -1205,6 +1270,14 @@ public class MultiEntityResultTests extends AbstractADTest {
             );
 
         setUpEntityResult(1, modelNodeStateManager);
+
+        CountDownLatch inProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            if (inProgress.getCount() == 1) {
+                inProgress.countDown();
+            }
+            return null;
+        }).when(stateManager).setException(anyString(), any());
 
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 
@@ -1229,11 +1302,15 @@ public class MultiEntityResultTests extends AbstractADTest {
      * @throws InterruptedException when failing to wait for inProgress to finish
      */
     public void testTimeOutExceptionInModelNode() throws IOException, InterruptedException {
-        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
-        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
-        CountDownLatch inProgress = preparedFixture.getRight();
+        NodeStateManager modelNodeStateManager = setUpTestExceptionTestingInModelNode();
 
         when(modelNodeStateManager.fetchExceptionAndClear(anyString())).thenReturn(Optional.of(new OpenSearchTimeoutException("blah")));
+
+        CountDownLatch inProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            inProgress.countDown();
+            return null;
+        }).when(stateManager).setException(anyString(), any(Exception.class));
 
         setUpEntityResult(1, modelNodeStateManager);
 
@@ -1263,13 +1340,17 @@ public class MultiEntityResultTests extends AbstractADTest {
     public void testSelectHigherExceptionInModelNode() throws InterruptedException, IOException {
         when(entityCache.get(any(), any())).thenThrow(EndRunException.class);
 
-        Pair<NodeStateManager, CountDownLatch> preparedFixture = setUpTestExceptionTestingInModelNode();
-        NodeStateManager modelNodeStateManager = preparedFixture.getLeft();
-        CountDownLatch inProgress = preparedFixture.getRight();
+        NodeStateManager modelNodeStateManager = setUpTestExceptionTestingInModelNode();
 
         when(modelNodeStateManager.fetchExceptionAndClear(anyString())).thenReturn(Optional.of(new OpenSearchTimeoutException("blah")));
 
         setUpEntityResult(1, modelNodeStateManager);
+
+        CountDownLatch inProgress = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            inProgress.countDown();
+            return null;
+        }).when(stateManager).setException(anyString(), any(Exception.class));
 
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
 

--- a/src/test/java/org/opensearch/ad/util/DateUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/DateUtilsTests.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.util;
+
+import java.time.Duration;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class DateUtilsTests extends OpenSearchTestCase {
+    public void testDuration() {
+        TimeValue time = TimeValue.timeValueHours(3);
+        assertEquals(Duration.ofHours(3), DateUtils.toDuration(time));
+    }
+}


### PR DESCRIPTION
### Description
This PR improves performance to make the 1M1min experiment possible. First, I changed coordinating node pagination from sync to async mode in AnomalyResultTransportAction so that the coordinating node does not have to wait for model nodes' responses before fetching the next page. Second, during the million-entity evaluation, CPU is mostly around 1% with hourly spikes up to 65%. An internal hourly maintenance job can account for the spike due to saving hundreds of thousands of model checkpoints, clearing unused models, and performing bookkeeping for internal states. This PR evens out the resource usage more fairly across a large maintenance window by introducing CheckpointMaintainWorker. Third, during a model corruption, I retrigger cold start for mitigation. Check ModelManager.score, EntityResultTransportAction, and CheckpointReadWorker.

Testing done:
1. Added unit tests.
2. Manually confirmed 1M1min is possible after the above changes.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/338

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
