### PR TITLE
Update BWC zip links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,10 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
-                'opensearch-anomaly-detection-1.0.0.0.zip'
-        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
-                'opensearch-job-scheduler-1.0.0.0.zip'
+        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.1.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-anomaly-detection-1.1.0.0.zip'
+        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.1.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-job-scheduler-1.1.0.0.zip'
 
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
@@ -367,7 +367,7 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 
-String bwcVersion = "1.0.0.0"
+String bwcVersion = "1.1.0.0"
 String baseName = "adBwcCluster"
 String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
 String bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
@@ -377,7 +377,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["1.0.1", opensearch_version]
+            versions = ["1.1.0", opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,11 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        bwcOpenDistroADDownload = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/' +
-                'opendistro-anomaly-detection/opendistro-anomaly-detection-1.13.0.0.zip'
-        bwcOpenDistroJSDownload = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/' +
-                'opendistro-job-scheduler/opendistro-job-scheduler-1.13.0.0.zip'
+        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-anomaly-detection-1.0.0.0.zip'
+        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-job-scheduler-1.0.0.0.zip'
+
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
         // This option turn on log printing during tests. 
@@ -366,7 +367,7 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 
-String bwcVersion = "1.13.0.0"
+String bwcVersion = "1.0.0.0"
 String baseName = "adBwcCluster"
 String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
 String bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
@@ -376,7 +377,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2", opensearch_version]
+            versions = ["1.0.0", opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override
@@ -388,7 +389,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
                                 project.delete(files("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion"))
                             }
                             project.mkdir bwcJobSchedulerPath + bwcVersion
-                            ant.get(src: bwcOpenDistroJSDownload,
+                            ant.get(src: opensearch1xJSDownload,
                                     dest: bwcJobSchedulerPath + bwcVersion,
                                     httpusecaches: false)
                             return fileTree(bwcJobSchedulerPath + bwcVersion).getSingleFile()
@@ -406,7 +407,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
                                 project.delete(files("$project.rootDir/$bwcFilePath/anomaly-detection/$bwcVersion"))
                             }
                             project.mkdir bwcAnomalyDetectionPath + bwcVersion
-                            ant.get(src: bwcOpenDistroADDownload,
+                            ant.get(src: opensearch1xADDownload,
                                     dest: bwcAnomalyDetectionPath + bwcVersion,
                                     httpusecaches: false)
                             return fileTree(bwcAnomalyDetectionPath + bwcVersion).getSingleFile()

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,9 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.1.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
                 'opensearch-anomaly-detection-1.1.0.0.zip'
-        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.1.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
                 'opensearch-job-scheduler-1.1.0.0.zip'
 
         // gradle build won't print logs during test by default unless there is a failure.

--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,10 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.1/latest/linux/x64/tar/builds/opensearch/plugins/' +
-                'opensearch-anomaly-detection-1.0.1.0.zip'
-        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.1/latest/linux/x64/tar/builds/opensearch/plugins/' +
-                'opensearch-job-scheduler-1.0.1.0.zip'
+        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-anomaly-detection-1.0.0.0.zip'
+        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-job-scheduler-1.0.0.0.zip'
 
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
@@ -367,7 +367,7 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 
-String bwcVersion = "1.0.1.0"
+String bwcVersion = "1.0.0.0"
 String baseName = "adBwcCluster"
 String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
 String bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"

--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,10 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
-                'opensearch-anomaly-detection-1.0.0.0.zip'
-        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.0/latest/linux/x64/tar/builds/opensearch/plugins/' +
-                'opensearch-job-scheduler-1.0.0.0.zip'
+        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.1/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-anomaly-detection-1.0.1.0.zip'
+        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.0.1/latest/linux/x64/tar/builds/opensearch/plugins/' +
+                'opensearch-job-scheduler-1.0.1.0.zip'
 
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
@@ -367,7 +367,7 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 
-String bwcVersion = "1.0.0.0"
+String bwcVersion = "1.0.1.0"
 String baseName = "adBwcCluster"
 String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
 String bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
@@ -377,7 +377,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["1.0.0", opensearch_version]
+            versions = ["1.0.1", opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,9 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        opensearch1xADDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
+        bwcOpenSearchADDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
                 'opensearch-anomaly-detection-1.1.0.0.zip'
-        opensearch1xJSDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
+        bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
                 'opensearch-job-scheduler-1.1.0.0.zip'
 
         // gradle build won't print logs during test by default unless there is a failure.
@@ -389,7 +389,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
                                 project.delete(files("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion"))
                             }
                             project.mkdir bwcJobSchedulerPath + bwcVersion
-                            ant.get(src: opensearch1xJSDownload,
+                            ant.get(src: bwcOpenSearchJSDownload,
                                     dest: bwcJobSchedulerPath + bwcVersion,
                                     httpusecaches: false)
                             return fileTree(bwcJobSchedulerPath + bwcVersion).getSingleFile()
@@ -407,7 +407,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
                                 project.delete(files("$project.rootDir/$bwcFilePath/anomaly-detection/$bwcVersion"))
                             }
                             project.mkdir bwcAnomalyDetectionPath + bwcVersion
-                            ant.get(src: opensearch1xADDownload,
+                            ant.get(src: bwcOpenSearchADDownload,
                                     dest: bwcAnomalyDetectionPath + bwcVersion,
                                     httpusecaches: false)
                             return fileTree(bwcAnomalyDetectionPath + bwcVersion).getSingleFile()

--- a/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
@@ -143,8 +143,8 @@ public class ADBackwardsCompatibilityIT extends OpenSearchRestTestCase {
                         categoryFieldSize
                     );
                     assertEquals(totalDocsPerCategory * categoryFieldSize * 2, getDocCountOfIndex(client(), dataIndexName));
-                    Assert.assertTrue(pluginNames.contains("opendistro-anomaly-detection"));
-                    Assert.assertTrue(pluginNames.contains("opendistro-job-scheduler"));
+                    Assert.assertTrue(pluginNames.contains("opensearch-anomaly-detection"));
+                    Assert.assertTrue(pluginNames.contains("opensearch-job-scheduler"));
 
                     // Create single entity detector and start realtime job
                     createRealtimeAnomalyDetectorsAndStart(SINGLE_ENTITY_DETECTOR);

--- a/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
@@ -403,8 +403,7 @@ public class ADBackwardsCompatibilityIT extends OpenSearchRestTestCase {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void createHistoricalAnomalyDetectorsAndStart() throws Exception {
+    private List<String> createHistoricalAnomalyDetectorsAndStart() throws Exception {
         // only support single entity for historical detector
         Response historicalSingleFlowDetectorResponse = createAnomalyDetector(
             client(),
@@ -418,16 +417,7 @@ public class ADBackwardsCompatibilityIT extends OpenSearchRestTestCase {
             null,
             true
         );
-        List<String> historicalDetectorStartResult = startAnomalyDetector(historicalSingleFlowDetectorResponse, true);
-        String detectorId = historicalDetectorStartResult.get(0);
-        String taskId = historicalDetectorStartResult.get(1);
-        deleteRunningDetector(detectorId);
-        waitUntilTaskDone(client(), detectorId);
-        List<ADTask> adTasks = searchLatestAdTaskOfDetector(client(), detectorId, ADTaskType.HISTORICAL.name());
-        assertEquals(1, adTasks.size());
-        assertEquals(taskId, adTasks.get(0).getTaskId());
-        int adResultCount = countADResultOfDetector(client(), detectorId, taskId);
-        assertTrue(adResultCount > 0);
+        return startAnomalyDetector(historicalSingleFlowDetectorResponse, true);
     }
 
     private void deleteRunningDetector(String detectorId) {


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Update BWC links to point to OpenSearch 1.1.0, since Open Distro is now officially unsupported. See OpenSearch [maintenance policy](https://opensearch.org/releases.html#maintenance-policy) on supported versions.

This PR also cleans up BWC tests to be compatible with 1.1 as the baseline. Note there was some changes to historical analysis between ODFE 1.13.0.0 (based on ES 7.10.2) => OpenSearch 1.1.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
