### PR TITLE
Fix taskmanager compilation error in FakeNode

### DIFF
--- a/src/test/java/test/org/opensearch/ad/util/FakeNode.java
+++ b/src/test/java/test/org/opensearch/ad/util/FakeNode.java
@@ -94,11 +94,11 @@ public class FakeNode implements Releasable {
             Collections.emptySet()
         ) {
             @Override
-            protected TaskManager createTaskManager(Settings settings, ThreadPool threadPool, Set<String> taskHeaders) {
+            protected TaskManager createTaskManager(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, Set<String> taskHeaders) {
                 if (MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.get(settings)) {
                     return new MockTaskManager(settings, threadPool, taskHeaders);
                 } else {
-                    return super.createTaskManager(settings, threadPool, taskHeaders);
+                    return super.createTaskManager(settings, clusterSettings, threadPool, taskHeaders);
                 }
             }
         };


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
This [PR in OpenSearch](https://github.com/opensearch-project/OpenSearch/pull/4141) refactored the `TaskManager` which is overridden in `FakeNode` and was merged on 8/5. This fixes the compilation error as seen from [this GHA](https://github.com/opensearch-project/anomaly-detection/runs/7700323125?check_suite_focus=true)

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
