### PR TITLE
Fix window delay test

### DIFF
--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -537,6 +537,8 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
         List<JsonObject> data = createData(2000, recDetectorIntervalMillis);
         indexTrainData("validation", data, 2000, client);
         long detectorInterval = 4;
+        long expectedWindowDelayMillis = Instant.now().toEpochMilli() - data.get(0).get("timestamp").getAsLong();
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(expectedWindowDelayMillis);
         String requestBody = String
             .format(
                 Locale.ROOT,
@@ -563,8 +565,7 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
             .extractValue("model", responseMap);
         // adding plus one since window delay always rounds up another minute
         assertEquals(
-            String
-                .format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, +recDetectorIntervalMinutes + 1, recDetectorIntervalMinutes + 1),
+            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, +minutes + 1, minutes + 1),
             messageMap.get("window_delay").get("message")
         );
     }

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -565,7 +565,7 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
             .extractValue("model", responseMap);
         // adding plus one since window delay always rounds up another minute
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, +minutes + 1, minutes + 1),
+            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC,  minutes + 1, minutes + 1),
             messageMap.get("window_delay").get("message")
         );
     }

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -531,14 +531,14 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
 
     public void testValidationWindowDelayRecommendation() throws Exception {
         RestClient client = client();
-        long recDetectorIntervalMillis = 180000;
+        long recDetectorIntervalMillisForDataSet = 180000;
         // this would be equivalent to the window delay in this data test
-        long recDetectorIntervalMinutes = recDetectorIntervalMillis / 60000;
-        List<JsonObject> data = createData(2000, recDetectorIntervalMillis);
+        List<JsonObject> data = createData(2000, recDetectorIntervalMillisForDataSet);
         indexTrainData("validation", data, 2000, client);
         long detectorInterval = 4;
         long expectedWindowDelayMillis = Instant.now().toEpochMilli() - data.get(0).get("timestamp").getAsLong();
-        long minutes = TimeUnit.MILLISECONDS.toMinutes(expectedWindowDelayMillis);
+        // we always round up for window delay recommendation to reduce chance of missed data.
+        long expectedWindowDelayMinutes = (long) Math.ceil(expectedWindowDelayMillis / 60000.0);
         String requestBody = String
             .format(
                 Locale.ROOT,
@@ -563,9 +563,8 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Map<String, String>> messageMap = (Map<String, Map<String, String>>) XContentMapValues
             .extractValue("model", responseMap);
-        // adding plus one since window delay always rounds up another minute
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, minutes + 1, minutes + 1),
+            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, expectedWindowDelayMinutes, expectedWindowDelayMinutes),
             messageMap.get("window_delay").get("message")
         );
     }

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -565,7 +565,7 @@ public class DetectionResultEvalutationIT extends ODFERestTestCase {
             .extractValue("model", responseMap);
         // adding plus one since window delay always rounds up another minute
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC,  minutes + 1, minutes + 1),
+            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, minutes + 1, minutes + 1),
             messageMap.get("window_delay").get("message")
         );
     }


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Changed integration test so it doesn't default to exact window delay that assumes creation of data and test run time is in a few seconds. When I ran this test on my mac, the test took longer to run meaning more time has passed between the data creation and the validate API call. 

Meaning that it would fail with something like, "expected window delay to be 4 minutes but got 6 minutes if test took 2 minutes longer". I am not 100% sure why my macbook was so slow for this test where it didn't even fail on the github CI runner but regardless new logic makes more sense.

However with this fixed we can now, run, test and build AD on macos. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
