### PR TITLE
Replace references to deleted BaseNodeRequest with TransportRequest

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/ADCancelTaskNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ADCancelTaskNodeRequest.java
@@ -13,11 +13,11 @@ package org.opensearch.ad.transport;
 
 import java.io.IOException;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class ADCancelTaskNodeRequest extends BaseNodeRequest {
+public class ADCancelTaskNodeRequest extends TransportRequest {
     private String detectorId;
     private String detectorTaskId;
     private String userName;

--- a/src/main/java/org/opensearch/ad/transport/ADStatsNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ADStatsNodeRequest.java
@@ -13,14 +13,14 @@ package org.opensearch.ad.transport;
 
 import java.io.IOException;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 /**
  *  ADStatsNodeRequest to get a nodes stat
  */
-public class ADStatsNodeRequest extends BaseNodeRequest {
+public class ADStatsNodeRequest extends TransportRequest {
     private ADStatsRequest request;
 
     /**

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileNodeRequest.java
@@ -13,11 +13,11 @@ package org.opensearch.ad.transport;
 
 import java.io.IOException;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class ADTaskProfileNodeRequest extends BaseNodeRequest {
+public class ADTaskProfileNodeRequest extends TransportRequest {
     private String detectorId;
 
     public ADTaskProfileNodeRequest(StreamInput in) throws IOException {

--- a/src/main/java/org/opensearch/ad/transport/CronNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/CronNodeRequest.java
@@ -13,13 +13,13 @@ package org.opensearch.ad.transport;
 
 import java.io.IOException;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.transport.TransportRequest;
 
 /**
  *  Delete model represents the request to an individual node
  */
-public class CronNodeRequest extends BaseNodeRequest {
+public class CronNodeRequest extends TransportRequest {
 
     public CronNodeRequest() {}
 

--- a/src/main/java/org/opensearch/ad/transport/DeleteModelNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteModelNodeRequest.java
@@ -13,14 +13,14 @@ package org.opensearch.ad.transport;
 
 import java.io.IOException;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 /**
  *  Delete model represents the request to an individual node
  */
-public class DeleteModelNodeRequest extends BaseNodeRequest {
+public class DeleteModelNodeRequest extends TransportRequest {
 
     private String adID;
 

--- a/src/main/java/org/opensearch/ad/transport/ProfileNodeRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ProfileNodeRequest.java
@@ -14,15 +14,15 @@ package org.opensearch.ad.transport;
 import java.io.IOException;
 import java.util.Set;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 /**
  *  Class representing a nodes's profile request
  */
-public class ProfileNodeRequest extends BaseNodeRequest {
+public class ProfileNodeRequest extends TransportRequest {
     private ProfileRequest request;
 
     public ProfileNodeRequest(StreamInput in) throws IOException {

--- a/src/test/java/org/opensearch/ad/mock/transport/MockADCancelTaskNodeRequest_1_0.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockADCancelTaskNodeRequest_1_0.java
@@ -13,11 +13,11 @@ package org.opensearch.ad.mock.transport;
 
 import java.io.IOException;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
-public class MockADCancelTaskNodeRequest_1_0 extends BaseNodeRequest {
+public class MockADCancelTaskNodeRequest_1_0 extends TransportRequest {
     private String detectorId;
     private String userName;
 


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
[#4702](https://github.com/opensearch-project/OpenSearch/pull/4702) removed the (deprecated) `BaseNodeRequest` class.

Per the `@deprecated` tag in the javadocs of the removed class, subclasses should extend `TransportRequest` directly.

### Issues Resolved
Fixes #687

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
