### PR TITLE
[Feature/extensions] Randomized detector id for create/get detector

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -103,7 +103,8 @@ public class AnomalyDetectorExtension implements Extension {
 
     public OpenSearchClient getClient() {
         SDKClient sdkClient = new SDKClient();
-        OpenSearchClient client = sdkClient.initializeClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
+        OpenSearchClient client = sdkClient
+            .initializeClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
         return client;
     }
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -103,7 +103,7 @@ public class AnomalyDetectorExtension implements Extension {
 
     public OpenSearchClient getClient() {
         SDKClient sdkClient = new SDKClient();
-        OpenSearchClient client = sdkClient.initializeClient("localhost", 9200);
+        OpenSearchClient client = sdkClient.initializeClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
         return client;
     }
 

--- a/src/main/java/org/opensearch/ad/rest/RestCreateDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestCreateDetectorAction.java
@@ -94,7 +94,6 @@ public class RestCreateDetectorAction implements ExtensionRestHandler {
 
         IndexRequest<AnomalyDetector> indexRequest = new IndexRequest.Builder<AnomalyDetector>()
             .index(ANOMALY_DETECTORS_INDEX)
-            .id("1")
             .document(detector)
             .build();
         IndexResponse indexResponse = sdkClient.index(indexRequest);

--- a/src/main/resources/ad-extension.yml
+++ b/src/main/resources/ad-extension.yml
@@ -1,3 +1,5 @@
 extensionName: ad-extension
 hostAddress: 127.0.0.1
 hostPort: 4532
+opensearchAddress: 127.0.01
+opensearchPort: 9200

--- a/src/main/resources/ad-extension.yml
+++ b/src/main/resources/ad-extension.yml
@@ -1,5 +1,5 @@
 extensionName: ad-extension
 hostAddress: 127.0.0.1
 hostPort: 4532
-opensearchAddress: 127.0.01
+opensearchAddress: 127.0.0.1
 opensearchPort: 9200


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Randomized detector id for create/get detector
Currently the detector id for create/get detector is not randomized and is a pure string in the response of create detector
```
{
    "id": "1",
    "version": 1,
   ```
Changed it to
```
{
  "_id": "VEHKTXwBwf_U8gjUXY2s",
  "_version": 1,
```
### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-sdk-java/issues/212

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
