### PR TITLE
Speed up cold start

### DIFF
--- a/src/main/java/org/opensearch/ad/settings/EnabledSetting.java
+++ b/src/main/java/org/opensearch/ad/settings/EnabledSetting.java
@@ -39,8 +39,9 @@ public class EnabledSetting extends AbstractSetting {
 
     public static final String LEGACY_OPENDISTRO_AD_BREAKER_ENABLED = "opendistro.anomaly_detection.breaker.enabled";
 
-    public static final String INTERPOLATION_IN_HCAD_COLD_START_ENABLED =
-        "plugins.anomaly_detection.hcad_cold_start_interpolation.enabled";;
+    public static final String INTERPOLATION_IN_HCAD_COLD_START_ENABLED = "plugins.anomaly_detection.hcad_cold_start_interpolation.enabled";
+
+    public static final String DOOR_KEEPER_IN_CACHE_ENABLED = "plugins.anomaly_detection.door_keeper_in_cache.enabled";;
 
     public static final Map<String, Setting<?>> settings = unmodifiableMap(new HashMap<String, Setting<?>>() {
         {
@@ -75,6 +76,13 @@ public class EnabledSetting extends AbstractSetting {
                 INTERPOLATION_IN_HCAD_COLD_START_ENABLED,
                 Setting.boolSetting(INTERPOLATION_IN_HCAD_COLD_START_ENABLED, false, NodeScope, Dynamic)
             );
+
+            /**
+             * We have a bloom filter placed in front of inactive entity cache to
+             * filter out unpopular items that are not likely to appear more
+             * than once. Whether this bloom filter is enabled or not.
+             */
+            put(DOOR_KEEPER_IN_CACHE_ENABLED, Setting.boolSetting(DOOR_KEEPER_IN_CACHE_ENABLED, false, NodeScope, Dynamic));
         }
     });
 
@@ -111,5 +119,13 @@ public class EnabledSetting extends AbstractSetting {
      */
     public static boolean isInterpolationInColdStartEnabled() {
         return EnabledSetting.getInstance().getSettingValue(EnabledSetting.INTERPOLATION_IN_HCAD_COLD_START_ENABLED);
+    }
+
+    /**
+     * If enabled, we filter out unpopular items that are not likely to appear more than once
+     * @return wWhether door keeper in cache is enabled or not.
+     */
+    public static boolean isDoorKeeperInCacheEnabled() {
+        return EnabledSetting.getInstance().getSettingValue(EnabledSetting.DOOR_KEEPER_IN_CACHE_ENABLED);
     }
 }


### PR DESCRIPTION
### Description
If historical data is enough, a single stream detector takes 1 interval for cold start to be triggered + 1 interval for the state document to be updated. Similar to single stream detectors, HCAD cold start needs 2 intervals and one more interval to make sure an entity appears more than once. So HCAD needs three intervals to complete cold starts. Long initialization is the single most complained problem of AD. This PR reduces both single stream and HCAD detectors' initialization time to one interval + 1 minute by
* delaying real time cache update by one minute so we will have trained models by then and update the state document accordingly.
* disable door keeper by default so that we won't wait extra interval in HCAD

Testing done:
1. verified the cold start time is reduced using the frontend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
