### PR TITLE
Fix: typo in ohltyler.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,7 @@
 | Kaituo Li               | [kaituo](https://github.com/kaituo)                     | Amazon      |
 | Lai Jiang               | [wnbts](https://github.com/wnbts)                       | Amazon      |
 | Sarat Vemulapalli       | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
-| Tyler Ohlsen            | [ohtyler](https://github.com/ohltyler)                  | Amazon      |
+| Tyler Ohlsen            | [ohltyler](https://github.com/ohltyler)                 | Amazon      |
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)                   | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)                 | Amazon      |
 | Yaliang Wu              | [ylwu-amzn](https://github.com/ylwu-amzn)               | Amazon      |


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Fix: typo in ohltyler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
