### PR TITLE
[Backport to 2.x] Speed up cold start (#753)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ configurations.all {
     if (it.state != Configuration.State.UNRESOLVED) return
     resolutionStrategy {
         force "joda-time:joda-time:${versions.joda}"
-        force "com.fasterxml.jackson.core:jackson-core:2.14.0"
+        force "com.fasterxml.jackson.core:jackson-core:2.14.1"
         force "commons-logging:commons-logging:${versions.commonslogging}"
         force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
         force "commons-codec:commons-codec:${versions.commonscodec}"
@@ -677,9 +677,9 @@ dependencies {
     implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0-rc3'
 
     // force Jackson version to avoid version conflict issue
-    implementation "com.fasterxml.jackson.core:jackson-core:2.14.0"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.0"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.0"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.14.1"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.1"
 
     // used for serializing/deserializing rcf models.
     implementation group: 'io.protostuff', name: 'protostuff-core', version: '1.8.0'

--- a/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
+++ b/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
@@ -1,0 +1,288 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad;
+
+import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_LATEST_TASK;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.ad.common.exception.EndRunException;
+import org.opensearch.ad.common.exception.ResourceNotFoundException;
+import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.indices.ADIndex;
+import org.opensearch.ad.indices.AnomalyDetectionIndices;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.model.DetectorProfileName;
+import org.opensearch.ad.model.FeatureData;
+import org.opensearch.ad.model.IntervalTimeConfiguration;
+import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.ad.transport.AnomalyResultResponse;
+import org.opensearch.ad.transport.ProfileAction;
+import org.opensearch.ad.transport.ProfileRequest;
+import org.opensearch.ad.transport.RCFPollingAction;
+import org.opensearch.ad.transport.RCFPollingRequest;
+import org.opensearch.ad.transport.handler.AnomalyIndexHandler;
+import org.opensearch.ad.util.DiscoveryNodeFilterer;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.threadpool.ThreadPool;
+
+public class ExecuteADResultResponseRecorder {
+    private static final Logger log = LogManager.getLogger(ExecuteADResultResponseRecorder.class);
+
+    private AnomalyDetectionIndices anomalyDetectionIndices;
+    private AnomalyIndexHandler<AnomalyResult> anomalyResultHandler;
+    private ADTaskManager adTaskManager;
+    private DiscoveryNodeFilterer nodeFilter;
+    private ThreadPool threadPool;
+    private Client client;
+
+    public ExecuteADResultResponseRecorder(
+        AnomalyDetectionIndices anomalyDetectionIndices,
+        AnomalyIndexHandler<AnomalyResult> anomalyResultHandler,
+        ADTaskManager adTaskManager,
+        DiscoveryNodeFilterer nodeFilter,
+        ThreadPool threadPool,
+        Client client
+    ) {
+        this.anomalyDetectionIndices = anomalyDetectionIndices;
+        this.anomalyResultHandler = anomalyResultHandler;
+        this.adTaskManager = adTaskManager;
+        this.nodeFilter = nodeFilter;
+        this.threadPool = threadPool;
+        this.client = client;
+    }
+
+    public void indexAnomalyResult(
+        Instant detectionStartTime,
+        Instant executionStartTime,
+        AnomalyResultResponse response,
+        AnomalyDetector detector
+    ) {
+        String detectorId = detector.getDetectorId();
+        try {
+            // skipping writing to the result index if not necessary
+            // For a single-entity detector, the result is not useful if error is null
+            // and rcf score (thus anomaly grade/confidence) is null.
+            // For a HCAD detector, we don't need to save on the detector level.
+            // We return 0 or Double.NaN rcf score if there is no error.
+            if ((response.getAnomalyScore() <= 0 || Double.isNaN(response.getAnomalyScore())) && response.getError() == null) {
+                updateRealtimeTask(response, detectorId);
+                return;
+            }
+            IntervalTimeConfiguration windowDelay = (IntervalTimeConfiguration) detector.getWindowDelay();
+            Instant dataStartTime = detectionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+            Instant dataEndTime = executionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+            User user = detector.getUser();
+
+            if (response.getError() != null) {
+                log.info("Anomaly result action run successfully for {} with error {}", detectorId, response.getError());
+            }
+
+            AnomalyResult anomalyResult = response
+                .toAnomalyResult(
+                    detectorId,
+                    dataStartTime,
+                    dataEndTime,
+                    executionStartTime,
+                    Instant.now(),
+                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT),
+                    user,
+                    response.getError()
+                );
+
+            String resultIndex = detector.getResultIndex();
+            anomalyResultHandler.index(anomalyResult, detectorId, resultIndex);
+            updateRealtimeTask(response, detectorId);
+        } catch (EndRunException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to index anomaly result for " + detectorId, e);
+        }
+    }
+
+    /**
+     * Update real time task (one document per detector in state index). If the real-time task has no changes compared with local cache,
+     * the task won't update. Task only updates when the state changed, or any error happened, or AD job stopped. Task is mainly consumed
+     * by the front-end to track detector status. For single-stream detectors, we embed model total updates in AnomalyResultResponse and
+     * update state accordingly. For HCAD, we won't wait for model finishing updating before returning a response to the job scheduler
+     * since it might be long before all entities finish execution. So we don't embed model total updates in AnomalyResultResponse.
+     * Instead, we issue a profile request to poll each model node and get the maximum total updates among all models.
+     * @param response response returned from executing AnomalyResultAction
+     * @param detectorId Detector Id
+     */
+    private void updateRealtimeTask(AnomalyResultResponse response, String detectorId) {
+        if (response.isHCDetector() != null && response.isHCDetector()) {
+            if (adTaskManager.skipUpdateHCRealtimeTask(detectorId, response.getError())) {
+                return;
+            }
+            DiscoveryNode[] dataNodes = nodeFilter.getEligibleDataNodes();
+            Set<DetectorProfileName> profiles = new HashSet<>();
+            profiles.add(DetectorProfileName.INIT_PROGRESS);
+            ProfileRequest profileRequest = new ProfileRequest(detectorId, profiles, true, dataNodes);
+            Runnable profileHCInitProgress = () -> {
+                client.execute(ProfileAction.INSTANCE, profileRequest, ActionListener.wrap(r -> {
+                    log.debug("Update latest realtime task for HC detector {}, total updates: {}", detectorId, r.getTotalUpdates());
+                    updateLatestRealtimeTask(
+                        detectorId,
+                        null,
+                        r.getTotalUpdates(),
+                        response.getDetectorIntervalInMinutes(),
+                        response.getError()
+                    );
+                }, e -> { log.error("Failed to update latest realtime task for " + detectorId, e); }));
+            };
+            if (!adTaskManager.isHCRealtimeTaskStartInitializing(detectorId)) {
+                // real time init progress is 0 may mean this is a newly started detector
+                // Delay real time cache update by one minute. If we are in init status, the delay may give the model training time to
+                // finish. We can change the detector running immediately instead of waiting for the next interval.
+                threadPool.schedule(profileHCInitProgress, new TimeValue(60, TimeUnit.SECONDS), AnomalyDetectorPlugin.AD_THREAD_POOL_NAME);
+            } else {
+                profileHCInitProgress.run();
+            }
+
+        } else {
+            log
+                .debug(
+                    "Update latest realtime task for single stream detector {}, total updates: {}",
+                    detectorId,
+                    response.getRcfTotalUpdates()
+                );
+            updateLatestRealtimeTask(
+                detectorId,
+                null,
+                response.getRcfTotalUpdates(),
+                response.getDetectorIntervalInMinutes(),
+                response.getError()
+            );
+        }
+    }
+
+    private void updateLatestRealtimeTask(
+        String detectorId,
+        String taskState,
+        Long rcfTotalUpdates,
+        Long detectorIntervalInMinutes,
+        String error
+    ) {
+        // Don't need info as this will be printed repeatedly in each interval
+        adTaskManager
+            .updateLatestRealtimeTaskOnCoordinatingNode(
+                detectorId,
+                taskState,
+                rcfTotalUpdates,
+                detectorIntervalInMinutes,
+                error,
+                ActionListener.wrap(r -> {
+                    if (r != null) {
+                        log.debug("Updated latest realtime task successfully for detector {}, taskState: {}", detectorId, taskState);
+                    }
+                }, e -> {
+                    if ((e instanceof ResourceNotFoundException) && e.getMessage().contains(CAN_NOT_FIND_LATEST_TASK)) {
+                        // Clear realtime task cache, will recreate AD task in next run, check AnomalyResultTransportAction.
+                        log.error("Can't find latest realtime task of detector " + detectorId);
+                        adTaskManager.removeRealtimeTaskCache(detectorId);
+                    } else {
+                        log.error("Failed to update latest realtime task for detector " + detectorId, e);
+                    }
+                })
+            );
+    }
+
+    /**
+     * The function is not only indexing the result with the exception, but also updating the task state after
+     * 60s if the exception is related to cold start (index not found exceptions) for a single stream detector.
+     *
+     * @param detectionStartTime execution start time
+     * @param executionStartTime execution end time
+     * @param errorMessage Error message to record
+     * @param taskState AD task state (e.g., stopped)
+     * @param detector Detector config accessor
+     */
+    public void indexAnomalyResultException(
+        Instant detectionStartTime,
+        Instant executionStartTime,
+        String errorMessage,
+        String taskState,
+        AnomalyDetector detector
+    ) {
+        String detectorId = detector.getDetectorId();
+        try {
+            IntervalTimeConfiguration windowDelay = (IntervalTimeConfiguration) detector.getWindowDelay();
+            Instant dataStartTime = detectionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+            Instant dataEndTime = executionStartTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+            User user = detector.getUser();
+
+            AnomalyResult anomalyResult = new AnomalyResult(
+                detectorId,
+                null, // no task id
+                new ArrayList<FeatureData>(),
+                dataStartTime,
+                dataEndTime,
+                executionStartTime,
+                Instant.now(),
+                errorMessage,
+                null, // single-stream detectors have no entity
+                user,
+                anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT),
+                null // no model id
+            );
+            String resultIndex = detector.getResultIndex();
+            if (resultIndex != null && !anomalyDetectionIndices.doesIndexExist(resultIndex)) {
+                // Set result index as null, will write exception to default result index.
+                anomalyResultHandler.index(anomalyResult, detectorId, null);
+            } else {
+                anomalyResultHandler.index(anomalyResult, detectorId, resultIndex);
+            }
+
+            if (errorMessage.contains(CommonErrorMessages.NO_CHECKPOINT_ERR_MSG) && !detector.isMultiCategoryDetector()) {
+                // single stream detector raises ResourceNotFoundException containing CommonErrorMessages.NO_CHECKPOINT_ERR_MSG
+                // when there is no checkpoint.
+                // Delay real time cache update by one minute so we will have trained models by then and update the state
+                // document accordingly.
+                threadPool.schedule(() -> {
+                    RCFPollingRequest request = new RCFPollingRequest(detectorId);
+                    client.execute(RCFPollingAction.INSTANCE, request, ActionListener.wrap(rcfPollResponse -> {
+                        long totalUpdates = rcfPollResponse.getTotalUpdates();
+                        // if there are updates, don't record failures
+                        updateLatestRealtimeTask(
+                            detectorId,
+                            taskState,
+                            totalUpdates,
+                            detector.getDetectorIntervalInMinutes(),
+                            totalUpdates > 0 ? "" : errorMessage
+                        );
+                    }, e -> {
+                        log.error("Fail to execute RCFRollingAction", e);
+                        updateLatestRealtimeTask(detectorId, taskState, null, null, errorMessage);
+                    }));
+                }, new TimeValue(60, TimeUnit.SECONDS), AnomalyDetectorPlugin.AD_THREAD_POOL_NAME);
+            } else {
+                updateLatestRealtimeTask(detectorId, taskState, null, null, errorMessage);
+            }
+
+        } catch (Exception e) {
+            log.error("Failed to index anomaly result for " + detectorId, e);
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -123,6 +123,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     private DetectionDateRange detectionDateRange;
 
     public static final int MAX_RESULT_INDEX_NAME_SIZE = 255;
+    // OS doesn’t allow uppercase: https://tinyurl.com/yse2xdbx
     public static final String RESULT_INDEX_NAME_PATTERN = "[a-z0-9_-]+";
 
     /**

--- a/src/main/java/org/opensearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -70,7 +70,6 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
         }
         AnomalyDetectorExecutionInput input = getAnomalyDetectorExecutionInput(request);
         return channel -> {
-            String rawPath = request.rawPath();
             String error = validateAdExecutionInput(input);
             if (StringUtils.isNotBlank(error)) {
                 channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, error));

--- a/src/main/java/org/opensearch/ad/settings/EnabledSetting.java
+++ b/src/main/java/org/opensearch/ad/settings/EnabledSetting.java
@@ -39,8 +39,9 @@ public class EnabledSetting extends AbstractSetting {
 
     public static final String LEGACY_OPENDISTRO_AD_BREAKER_ENABLED = "opendistro.anomaly_detection.breaker.enabled";
 
-    public static final String INTERPOLATION_IN_HCAD_COLD_START_ENABLED =
-        "plugins.anomaly_detection.hcad_cold_start_interpolation.enabled";;
+    public static final String INTERPOLATION_IN_HCAD_COLD_START_ENABLED = "plugins.anomaly_detection.hcad_cold_start_interpolation.enabled";
+
+    public static final String DOOR_KEEPER_IN_CACHE_ENABLED = "plugins.anomaly_detection.door_keeper_in_cache.enabled";;
 
     public static final Map<String, Setting<?>> settings = unmodifiableMap(new HashMap<String, Setting<?>>() {
         {
@@ -75,6 +76,13 @@ public class EnabledSetting extends AbstractSetting {
                 INTERPOLATION_IN_HCAD_COLD_START_ENABLED,
                 Setting.boolSetting(INTERPOLATION_IN_HCAD_COLD_START_ENABLED, false, NodeScope, Dynamic)
             );
+
+            /**
+             * We have a bloom filter placed in front of inactive entity cache to
+             * filter out unpopular items that are not likely to appear more
+             * than once. Whether this bloom filter is enabled or not.
+             */
+            put(DOOR_KEEPER_IN_CACHE_ENABLED, Setting.boolSetting(DOOR_KEEPER_IN_CACHE_ENABLED, false, NodeScope, Dynamic));
         }
     });
 
@@ -111,5 +119,13 @@ public class EnabledSetting extends AbstractSetting {
      */
     public static boolean isInterpolationInColdStartEnabled() {
         return EnabledSetting.getInstance().getSettingValue(EnabledSetting.INTERPOLATION_IN_HCAD_COLD_START_ENABLED);
+    }
+
+    /**
+     * If enabled, we filter out unpopular items that are not likely to appear more than once
+     * @return wWhether door keeper in cache is enabled or not.
+     */
+    public static boolean isDoorKeeperInCacheEnabled() {
+        return EnabledSetting.getInstance().getSettingValue(EnabledSetting.DOOR_KEEPER_IN_CACHE_ENABLED);
     }
 }

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -334,7 +334,7 @@ public class ADTaskManager {
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             if (detectionDateRange == null) {
                 // start realtime job
-                handler.startAnomalyDetectorJob(detector.get());
+                handler.startAnomalyDetectorJob(detector.get(), listener);
             } else {
                 // start historical analysis task
                 forwardApplyForTaskSlotsRequestToLeadNode(detector.get(), detectionDateRange, user, transportService, listener);
@@ -852,7 +852,7 @@ public class ADTaskManager {
                 );
             } else {
                 // stop realtime detector job
-                handler.stopAnomalyDetectorJob(detectorId);
+                handler.stopAnomalyDetectorJob(detectorId, listener);
             }
         }, listener);
     }
@@ -2818,6 +2818,13 @@ public class ADTaskManager {
             && realtimeTaskCache.getInitProgress() != null
             && realtimeTaskCache.getInitProgress().floatValue() == 1.0
             && Objects.equals(error, realtimeTaskCache.getError());
+    }
+
+    public boolean isHCRealtimeTaskStartInitializing(String detectorId) {
+        ADRealtimeTaskCache realtimeTaskCache = adTaskCacheManager.getRealtimeTaskCache(detectorId);
+        return realtimeTaskCache != null
+            && realtimeTaskCache.getInitProgress() != null
+            && realtimeTaskCache.getInitProgress().floatValue() > 0;
     }
 
     public String convertEntityToString(ADTask adTask) {

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -696,7 +696,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         }
         LOG.info("Trigger cold start for {}", detector.getDetectorId());
         coldStart(detector);
-        return previousException.orElse(new InternalFailure(adID, NO_MODEL_ERR_MSG));
+        return previousException.orElse(exp);
     }
 
     private void findException(Throwable cause, String adID, AtomicReference<Exception> failure, String nodeId) {

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -114,7 +114,6 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
 
     public void testColdStart() throws InterruptedException, IOException {
         Queue<double[]> samples = MLUtil.createQueueSamples(1);
-        double[] savedSample = samples.peek();
         EntityModel model = new EntityModel(entity, samples, null);
         modelState = new ModelState<>(model, modelId, detectorId, ModelType.ENTITY.getName(), clock, priority);
 

--- a/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.ad.ExecuteADResultResponseRecorder;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.rest.handler.IndexAnomalyDetectorJobActionHandler;
@@ -52,6 +53,7 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
     private ThreadContext.StoredContext context;
     private final ADTaskManager adTaskManager;
     private final TransportService transportService;
+    private final ExecuteADResultResponseRecorder recorder;
 
     @Inject
     public MockAnomalyDetectorJobTransportActionWithUser(
@@ -62,7 +64,8 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
         Settings settings,
         AnomalyDetectionIndices anomalyDetectionIndices,
         NamedXContentRegistry xContentRegistry,
-        ADTaskManager adTaskManager
+        ADTaskManager adTaskManager,
+        ExecuteADResultResponseRecorder recorder
     ) {
         super(MockAnomalyDetectorJobAction.NAME, transportService, actionFilters, AnomalyDetectorJobRequest::new);
         this.transportService = transportService;
@@ -77,6 +80,7 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
 
         ThreadContext threadContext = new ThreadContext(settings);
         context = threadContext.stashContext();
+        this.recorder = recorder;
     }
 
     @Override
@@ -131,7 +135,6 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
     ) {
         IndexAnomalyDetectorJobActionHandler handler = new IndexAnomalyDetectorJobActionHandler(
             client,
-            listener,
             anomalyDetectionIndices,
             detectorId,
             seqNo,
@@ -139,7 +142,8 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
             requestTimeout,
             xContentRegistry,
             transportService,
-            adTaskManager
+            adTaskManager,
+            recorder
         );
         if (rawPath.endsWith(RestHandlerUtils.START_JOB)) {
             adTaskManager.startDetector(detectorId, detectionDateRange, handler, user, transportService, context, listener);

--- a/src/test/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandlerTests.java
@@ -1,0 +1,354 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.rest.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.action.DocWriteResponse.Result.CREATED;
+import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_LATEST_TASK;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.ad.ExecuteADResultResponseRecorder;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.common.exception.ResourceNotFoundException;
+import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.indices.AnomalyDetectionIndices;
+import org.opensearch.ad.mock.model.MockSimpleLog;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.model.Feature;
+import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.ad.transport.AnomalyDetectorJobResponse;
+import org.opensearch.ad.transport.AnomalyResultAction;
+import org.opensearch.ad.transport.AnomalyResultResponse;
+import org.opensearch.ad.transport.ProfileAction;
+import org.opensearch.ad.transport.ProfileResponse;
+import org.opensearch.ad.transport.handler.AnomalyIndexHandler;
+import org.opensearch.ad.util.DiscoveryNodeFilterer;
+import org.opensearch.client.Client;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import com.google.common.collect.ImmutableList;
+
+public class IndexAnomalyDetectorJobActionHandlerTests extends OpenSearchTestCase {
+
+    private static AnomalyDetectionIndices anomalyDetectionIndices;
+    private static String detectorId;
+    private static Long seqNo;
+    private static Long primaryTerm;
+
+    private static NamedXContentRegistry xContentRegistry;
+    private static TransportService transportService;
+    private static TimeValue requestTimeout;
+    private static DiscoveryNodeFilterer nodeFilter;
+    private static AnomalyDetector detector;
+
+    private ADTaskManager adTaskManager;
+
+    private ThreadPool threadPool;
+
+    private ExecuteADResultResponseRecorder recorder;
+    private Client client;
+    private IndexAnomalyDetectorJobActionHandler handler;
+    private AnomalyIndexHandler<AnomalyResult> anomalyResultHandler;
+
+    @BeforeClass
+    public static void setOnce() throws IOException {
+        detectorId = "123";
+        seqNo = 1L;
+        primaryTerm = 2L;
+        anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
+        xContentRegistry = NamedXContentRegistry.EMPTY;
+        transportService = mock(TransportService.class);
+
+        requestTimeout = TimeValue.timeValueMinutes(60);
+        when(anomalyDetectionIndices.doesAnomalyDetectorJobIndexExist()).thenReturn(true);
+
+        nodeFilter = mock(DiscoveryNodeFilterer.class);
+        detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList("a"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+
+            GetResponse response = mock(GetResponse.class);
+            when(response.isExists()).thenReturn(false);
+            listener.onResponse(response);
+
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<IndexResponse> listener = (ActionListener<IndexResponse>) args[1];
+
+            IndexResponse response = mock(IndexResponse.class);
+            when(response.getResult()).thenReturn(CREATED);
+            listener.onResponse(response);
+
+            return null;
+        }).when(client).index(any(IndexRequest.class), any());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<AnomalyResultResponse> listener = (ActionListener<AnomalyResultResponse>) args[2];
+
+            AnomalyResultResponse response = new AnomalyResultResponse(null, "", 0L, 10L, true);
+            listener.onResponse(response);
+
+            return null;
+        }).when(client).execute(any(AnomalyResultAction.class), any(), any());
+
+        adTaskManager = mock(ADTaskManager.class);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<AnomalyDetectorJobResponse> listener = (ActionListener<AnomalyDetectorJobResponse>) args[4];
+
+            AnomalyDetectorJobResponse response = mock(AnomalyDetectorJobResponse.class);
+            listener.onResponse(response);
+
+            return null;
+        }).when(adTaskManager).startDetector(any(), any(), any(), any(), any());
+
+        threadPool = mock(ThreadPool.class);
+
+        anomalyResultHandler = mock(AnomalyIndexHandler.class);
+
+        recorder = new ExecuteADResultResponseRecorder(
+            anomalyDetectionIndices,
+            anomalyResultHandler,
+            adTaskManager,
+            nodeFilter,
+            threadPool,
+            client
+        );
+
+        handler = new IndexAnomalyDetectorJobActionHandler(
+            client,
+            anomalyDetectionIndices,
+            detectorId,
+            seqNo,
+            primaryTerm,
+            requestTimeout,
+            xContentRegistry,
+            transportService,
+            adTaskManager,
+            recorder
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDelayHCProfile() {
+        when(adTaskManager.isHCRealtimeTaskStartInitializing(anyString())).thenReturn(false);
+
+        ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
+
+        handler.startAnomalyDetectorJob(detector, listener);
+
+        verify(client, times(1)).get(any(), any());
+        verify(client, times(1)).execute(any(), any(), any());
+        verify(adTaskManager, times(1)).startDetector(any(), any(), any(), any(), any());
+        verify(adTaskManager, times(1)).isHCRealtimeTaskStartInitializing(anyString());
+        verify(threadPool, times(1)).schedule(any(), any(), any());
+        verify(listener, times(1)).onResponse(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testNoDelayHCProfile() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<ProfileResponse> listener = (ActionListener<ProfileResponse>) args[2];
+
+            ProfileResponse response = mock(ProfileResponse.class);
+            when(response.getTotalUpdates()).thenReturn(3L);
+            listener.onResponse(response);
+
+            return null;
+        }).when(client).execute(any(ProfileAction.class), any(), any());
+
+        when(adTaskManager.isHCRealtimeTaskStartInitializing(anyString())).thenReturn(true);
+
+        ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
+
+        handler.startAnomalyDetectorJob(detector, listener);
+
+        verify(client, times(1)).get(any(), any());
+        verify(client, times(2)).execute(any(), any(), any());
+        verify(adTaskManager, times(1)).startDetector(any(), any(), any(), any(), any());
+        verify(adTaskManager, times(1)).isHCRealtimeTaskStartInitializing(anyString());
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(listener, times(1)).onResponse(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testHCProfileException() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<ProfileResponse> listener = (ActionListener<ProfileResponse>) args[2];
+
+            listener.onFailure(new RuntimeException());
+
+            return null;
+        }).when(client).execute(any(ProfileAction.class), any(), any());
+
+        when(adTaskManager.isHCRealtimeTaskStartInitializing(anyString())).thenReturn(true);
+
+        ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
+
+        handler.startAnomalyDetectorJob(detector, listener);
+
+        verify(client, times(1)).get(any(), any());
+        verify(client, times(2)).execute(any(), any(), any());
+        verify(adTaskManager, times(1)).startDetector(any(), any(), any(), any(), any());
+        verify(adTaskManager, times(1)).isHCRealtimeTaskStartInitializing(anyString());
+        verify(adTaskManager, never()).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(listener, times(1)).onResponse(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateLatestRealtimeTaskOnCoordinatingNodeResourceNotFoundException() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<ProfileResponse> listener = (ActionListener<ProfileResponse>) args[2];
+
+            ProfileResponse response = mock(ProfileResponse.class);
+            when(response.getTotalUpdates()).thenReturn(3L);
+            listener.onResponse(response);
+
+            return null;
+        }).when(client).execute(any(ProfileAction.class), any(), any());
+
+        when(adTaskManager.isHCRealtimeTaskStartInitializing(anyString())).thenReturn(true);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<UpdateResponse> listener = (ActionListener<UpdateResponse>) args[5];
+
+            listener.onFailure(new ResourceNotFoundException(CAN_NOT_FIND_LATEST_TASK));
+
+            return null;
+        }).when(adTaskManager).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+
+        ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
+
+        handler.startAnomalyDetectorJob(detector, listener);
+
+        verify(client, times(1)).get(any(), any());
+        verify(client, times(2)).execute(any(), any(), any());
+        verify(adTaskManager, times(1)).startDetector(any(), any(), any(), any(), any());
+        verify(adTaskManager, times(1)).isHCRealtimeTaskStartInitializing(anyString());
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        verify(adTaskManager, times(1)).removeRealtimeTaskCache(anyString());
+        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(listener, times(1)).onResponse(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdateLatestRealtimeTaskOnCoordinatingException() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<ProfileResponse> listener = (ActionListener<ProfileResponse>) args[2];
+
+            ProfileResponse response = mock(ProfileResponse.class);
+            when(response.getTotalUpdates()).thenReturn(3L);
+            listener.onResponse(response);
+
+            return null;
+        }).when(client).execute(any(ProfileAction.class), any(), any());
+
+        when(adTaskManager.isHCRealtimeTaskStartInitializing(anyString())).thenReturn(true);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<UpdateResponse> listener = (ActionListener<UpdateResponse>) args[5];
+
+            listener.onFailure(new RuntimeException());
+
+            return null;
+        }).when(adTaskManager).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+
+        ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
+
+        handler.startAnomalyDetectorJob(detector, listener);
+
+        verify(client, times(1)).get(any(), any());
+        verify(client, times(2)).execute(any(), any(), any());
+        verify(adTaskManager, times(1)).startDetector(any(), any(), any(), any(), any());
+        verify(adTaskManager, times(1)).isHCRealtimeTaskStartInitializing(anyString());
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        verify(adTaskManager, never()).removeRealtimeTaskCache(anyString());
+        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(listener, times(1)).onResponse(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testIndexException() throws IOException {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<AnomalyResultResponse> listener = (ActionListener<AnomalyResultResponse>) args[2];
+
+            listener.onFailure(new ResourceNotFoundException(detectorId, CommonErrorMessages.NO_CHECKPOINT_ERR_MSG));
+
+            return null;
+        }).when(client).execute(any(AnomalyResultAction.class), any(), any());
+
+        ActionListener<AnomalyDetectorJobResponse> listener = mock(ActionListener.class);
+        AggregationBuilder aggregationBuilder = TestHelpers
+            .parseAggregation("{\"test\":{\"max\":{\"field\":\"" + MockSimpleLog.VALUE_FIELD + "\"}}}");
+        Feature feature = new Feature(randomAlphaOfLength(5), randomAlphaOfLength(10), true, aggregationBuilder);
+        detector = TestHelpers
+            .randomDetector(
+                ImmutableList.of(feature),
+                "test",
+                10,
+                MockSimpleLog.TIME_FIELD,
+                null,
+                CommonName.CUSTOM_RESULT_INDEX_PREFIX + "index"
+            );
+        when(anomalyDetectionIndices.doesIndexExist(anyString())).thenReturn(false);
+        handler.startAnomalyDetectorJob(detector, listener);
+        verify(anomalyResultHandler, times(1)).index(any(), any(), eq(null));
+        verify(threadPool, times(1)).schedule(any(), any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.ad.ExecuteADResultResponseRecorder;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
@@ -76,7 +77,8 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
             indexSettings(),
             mock(AnomalyDetectionIndices.class),
             xContentRegistry(),
-            mock(ADTaskManager.class)
+            mock(ADTaskManager.class),
+            mock(ExecuteADResultResponseRecorder.class)
         );
         task = mock(Task.class);
         request = new AnomalyDetectorJobRequest("1234", 4567, 7890, "_start");


### PR DESCRIPTION
### Description
If historical data is enough, a single stream detector takes 1 interval for cold start to be triggered + 1 interval for the state document to be updated. Similar to single stream detectors, HCAD cold start needs 2 intervals and one more interval to make sure an entity appears more than once. So HCAD needs three intervals to complete cold starts. Long initialization is the single most complained problem of AD. This PR reduces both single stream and HCAD detectors' initialization time to 1 minute by
* delaying real time cache update by one minute when we receive ResourceNotFoundException in single stream detectors or when the init progress of HCAD real time cache is 0. Thus, we can finish the cold start and writing checkpoint one minute later and update the state document accordingly. This optimization saves one interval to wait for the state document update.
* disable the door keeper by default so that we won't have to wait an extra interval in HCAD.
* trigger cold start when starting a real time detector. This optimization saves one interval to wait for the cold start to be triggered.

Testing done:
* verified the cold start time is reduced to 1 minute.
* added tests for new code.

Signed-off-by: Kaituo Li <kaituo@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
