### PR TITLE
Get detector serialization

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -44,7 +44,12 @@ public class AnomalyDetectorExtension extends BaseExtension {
 
     @Override
     public List<ExtensionRestHandler> getExtensionRestHandlers() {
-        return List.of(new RestCreateDetectorAction(extensionsRunner, this), new RestGetDetectorAction(), new RestValidateDetectorAction());
+        return List
+            .of(
+                new RestCreateDetectorAction(extensionsRunner, this),
+                new RestGetDetectorAction(extensionsRunner, this),
+                new RestValidateDetectorAction()
+            );
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -87,7 +87,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String DETECTION_INTERVAL_FIELD = "detection_interval";
     public static final String WINDOW_DELAY_FIELD = "window_delay";
     public static final String SHINGLE_SIZE_FIELD = "shingle_size";
-    private static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
+    public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String UI_METADATA_FIELD = "ui_metadata";
     public static final String CATEGORY_FIELD = "category_field";
     public static final String USER_FIELD = "user";
@@ -372,6 +372,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
             xContentBuilder.field(RESULT_INDEX_FIELD, resultIndex);
         }
         return xContentBuilder.endObject();
+
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -30,10 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.auth.UserIdentity;
@@ -68,7 +64,6 @@ import com.google.common.collect.ImmutableList;
  * TODO: Will replace detector config mapping in AD task with detector config setting directly \
  *      in code rather than config it in anomaly-detection-state.json file.
  */
-@JsonIgnoreProperties({"fragment"})
 public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String PARSE_FIELD_NAME = "AnomalyDetector";
     public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
@@ -129,8 +124,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final int MAX_RESULT_INDEX_NAME_SIZE = 255;
     public static final String RESULT_INDEX_NAME_PATTERN = "[a-z0-9_-]+";
 
-    private AnomalyDetector() {
-    }
+    private AnomalyDetector() {}
 
     /**
      * Constructor function.
@@ -264,44 +258,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         }
         return null;
     }
-
-//    @JsonIgnoreProperties(ignoreUnknown = true)
-//    public AnomalyDetector(
-//        @JsonProperty("detectorId") String detectorId,
-//        @JsonProperty("version") Long version,
-//        @JsonProperty("name") String name,
-//        @JsonProperty("description") String description,
-//        @JsonProperty("timeField") String timeField,
-//        @JsonProperty("indices") List<String> indices,
-//        @JsonProperty("features") List<Feature> features,
-//        @JsonProperty("filterQuery") QueryBuilder filterQuery,
-//        @JsonProperty("detectionInterval") TimeConfiguration detectionInterval,
-//        @JsonProperty("windowDelay") TimeConfiguration windowDelay,
-//        @JsonProperty("shingleSize") Integer shingleSize,
-//        @JsonProperty("uiMetadata") Map<String, Object> uiMetadata,
-//        @JsonProperty("schemaVersion") Integer schemaVersion,
-//        @JsonProperty("lastUpdateTime") Instant lastUpdateTime,
-//        @JsonProperty("categoryFields") List<String> categoryFields,
-//        @JsonProperty("user") UserIdentity user
-//    ) {
-//        this.detectorId = detectorId;
-//        this.version = version;
-//        this.name = name;
-//        this.description = description;
-//        this.timeField = timeField;
-//        this.indices = indices;
-//        this.featureAttributes = features == null ? ImmutableList.of() : ImmutableList.copyOf(features);
-//        this.filterQuery = filterQuery;
-//        this.detectionInterval = detectionInterval;
-//        this.windowDelay = windowDelay;
-//        this.shingleSize = getShingleSize(shingleSize);
-//        this.uiMetadata = uiMetadata;
-//        this.schemaVersion = schemaVersion;
-//        this.lastUpdateTime = lastUpdateTime;
-//        this.categoryFields = categoryFields;
-//        this.user = user;
-//        this.detectorType = isMultientityDetector(categoryFields) ? MULTI_ENTITY.name() : SINGLE_ENTITY.name();
-//    }
 
     public AnomalyDetector(StreamInput input) throws IOException {
         detectorId = input.readOptionalString();
@@ -691,12 +647,10 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return indices;
     }
 
-    @JsonProperty("featureAttributes")
     public List<Feature> getFeatureAttributes() {
         return featureAttributes;
     }
 
-    @JsonProperty("filterQuery")
     public QueryBuilder getFilterQuery() {
         return filterQuery;
     }
@@ -706,22 +660,18 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
      *
      * @return a list of filtered feature ids.
      */
-    @JsonProperty("enabledFeatureIds")
     public List<String> getEnabledFeatureIds() {
         return featureAttributes.stream().filter(Feature::getEnabled).map(Feature::getId).collect(Collectors.toList());
     }
 
-    @JsonProperty("enabledFeatureNames")
     public List<String> getEnabledFeatureNames() {
         return featureAttributes.stream().filter(Feature::getEnabled).map(Feature::getName).collect(Collectors.toList());
     }
 
-    @JsonProperty("detectionInterval")
     public TimeConfiguration getDetectionInterval() {
         return detectionInterval;
     }
 
-    @JsonProperty("windowDelay")
     public TimeConfiguration getWindowDelay() {
         return windowDelay;
     }
@@ -760,22 +710,18 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return this.categoryFields;
     }
 
-    @JsonIgnore
     public long getDetectorIntervalInMilliseconds() {
         return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration().toMillis();
     }
 
-    @JsonIgnore
     public long getDetectorIntervalInSeconds() {
         return getDetectorIntervalInMilliseconds() / 1000;
     }
 
-    @JsonIgnore
     public long getDetectorIntervalInMinutes() {
         return getDetectorIntervalInMilliseconds() / 1000 / 60;
     }
 
-    @JsonIgnore
     public Duration getDetectionIntervalDuration() {
         return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration();
     }
@@ -804,17 +750,14 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return resultIndex;
     }
 
-    @JsonIgnore
     public boolean isMultientityDetector() {
         return AnomalyDetector.isMultientityDetector(getCategoryField());
     }
 
-    @JsonIgnore
     public boolean isMultiCategoryDetector() {
         return categoryFields != null && categoryFields.size() > 1;
     }
 
-    @JsonIgnore
     private static boolean isMultientityDetector(List<String> categoryFields) {
         return categoryFields != null && categoryFields.size() > 0;
     }

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -30,6 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.auth.UserIdentity;
@@ -64,6 +68,7 @@ import com.google.common.collect.ImmutableList;
  * TODO: Will replace detector config mapping in AD task with detector config setting directly \
  *      in code rather than config it in anomaly-detection-state.json file.
  */
+@JsonIgnoreProperties({"fragment"})
 public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String PARSE_FIELD_NAME = "AnomalyDetector";
     public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
@@ -98,21 +103,21 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     @Deprecated
     public static final String DETECTION_DATE_RANGE_FIELD = "detection_date_range";
 
-    private final String detectorId;
-    private final Long version;
-    private final String name;
-    private final String description;
-    private final String timeField;
-    private final List<String> indices;
-    private final List<Feature> featureAttributes;
-    private final QueryBuilder filterQuery;
-    private final TimeConfiguration detectionInterval;
-    private final TimeConfiguration windowDelay;
-    private final Integer shingleSize;
-    private final Map<String, Object> uiMetadata;
-    private final Integer schemaVersion;
-    private final Instant lastUpdateTime;
-    private final List<String> categoryFields;
+    private String detectorId;
+    private Long version;
+    private String name;
+    private String description;
+    private String timeField;
+    private List<String> indices;
+    private List<Feature> featureAttributes;
+    private QueryBuilder filterQuery;
+    private TimeConfiguration detectionInterval;
+    private TimeConfiguration windowDelay;
+    private Integer shingleSize;
+    private Map<String, Object> uiMetadata;
+    private Integer schemaVersion;
+    private Instant lastUpdateTime;
+    private List<String> categoryFields;
     private UserIdentity user;
     private String detectorType;
     private String resultIndex;
@@ -123,6 +128,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
 
     public static final int MAX_RESULT_INDEX_NAME_SIZE = 255;
     public static final String RESULT_INDEX_NAME_PATTERN = "[a-z0-9_-]+";
+
+    private AnomalyDetector() {
+    }
 
     /**
      * Constructor function.
@@ -256,6 +264,44 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         }
         return null;
     }
+
+//    @JsonIgnoreProperties(ignoreUnknown = true)
+//    public AnomalyDetector(
+//        @JsonProperty("detectorId") String detectorId,
+//        @JsonProperty("version") Long version,
+//        @JsonProperty("name") String name,
+//        @JsonProperty("description") String description,
+//        @JsonProperty("timeField") String timeField,
+//        @JsonProperty("indices") List<String> indices,
+//        @JsonProperty("features") List<Feature> features,
+//        @JsonProperty("filterQuery") QueryBuilder filterQuery,
+//        @JsonProperty("detectionInterval") TimeConfiguration detectionInterval,
+//        @JsonProperty("windowDelay") TimeConfiguration windowDelay,
+//        @JsonProperty("shingleSize") Integer shingleSize,
+//        @JsonProperty("uiMetadata") Map<String, Object> uiMetadata,
+//        @JsonProperty("schemaVersion") Integer schemaVersion,
+//        @JsonProperty("lastUpdateTime") Instant lastUpdateTime,
+//        @JsonProperty("categoryFields") List<String> categoryFields,
+//        @JsonProperty("user") UserIdentity user
+//    ) {
+//        this.detectorId = detectorId;
+//        this.version = version;
+//        this.name = name;
+//        this.description = description;
+//        this.timeField = timeField;
+//        this.indices = indices;
+//        this.featureAttributes = features == null ? ImmutableList.of() : ImmutableList.copyOf(features);
+//        this.filterQuery = filterQuery;
+//        this.detectionInterval = detectionInterval;
+//        this.windowDelay = windowDelay;
+//        this.shingleSize = getShingleSize(shingleSize);
+//        this.uiMetadata = uiMetadata;
+//        this.schemaVersion = schemaVersion;
+//        this.lastUpdateTime = lastUpdateTime;
+//        this.categoryFields = categoryFields;
+//        this.user = user;
+//        this.detectorType = isMultientityDetector(categoryFields) ? MULTI_ENTITY.name() : SINGLE_ENTITY.name();
+//    }
 
     public AnomalyDetector(StreamInput input) throws IOException {
         detectorId = input.readOptionalString();
@@ -645,10 +691,12 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return indices;
     }
 
+    @JsonProperty("featureAttributes")
     public List<Feature> getFeatureAttributes() {
         return featureAttributes;
     }
 
+    @JsonProperty("filterQuery")
     public QueryBuilder getFilterQuery() {
         return filterQuery;
     }
@@ -658,18 +706,22 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
      *
      * @return a list of filtered feature ids.
      */
+    @JsonProperty("enabledFeatureIds")
     public List<String> getEnabledFeatureIds() {
         return featureAttributes.stream().filter(Feature::getEnabled).map(Feature::getId).collect(Collectors.toList());
     }
 
+    @JsonProperty("enabledFeatureNames")
     public List<String> getEnabledFeatureNames() {
         return featureAttributes.stream().filter(Feature::getEnabled).map(Feature::getName).collect(Collectors.toList());
     }
 
+    @JsonProperty("detectionInterval")
     public TimeConfiguration getDetectionInterval() {
         return detectionInterval;
     }
 
+    @JsonProperty("windowDelay")
     public TimeConfiguration getWindowDelay() {
         return windowDelay;
     }
@@ -708,18 +760,22 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return this.categoryFields;
     }
 
+    @JsonIgnore
     public long getDetectorIntervalInMilliseconds() {
         return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration().toMillis();
     }
 
+    @JsonIgnore
     public long getDetectorIntervalInSeconds() {
         return getDetectorIntervalInMilliseconds() / 1000;
     }
 
+    @JsonIgnore
     public long getDetectorIntervalInMinutes() {
         return getDetectorIntervalInMilliseconds() / 1000 / 60;
     }
 
+    @JsonIgnore
     public Duration getDetectionIntervalDuration() {
         return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration();
     }
@@ -748,14 +804,17 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return resultIndex;
     }
 
+    @JsonIgnore
     public boolean isMultientityDetector() {
         return AnomalyDetector.isMultientityDetector(getCategoryField());
     }
 
+    @JsonIgnore
     public boolean isMultiCategoryDetector() {
         return categoryFields != null && categoryFields.size() > 1;
     }
 
+    @JsonIgnore
     private static boolean isMultientityDetector(List<String> categoryFields) {
         return categoryFields != null && categoryFields.size() > 0;
     }

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -79,7 +79,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public static final String GENERAL_SETTINGS = "general_settings";
 
     public static final String NAME_FIELD = "name";
-    private static final String DESCRIPTION_FIELD = "description";
+    public static final String DESCRIPTION_FIELD = "description";
     public static final String TIMEFIELD_FIELD = "time_field";
     public static final String INDICES_FIELD = "indices";
     public static final String FILTER_QUERY_FIELD = "filter_query";

--- a/src/main/java/org/opensearch/ad/model/Feature.java
+++ b/src/main/java/org/opensearch/ad/model/Feature.java
@@ -14,10 +14,12 @@ package org.opensearch.ad.model;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.util.ParseUtils;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -107,6 +109,8 @@ public class Feature implements Writeable, ToXContentObject {
         String name = null;
         Boolean enabled = null;
         AggregationBuilder aggregation = null;
+        Aggregate aggregate = null;
+
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -126,6 +130,8 @@ public class Feature implements Writeable, ToXContentObject {
                 case AGGREGATION_QUERY:
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
                     aggregation = ParseUtils.toAggregationBuilder(parser);
+//                    aggregate = ParseUtils.toAggregare(parser);
+
                     break;
                 default:
                     break;

--- a/src/main/java/org/opensearch/ad/model/Feature.java
+++ b/src/main/java/org/opensearch/ad/model/Feature.java
@@ -15,9 +15,6 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedT
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.util.ParseUtils;
@@ -35,7 +32,6 @@ import com.google.common.base.Objects;
 /**
  * Anomaly detector feature
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature implements Writeable, ToXContentObject {
 
     private static final String FEATURE_ID_FIELD = "feature_id";
@@ -48,8 +44,7 @@ public class Feature implements Writeable, ToXContentObject {
     private Boolean enabled;
     private AggregationBuilder aggregation;
 
-    private Feature() {
-    }
+    private Feature() {}
 
     /**
      * Constructor function.
@@ -171,7 +166,6 @@ public class Feature implements Writeable, ToXContentObject {
         return enabled;
     }
 
-    @JsonProperty("aggregation")
     public AggregationBuilder getAggregation() {
         return aggregation;
     }

--- a/src/main/java/org/opensearch/ad/model/Feature.java
+++ b/src/main/java/org/opensearch/ad/model/Feature.java
@@ -15,6 +15,9 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedT
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.ad.annotation.Generated;
 import org.opensearch.ad.util.ParseUtils;
@@ -32,6 +35,7 @@ import com.google.common.base.Objects;
 /**
  * Anomaly detector feature
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature implements Writeable, ToXContentObject {
 
     private static final String FEATURE_ID_FIELD = "feature_id";
@@ -39,10 +43,13 @@ public class Feature implements Writeable, ToXContentObject {
     private static final String FEATURE_ENABLED_FIELD = "feature_enabled";
     private static final String AGGREGATION_QUERY = "aggregation_query";
 
-    private final String id;
-    private final String name;
-    private final Boolean enabled;
-    private final AggregationBuilder aggregation;
+    private String id;
+    private String name;
+    private Boolean enabled;
+    private AggregationBuilder aggregation;
+
+    private Feature() {
+    }
 
     /**
      * Constructor function.
@@ -164,6 +171,7 @@ public class Feature implements Writeable, ToXContentObject {
         return enabled;
     }
 
+    @JsonProperty("aggregation")
     public AggregationBuilder getAggregation() {
         return aggregation;
     }

--- a/src/main/java/org/opensearch/ad/model/IndexAnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/IndexAnomalyDetector.java
@@ -1,0 +1,219 @@
+package org.opensearch.ad.model;
+
+import org.opensearch.ad.auth.UserIdentity;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE;
+
+/**
+ * JSON Object class required by opensearch-java client
+ */
+public class IndexAnomalyDetector {
+
+    private String detectorId;
+    private Long version;
+    private String name;
+    private String description;
+    private String timeField;
+    private List<String> indices;
+    private List<Feature> featureAttributes;
+    private QueryBuilder filterQuery;
+    private TimeConfiguration detectionInterval;
+    private TimeConfiguration windowDelay;
+    private Integer shingleSize;
+    private Map<String, Object> uiMetadata;
+    private Integer schemaVersion;
+    private Instant lastUpdateTime;
+    private List<String> categoryFields;
+    private UserIdentity user;
+    private String detectorType;
+    private String resultIndex;
+
+    private DetectionDateRange detectionDateRange;
+
+    public String getDetectorId() {
+        return detectorId;
+    }
+
+    public void setDetectorId(String detectorId) {
+        this.detectorId = detectorId;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTimeField() {
+        return timeField;
+    }
+
+    public void setTimeField(String timeField) {
+        this.timeField = timeField;
+    }
+
+    public List<String> getIndices() {
+        return indices;
+    }
+
+    public void setIndices(List<String> indices) {
+        this.indices = indices;
+    }
+
+    public List<Feature> getFeatureAttributes() {
+        return featureAttributes;
+    }
+
+    public void setFeatureAttributes(List<Feature> featureAttributes) {
+        this.featureAttributes = featureAttributes;
+    }
+
+    public QueryBuilder getFilterQuery() {
+        return filterQuery;
+    }
+
+    public void setFilterQuery(QueryBuilder filterQuery) {
+        this.filterQuery = filterQuery;
+    }
+
+//    public List<String> getEnabledFeatureIds() {
+//        return featureAttributes.stream().filter(Feature::getEnabled).map(Feature::getId).collect(Collectors.toList());
+//    }
+
+//    public List<String> getEnabledFeatureNames() {
+//        return featureAttributes.stream().filter(Feature::getEnabled).map(Feature::getName).collect(Collectors.toList());
+//    }
+
+    public TimeConfiguration getDetectionInterval() {
+        return detectionInterval;
+    }
+
+    public void setDetectionInterval(TimeConfiguration detectionInterval) {
+        this.detectionInterval = detectionInterval;
+    }
+
+    public TimeConfiguration getWindowDelay() {
+        return windowDelay;
+    }
+
+    public void setWindowDelay(TimeConfiguration windowDelay) {
+        this.windowDelay = windowDelay;
+    }
+
+    public Integer getShingleSize() {
+        return shingleSize;
+    }
+
+    public void setShingleSize(Integer shingleSize) {
+        this.shingleSize = shingleSize;
+    }
+
+    public Integer getShingleSize(Integer customShingleSize) {
+        return customShingleSize == null ? DEFAULT_SHINGLE_SIZE : customShingleSize;
+    }
+
+
+    public Map<String, Object> getUiMetadata() {
+        return uiMetadata;
+    }
+
+    public void setUiMetadata(Map<String, Object> uiMetadata) {
+        this.uiMetadata = uiMetadata;
+    }
+
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(Integer schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public Instant getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(Instant lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+    }
+
+    public List<String> getCategoryField() {
+        return this.categoryFields;
+    }
+
+    public void setCategoryFields(List<String> categoryFields) {
+        this.categoryFields = categoryFields;
+    }
+
+//    public long getDetectorIntervalInMilliseconds() {
+//        return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration().toMillis();
+//    }
+
+//    public long getDetectorIntervalInSeconds() {
+//        return getDetectorIntervalInMilliseconds() / 1000;
+//    }
+//
+//    public long getDetectorIntervalInMinutes() {
+//        return getDetectorIntervalInMilliseconds() / 1000 / 60;
+//    }
+
+//    public Duration getDetectionIntervalDuration() {
+//        return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration();
+//    }
+
+    public UserIdentity getUser() {
+        return user;
+    }
+
+    public void setUser(UserIdentity user) {
+        this.user = user;
+    }
+
+    public String getDetectorType() {
+        return detectorType;
+    }
+
+    public void setDetectorType(String detectorType) {
+        this.detectorType = detectorType;
+    }
+
+    public void setDetectionDateRange(DetectionDateRange detectionDateRange) {
+        this.detectionDateRange = detectionDateRange;
+    }
+
+    public DetectionDateRange getDetectionDateRange() {
+        return detectionDateRange;
+    }
+
+    public String getResultIndex() {
+        return resultIndex;
+    }
+
+    public void setResultIndex(String resultIndex) {
+        this.resultIndex = resultIndex;
+    }
+}

--- a/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
+++ b/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
@@ -33,6 +33,8 @@ public class IntervalTimeConfiguration extends TimeConfiguration {
 
     private static final Set<ChronoUnit> SUPPORTED_UNITS = ImmutableSet.of(ChronoUnit.MINUTES, ChronoUnit.SECONDS);
 
+    private IntervalTimeConfiguration() {}
+
     /**
      * Constructor function.
      *

--- a/src/main/java/org/opensearch/ad/rest/RestCreateDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestCreateDetectorAction.java
@@ -9,37 +9,54 @@
 
 package org.opensearch.ad.rest;
 
-import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.opensearch.ad.model.AnomalyDetector.*;
+import static org.opensearch.ad.model.AnomalyDetector.FEATURE_ATTRIBUTES_FIELD;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.ANOMALY_DETECTORS_INDEX_MAPPING_FILE;
+import static org.opensearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestRequest.Method.POST;
 import static org.opensearch.rest.RestStatus.BAD_REQUEST;
 import static org.opensearch.rest.RestStatus.CREATED;
 import static org.opensearch.rest.RestStatus.OK;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorExtension;
 import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.IndexAnomalyDetector;
+import org.opensearch.ad.rest.handler.CreateIndexRequestBuilder;
+import org.opensearch.ad.rest.handler.IndexLoader;
+import org.opensearch.ad.rest.handler.IndexSerializeRequestBuilder;
+import org.opensearch.ad.rest.handler.JacksonDetector;
 import org.opensearch.ad.settings.EnabledSetting;
-import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.*;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.IndexResponse;
+import org.opensearch.client.opensearch.core.search.CompletionSuggestOption;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.CreateIndexResponse;
-import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.client.opensearch.indices.PutMappingResponse;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.*;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.sdk.BaseExtensionRestHandler;
@@ -54,6 +71,7 @@ public class RestCreateDetectorAction extends BaseExtensionRestHandler {
 
     private final OpenSearchClient sdkClient;
     private final NamedXContentRegistry xContentRegistry;
+    private static final Logger logger = LogManager.getLogger(RestCreateDetectorAction.class);
 
     public RestCreateDetectorAction(ExtensionsRunner runner, AnomalyDetectorExtension extension) {
         this.xContentRegistry = runner.getNamedXContentRegistry().getRegistry();
@@ -91,9 +109,42 @@ public class RestCreateDetectorAction extends BaseExtensionRestHandler {
             anomalyDetector.getResultIndex()
         );
 
+
+        JacksonDetector jacksonDetector = new JacksonDetector(detector, detector.toString());
+//        IndexSerializeRequestBuilder indexSerializeRequestBuilder = new IndexSerializeRequestBuilder();
+//
+//        JacksonJsonpMapper mapper = (JacksonJsonpMapper) sdkClient._transport().jsonpMapper();
+//        JsonParser parser = Json.createParser(new ByteArrayInputStream(getAnomalyDetectorMappings().getBytes(StandardCharsets.UTF_8)));
+//        IndexSerializeRequestBuilder indexSerializeRequestBuilder = mapper.deserialize(parser, IndexSerializeRequestBuilder.class);
+
+        IndexAnomalyDetector indexAnomalyDetector = new IndexAnomalyDetector();
+        indexAnomalyDetector.setName(anomalyDetector.getName());
+        indexAnomalyDetector.setDetectorId(anomalyDetector.getDetectorId());
+        indexAnomalyDetector.setDetectorType(anomalyDetector.getDetectorType());
+        indexAnomalyDetector.setDetectionInterval(anomalyDetector.getDetectionInterval());
+        indexAnomalyDetector.setDetectionDateRange(anomalyDetector.getDetectionDateRange());
+        indexAnomalyDetector.setDescription(anomalyDetector.getDescription());
+        indexAnomalyDetector.setFeatureAttributes(anomalyDetector.getFeatureAttributes());
+        indexAnomalyDetector.setFilterQuery(anomalyDetector.getFilterQuery());
+        indexAnomalyDetector.setCategoryFields(anomalyDetector.getCategoryField());
+        indexAnomalyDetector.setLastUpdateTime(anomalyDetector.getLastUpdateTime());
+        indexAnomalyDetector.setResultIndex(anomalyDetector.getResultIndex());
+        indexAnomalyDetector.setSchemaVersion(anomalyDetector.getSchemaVersion());
+        indexAnomalyDetector.setShingleSize(anomalyDetector.getShingleSize());
+        indexAnomalyDetector.setTimeField(anomalyDetector.getTimeField());
+        indexAnomalyDetector.setWindowDelay(anomalyDetector.getWindowDelay());
+        indexAnomalyDetector.setUiMetadata(anomalyDetector.getUiMetadata());
+        indexAnomalyDetector.setVersion(anomalyDetector.getVersion());
+
+        IndexLoader indexLoader = new IndexLoader();
+//        detector.toXContent(indexLoader.toXContent(XContentFactory.jsonBuilder(), detector));
+
         IndexRequest<AnomalyDetector> indexRequest = new IndexRequest.Builder<AnomalyDetector>()
             .index(ANOMALY_DETECTORS_INDEX)
-            .document(detector)
+//                .tDocumentSerializer((JsonpSerializer<IndexSerializeRequestBuilder>) indexSerializeRequestBuilder.build())
+//            .document(detector)
+
+                .document(detector)
             .build();
         IndexResponse indexResponse = sdkClient.index(indexRequest);
         return indexResponse;
@@ -156,6 +207,7 @@ public class RestCreateDetectorAction extends BaseExtensionRestHandler {
                 }
             }
         } catch (Exception e) {
+            e.printStackTrace();
             return new ExtensionRestResponse(request, BAD_REQUEST, builder);
         }
         return new ExtensionRestResponse(request, OK, builder);

--- a/src/main/java/org/opensearch/ad/rest/RestCreateDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestCreateDetectorAction.java
@@ -72,7 +72,7 @@ public class RestCreateDetectorAction extends BaseExtensionRestHandler {
 
     private IndexResponse indexAnomalyDetector(AnomalyDetector anomalyDetector) throws IOException {
         AnomalyDetector detector = new AnomalyDetector(
-            anomalyDetector.getName(),
+            anomalyDetector.getDetectorId(),
             anomalyDetector.getVersion(),
             anomalyDetector.getName(),
             anomalyDetector.getDescription(),

--- a/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
@@ -1,20 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.ad.rest;
 
-import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.opensearch.ad.model.AnomalyDetector.*;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestStatus.OK;
 import static org.opensearch.rest.RestStatus.BAD_REQUEST;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.ad.AnomalyDetectorExtension;
 import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.EnabledSetting;
+import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.common.bytes.BytesArray;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.compress.CompressorFactory;
+import org.opensearch.common.io.stream.BytesStream;
 import org.opensearch.common.xcontent.*;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
@@ -39,6 +62,20 @@ public class RestGetDetectorAction extends BaseExtensionRestHandler {
         return List.of(new RouteHandler(GET, "/detectors/{detectorId}", (r) -> handleGetRequest(r)));
     }
 
+    static BytesReference bytes(XContentBuilder xContentBuilder) {
+        xContentBuilder.close();
+        OutputStream stream = xContentBuilder.getOutputStream();
+        if (stream instanceof ByteArrayOutputStream) {
+            return new BytesArray(((ByteArrayOutputStream) stream).toByteArray());
+        } else {
+            return ((BytesStream) stream).bytes();
+        }
+    }
+
+    public static XContentBuilder builder(XContent xContent) throws IOException {
+        return new XContentBuilder(xContent, new ByteArrayOutputStream());
+    }
+
     public ExtensionRestResponse handleGetRequest(ExtensionRestRequest request) {
         if (!EnabledSetting.isADPluginEnabled()) {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
@@ -52,32 +89,92 @@ public class RestGetDetectorAction extends BaseExtensionRestHandler {
         // 4. Follow the steps on the issue
         // 5. Look for MultiGetRequest
 
-        SearchResponse<AnomalyDetector> searchResponse = null;
-        try {
-            searchResponse = sdkClient.search(s -> s.index(ANOMALY_DETECTORS_INDEX), AnomalyDetector.class);
+        // Commented this code for SearchResponse
+//        SearchResponse<AnomalyDetector> searchResponse = null;
+//        try {
+//            searchResponse = sdkClient.search(s -> s.index(ANOMALY_DETECTORS_INDEX), AnomalyDetector.class);
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//        }
+
+        GetResponse<AnomalyDetector> getResponse = null;
+        try{
+            getResponse = sdkClient.get(s -> s.index(ANOMALY_DETECTORS_INDEX).id(detectorId), AnomalyDetector.class);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
+        logger.info("GET RESPONSE :{}", getResponse.version());
+
+
         XContentBuilder builder = null;
+        XContentParser parser;
+        AnomalyDetector detector;
+        // Commented this code for SearchResponse
+//        try {
+//            for (int i = 0; i < searchResponse.hits().hits().size(); i++) {
+//                logger.info("Search query response: {}", searchResponse.hits().hits().size());
+//                if (searchResponse.hits().hits().get(i).id().equals(detectorId)) {
+//////                    parser = request.contentParser(this.xContentRegistry);
+////                    parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, (BytesReference) searchResponse.hits().hits().stream());
+////                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+////                    detector = AnomalyDetector.parse(parser);
+//                    builder = XContentBuilder.builder(XContentType.JSON.xContent());
+//                    builder.startObject();
+//                    builder.field("id", searchResponse.hits().hits().get(i).id());
+//                    builder.field("version", searchResponse.hits().hits().get(i).version());
+//                    builder.field("seqNo", searchResponse.hits().hits().get(i).seqNo());
+//                    builder.field("primaryTerm", searchResponse.hits().hits().get(i).primaryTerm());
+//                    builder.field("detector", searchResponse.hits().hits().get(i).source());
+//                    builder.field("status", RestStatus.CREATED);
+//                    builder.endObject();
+//                }
+//            }
+//        } catch (Exception e) {
+//            return new ExtensionRestResponse(request, BAD_REQUEST, builder);
+//        }
+
+//        XContentParser parser;
+        BytesReference sources = null;
         try {
-            for (int i = 0; i < searchResponse.hits().hits().size(); i++) {
-                logger.info("Search query response: {}", searchResponse.hits().hits().size());
-                if (searchResponse.hits().hits().get(i).id().equals(detectorId)) {
-                    builder = XContentBuilder.builder(XContentType.JSON.xContent());
-                    builder.startObject();
-                    builder.field("id", searchResponse.hits().hits().get(i).id());
-                    builder.field("version", searchResponse.hits().hits().get(i).version());
-                    builder.field("seqNo", searchResponse.hits().hits().get(i).seqNo());
-                    builder.field("primaryTerm", searchResponse.hits().hits().get(i).primaryTerm());
-                    builder.field("detector", searchResponse.hits().hits().get(i).source());
-                    builder.field("status", RestStatus.CREATED);
-                    builder.endObject();
-                }
-            }
-        } catch (Exception e) {
+            sources = BytesReference.bytes(XContentBuilder.builder(XContentType.JSON.xContent()).startObject()
+                    .field(NAME_FIELD, getResponse.source().getName())
+                    .field(DESCRIPTION_FIELD, getResponse.source().getDescription())
+                    .field(TIMEFIELD_FIELD, getResponse.source().getTimeField())
+                    .field(INDICES_FIELD, getResponse.source().getIndices())
+                    .field(FILTER_QUERY_FIELD, getResponse.source().getFilterQuery())
+                    .field(DETECTION_INTERVAL_FIELD, getResponse.source().getDetectionInterval())
+                    .field(WINDOW_DELAY_FIELD, getResponse.source().getWindowDelay())
+                    .field(SHINGLE_SIZE_FIELD, getResponse.source().getShingleSize())
+                    .field(CommonName.SCHEMA_VERSION_FIELD, getResponse.source().getSchemaVersion())
+                    .field(FEATURE_ATTRIBUTES_FIELD, getResponse.source().getFeatureAttributes())
+                    .endObject());
+
+        } catch(Exception e) {
+            e.printStackTrace();;
+        }
+
+        try{
+            parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, sources);
+
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            detector = AnomalyDetector.parse(parser);
+            builder = XContentBuilder.builder(XContentType.JSON.xContent());
+            builder.startObject();
+            builder.field("id", getResponse.id());
+            builder.field("version", getResponse.version());
+            builder.field("seqNo", getResponse.seqNo());
+            builder.field("primaryTerm", getResponse.primaryTerm());
+            builder.field("detector", detector);
+            builder.field("status", RestStatus.CREATED);
+            builder.endObject();
+
+        } catch(Exception e) {
+            e.printStackTrace();
             return new ExtensionRestResponse(request, BAD_REQUEST, builder);
         }
+
+
         return new ExtensionRestResponse(request, OK, builder);
     }
 }

--- a/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
@@ -1,15 +1,21 @@
 package org.opensearch.ad.rest;
 
+import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestStatus.OK;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ad.AnomalyDetectorExtension;
 import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.EnabledSetting;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.rest.RestHandler.Route;
@@ -18,6 +24,8 @@ import org.opensearch.sdk.ExtensionRestHandler;
 
 public class RestGetDetectorAction implements ExtensionRestHandler {
     private final Logger logger = LogManager.getLogger(RestGetDetectorAction.class);
+    private AnomalyDetectorExtension anomalyDetectorExtension = new AnomalyDetectorExtension();
+    private OpenSearchClient sdkClient = anomalyDetectorExtension.getClient();
 
     @Override
     public List<Route> routes() {
@@ -38,6 +46,24 @@ public class RestGetDetectorAction implements ExtensionRestHandler {
                 "Extension REST action improperly configured to handle " + request.toString()
             );
         }
+
+//        String detectorId = request.param("detectorId");
+
+
+        // Search without query
+        SearchResponse<AnomalyDetector> searchResponse = null;
+        try {
+            searchResponse = sdkClient.search(s -> s.index(ANOMALY_DETECTORS_INDEX), AnomalyDetector.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        for (int i = 0; i< searchResponse.hits().hits().size(); i++) {
+            logger.info("Search query response: {}", searchResponse.hits().hits().get(i).source());
+            logger.info("Documents: {}", searchResponse.documents());
+            logger.info("2: {}", searchResponse.hits().hits().get(i).id());
+        }
+
+
         // do things with request
         return new ExtensionRestResponse(request, OK, "placeholder");
     }

--- a/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
@@ -48,7 +48,12 @@ public class RestGetDetectorAction implements ExtensionRestHandler {
         }
 
 //        String detectorId = request.param("detectorId");
-
+        //TODO
+        //1. Get Detector id
+        //2. Find a way to query SearchRequest
+        //3. Else, match detectorId with the SearchRequest response
+        //4. Follow the steps on the issue
+        //5. Look for MultiGetRequest
 
         // Search without query
         SearchResponse<AnomalyDetector> searchResponse = null;

--- a/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
@@ -1,6 +1,7 @@
 package org.opensearch.ad.rest;
 
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestStatus.OK;
@@ -15,11 +16,20 @@ import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.indices.GetIndexRequest;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.ExtensionRestHandler;
 
 public class RestGetDetectorAction implements ExtensionRestHandler {
@@ -29,7 +39,7 @@ public class RestGetDetectorAction implements ExtensionRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/detectors"));
+        return List.of(new Route(GET, "/detectors/{detectorId}"));
     }
 
     @Override
@@ -47,27 +57,75 @@ public class RestGetDetectorAction implements ExtensionRestHandler {
             );
         }
 
-//        String detectorId = request.param("detectorId");
-        //TODO
-        //1. Get Detector id
-        //2. Find a way to query SearchRequest
-        //3. Else, match detectorId with the SearchRequest response
-        //4. Follow the steps on the issue
-        //5. Look for MultiGetRequest
+        String detectorId = request.param("detectorId");
+        logger.info("DETECTOR : {}", detectorId);
+        // TODO
+        // 1. Get Detector id
+        // 2. Find a way to query SearchRequest
+        // 3. Else, match detectorId with the SearchRequest response
+        // 4. Follow the steps on the issue
+        // 5. Look for MultiGetRequest
 
         // Search without query
+
+//        Query query = Query.of(qb -> qb.match(q -> q.field("name").query(t -> t.stringValue("test-detector"))));
+//        logger.info("Query: {}", query);
+//        final SearchRequest.Builder searchRequest = new SearchRequest.Builder()
+//            .allowPartialSearchResults(false)
+//            .index(ANOMALY_DETECTORS_INDEX);
+//            .query(query);
+
         SearchResponse<AnomalyDetector> searchResponse = null;
-        try {
+         try {
             searchResponse = sdkClient.search(s -> s.index(ANOMALY_DETECTORS_INDEX), AnomalyDetector.class);
-        } catch (Exception e) {
+         } catch (Exception e) {
+            e.printStackTrace();
+         }
+
+//         GetIndexRequest getIndexRequest = new GetIndexRequest.Builder().index(ANOMALY_DETECTORS_INDEX).build();
+//        GetIndexResponse getIndexResponse = null;
+//        try {
+//             getIndexResponse = sdkClient.indices().get(getIndexRequest);
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//
+//        logger.info("GetIndexResponse : {}", getIndexResponse.result().);
+
+//        try {
+//            searchResponse = sdkClient.search(searchRequest.build(), AnomalyDetector.class);
+//            logger.info("SearchResponse: {}", searchResponse.hits().hits().size());
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//        }
+        NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(getNamedXWriteables());
+        XContentParser parser;
+        AnomalyDetector detector;
+        XContentBuilder builder = null;
+        try {
+            parser = request.contentParser(xContentRegistry);
+//            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            detector = AnomalyDetector.parse(parser);
+        } catch (IOException e) {
             e.printStackTrace();
         }
-        for (int i = 0; i< searchResponse.hits().hits().size(); i++) {
+
+        for (int i = 0; i < searchResponse.hits().hits().size(); i++) {
             logger.info("Search query response: {}", searchResponse.hits().hits().get(i).source());
             logger.info("Documents: {}", searchResponse.documents());
+            if (searchResponse.hits().hits().get(i).id() == detectorId) {
+                builder = XContentBuilder.builder(XContentType.JSON.xContent());
+                builder.startObject();
+                builder.field("id", detectorId);
+                builder.field("version", searchResponse.hits().hits().get(i).version());
+                builder.field("seqNo", searchResponse.hits().hits().get(i).seqNo());
+                builder.field("primaryTerm", searchResponse.hits().hits().get(i).primaryTerm());
+                builder.field("detector", detector);
+                builder.field("status", RestStatus.CREATED);
+            }
             logger.info("2: {}", searchResponse.hits().hits().get(i).id());
+            logger.info("2: {}", searchResponse.hits().hits().get(i).version());
         }
-
 
         // do things with request
         return new ExtensionRestResponse(request, OK, "placeholder");

--- a/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
@@ -29,6 +29,8 @@ import org.opensearch.ad.AnomalyDetectorExtension;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.rest.handler.IndexLoader;
+import org.opensearch.ad.rest.handler.JacksonDetector;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -89,7 +91,6 @@ public class RestGetDetectorAction extends BaseExtensionRestHandler {
         // 4. Follow the steps on the issue
         // 5. Look for MultiGetRequest
 
-        // Commented this code for SearchResponse
 //        SearchResponse<AnomalyDetector> searchResponse = null;
 //        try {
 //            searchResponse = sdkClient.search(s -> s.index(ANOMALY_DETECTORS_INDEX), AnomalyDetector.class);
@@ -110,44 +111,20 @@ public class RestGetDetectorAction extends BaseExtensionRestHandler {
         XContentBuilder builder = null;
         XContentParser parser;
         AnomalyDetector detector;
-        // Commented this code for SearchResponse
-//        try {
-//            for (int i = 0; i < searchResponse.hits().hits().size(); i++) {
-//                logger.info("Search query response: {}", searchResponse.hits().hits().size());
-//                if (searchResponse.hits().hits().get(i).id().equals(detectorId)) {
-//////                    parser = request.contentParser(this.xContentRegistry);
-////                    parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, (BytesReference) searchResponse.hits().hits().stream());
-////                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-////                    detector = AnomalyDetector.parse(parser);
-//                    builder = XContentBuilder.builder(XContentType.JSON.xContent());
-//                    builder.startObject();
-//                    builder.field("id", searchResponse.hits().hits().get(i).id());
-//                    builder.field("version", searchResponse.hits().hits().get(i).version());
-//                    builder.field("seqNo", searchResponse.hits().hits().get(i).seqNo());
-//                    builder.field("primaryTerm", searchResponse.hits().hits().get(i).primaryTerm());
-//                    builder.field("detector", searchResponse.hits().hits().get(i).source());
-//                    builder.field("status", RestStatus.CREATED);
-//                    builder.endObject();
-//                }
-//            }
-//        } catch (Exception e) {
-//            return new ExtensionRestResponse(request, BAD_REQUEST, builder);
-//        }
-
-//        XContentParser parser;
         BytesReference sources = null;
+        logger.info("GET RESPONSE: {}", getResponse.source());
         try {
             sources = BytesReference.bytes(XContentBuilder.builder(XContentType.JSON.xContent()).startObject()
-                    .field(NAME_FIELD, getResponse.source().getName())
-                    .field(DESCRIPTION_FIELD, getResponse.source().getDescription())
-                    .field(TIMEFIELD_FIELD, getResponse.source().getTimeField())
-                    .field(INDICES_FIELD, getResponse.source().getIndices())
-                    .field(FILTER_QUERY_FIELD, getResponse.source().getFilterQuery())
-                    .field(DETECTION_INTERVAL_FIELD, getResponse.source().getDetectionInterval())
-                    .field(WINDOW_DELAY_FIELD, getResponse.source().getWindowDelay())
-                    .field(SHINGLE_SIZE_FIELD, getResponse.source().getShingleSize())
-                    .field(CommonName.SCHEMA_VERSION_FIELD, getResponse.source().getSchemaVersion())
-                    .field(FEATURE_ATTRIBUTES_FIELD, getResponse.source().getFeatureAttributes())
+                    .field(NAME_FIELD, getResponse.source())
+                    .field(DESCRIPTION_FIELD, getResponse.source())
+                    .field(TIMEFIELD_FIELD, getResponse.source())
+                    .field(INDICES_FIELD, getResponse.source())
+                    .field(FILTER_QUERY_FIELD, getResponse.source())
+                    .field(DETECTION_INTERVAL_FIELD, getResponse.source())
+                    .field(WINDOW_DELAY_FIELD, getResponse.source())
+                    .field(SHINGLE_SIZE_FIELD, getResponse.source())
+                    .field(CommonName.SCHEMA_VERSION_FIELD, getResponse.source())
+                    .field(FEATURE_ATTRIBUTES_FIELD, getResponse.source())
                     .endObject());
 
         } catch(Exception e) {

--- a/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetDetectorAction.java
@@ -1,12 +1,10 @@
 package org.opensearch.ad.rest;
 
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
-import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestRequest.Method.GET;
-import static org.opensearch.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestStatus.OK;
+import static org.opensearch.rest.RestStatus.BAD_REQUEST;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -16,49 +14,37 @@ import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.opensearch.indices.GetIndexRequest;
-import org.opensearch.client.opensearch.indices.GetIndexResponse;
-import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.*;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
-import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.rest.RestStatus;
-import org.opensearch.sdk.ExtensionRestHandler;
+import org.opensearch.sdk.BaseExtensionRestHandler;
+import org.opensearch.sdk.ExtensionsRunner;
+import org.opensearch.sdk.RouteHandler;
 
-public class RestGetDetectorAction implements ExtensionRestHandler {
+public class RestGetDetectorAction extends BaseExtensionRestHandler {
     private final Logger logger = LogManager.getLogger(RestGetDetectorAction.class);
-    private AnomalyDetectorExtension anomalyDetectorExtension = new AnomalyDetectorExtension();
-    private OpenSearchClient sdkClient = anomalyDetectorExtension.getClient();
+    private final OpenSearchClient sdkClient;
+    private final NamedXContentRegistry xContentRegistry;
 
-    @Override
-    public List<Route> routes() {
-        return List.of(new Route(GET, "/detectors/{detectorId}"));
+    public RestGetDetectorAction(ExtensionsRunner runner, AnomalyDetectorExtension extension) {
+        this.xContentRegistry = runner.getNamedXContentRegistry().getRegistry();
+        this.sdkClient = extension.getClient();
     }
 
     @Override
-    public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
+    protected List<RouteHandler> routeHandlers() {
+        return List.of(new RouteHandler(GET, "/detectors/{detectorId}", (r) -> handleGetRequest(r)));
+    }
+
+    public ExtensionRestResponse handleGetRequest(ExtensionRestRequest request) {
         if (!EnabledSetting.isADPluginEnabled()) {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
         }
-        Method method = request.method();
-
-        if (!Method.GET.equals(method)) {
-            return new ExtensionRestResponse(
-                request,
-                NOT_FOUND,
-                "Extension REST action improperly configured to handle " + request.toString()
-            );
-        }
 
         String detectorId = request.param("detectorId");
-        logger.info("DETECTOR : {}", detectorId);
         // TODO
         // 1. Get Detector id
         // 2. Find a way to query SearchRequest
@@ -66,69 +52,32 @@ public class RestGetDetectorAction implements ExtensionRestHandler {
         // 4. Follow the steps on the issue
         // 5. Look for MultiGetRequest
 
-        // Search without query
-
-//        Query query = Query.of(qb -> qb.match(q -> q.field("name").query(t -> t.stringValue("test-detector"))));
-//        logger.info("Query: {}", query);
-//        final SearchRequest.Builder searchRequest = new SearchRequest.Builder()
-//            .allowPartialSearchResults(false)
-//            .index(ANOMALY_DETECTORS_INDEX);
-//            .query(query);
-
         SearchResponse<AnomalyDetector> searchResponse = null;
-         try {
+        try {
             searchResponse = sdkClient.search(s -> s.index(ANOMALY_DETECTORS_INDEX), AnomalyDetector.class);
-         } catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
-         }
+        }
 
-//         GetIndexRequest getIndexRequest = new GetIndexRequest.Builder().index(ANOMALY_DETECTORS_INDEX).build();
-//        GetIndexResponse getIndexResponse = null;
-//        try {
-//             getIndexResponse = sdkClient.indices().get(getIndexRequest);
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
-//
-//        logger.info("GetIndexResponse : {}", getIndexResponse.result().);
-
-//        try {
-//            searchResponse = sdkClient.search(searchRequest.build(), AnomalyDetector.class);
-//            logger.info("SearchResponse: {}", searchResponse.hits().hits().size());
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//        }
-        NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(getNamedXWriteables());
-        XContentParser parser;
-        AnomalyDetector detector;
         XContentBuilder builder = null;
         try {
-            parser = request.contentParser(xContentRegistry);
-//            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-            detector = AnomalyDetector.parse(parser);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        for (int i = 0; i < searchResponse.hits().hits().size(); i++) {
-            logger.info("Search query response: {}", searchResponse.hits().hits().get(i).source());
-            logger.info("Documents: {}", searchResponse.documents());
-            if (searchResponse.hits().hits().get(i).id() == detectorId) {
-                builder = XContentBuilder.builder(XContentType.JSON.xContent());
-                builder.startObject();
-                builder.field("id", detectorId);
-                builder.field("version", searchResponse.hits().hits().get(i).version());
-                builder.field("seqNo", searchResponse.hits().hits().get(i).seqNo());
-                builder.field("primaryTerm", searchResponse.hits().hits().get(i).primaryTerm());
-                builder.field("detector", detector);
-                builder.field("status", RestStatus.CREATED);
+            for (int i = 0; i < searchResponse.hits().hits().size(); i++) {
+                logger.info("Search query response: {}", searchResponse.hits().hits().size());
+                if (searchResponse.hits().hits().get(i).id().equals(detectorId)) {
+                    builder = XContentBuilder.builder(XContentType.JSON.xContent());
+                    builder.startObject();
+                    builder.field("id", searchResponse.hits().hits().get(i).id());
+                    builder.field("version", searchResponse.hits().hits().get(i).version());
+                    builder.field("seqNo", searchResponse.hits().hits().get(i).seqNo());
+                    builder.field("primaryTerm", searchResponse.hits().hits().get(i).primaryTerm());
+                    builder.field("detector", searchResponse.hits().hits().get(i).source());
+                    builder.field("status", RestStatus.CREATED);
+                    builder.endObject();
+                }
             }
-            logger.info("2: {}", searchResponse.hits().hits().get(i).id());
-            logger.info("2: {}", searchResponse.hits().hits().get(i).version());
+        } catch (Exception e) {
+            return new ExtensionRestResponse(request, BAD_REQUEST, builder);
         }
-
-        // do things with request
-        return new ExtensionRestResponse(request, OK, "placeholder");
+        return new ExtensionRestResponse(request, OK, builder);
     }
-
 }

--- a/src/main/java/org/opensearch/ad/rest/handler/CreateIndexRequestBuilder.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/CreateIndexRequestBuilder.java
@@ -1,0 +1,63 @@
+package org.opensearch.ad.rest.handler;
+
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Builder class for CreateIndexRequest
+ */
+@JsonpDeserializable
+public class CreateIndexRequestBuilder extends CreateIndexRequest.Builder{
+
+    private CreateIndexRequestBuilder(Builder builder) {
+        mappings(builder.mappings);
+        settings(builder.settings);
+    }
+
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CreateIndexRequestBuilder> {
+
+        @Nullable
+        private TypeMapping mappings;
+        @Nullable
+        private IndexSettings settings;
+
+        public final Builder mappings(@Nullable TypeMapping value) {
+            this.mappings = value;
+            return this;
+        }
+
+        public final Builder settings(@Nullable IndexSettings value) {
+            this.settings = value;
+            return this;
+        }
+
+        public CreateIndexRequestBuilder build() {
+            _checkSingleUse();
+            return new CreateIndexRequestBuilder(this);
+        }
+    }
+
+    /**
+     * Json deserializer for {@link CreateIndexRequestBuilder}
+     */
+    public static final JsonpDeserializer<CreateIndexRequestBuilder> _DESERIALIZER = ObjectBuilderDeserializer
+            .lazy(Builder::new, CreateIndexRequestBuilder::setupCreateIndexRequestDeserializer);
+
+    protected static void setupCreateIndexRequestDeserializer(ObjectDeserializer<Builder> op) {
+        op.add(Builder::mappings, TypeMapping._DESERIALIZER, "mappings");
+        op.add(Builder::settings, IndexSettings._DESERIALIZER, "settings");
+    }
+
+
+
+}

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexLoader.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexLoader.java
@@ -1,0 +1,101 @@
+package org.opensearch.ad.rest.handler;
+
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.ad.model.AnomalyDetector.*;
+
+/**
+ * Serializer for detector with Map<String, Object> type and XContent
+ */
+
+public class IndexLoader {
+    public Map<String, Object> document(AnomalyDetector anomalyDetector) throws IOException {
+        Map<String, Object> builder = new HashMap<>();
+        builder.put(NAME_FIELD, anomalyDetector.getName());
+        builder.put(DESCRIPTION_FIELD, anomalyDetector.getDescription());
+        builder.put(TIMEFIELD_FIELD, anomalyDetector.getTimeField());
+        builder.put(INDICES_FIELD, anomalyDetector.getIndices());
+        builder.put(FILTER_QUERY_FIELD, anomalyDetector.getFilterQuery());
+        builder.put(DETECTION_INTERVAL_FIELD, anomalyDetector.getDetectionInterval());
+        builder.put(WINDOW_DELAY_FIELD, anomalyDetector.getWindowDelay());
+        builder.put(SHINGLE_SIZE_FIELD, anomalyDetector.getShingleSize());
+        builder.put(CommonName.SCHEMA_VERSION_FIELD, anomalyDetector.getSchemaVersion());
+        builder.put(FEATURE_ATTRIBUTES_FIELD,anomalyDetector.getFeatureAttributes());
+
+        if (anomalyDetector.getUiMetadata() != null && !anomalyDetector.getUiMetadata().isEmpty()) {
+            builder.put(UI_METADATA_FIELD, anomalyDetector.getUiMetadata());
+        }
+        if (anomalyDetector.getLastUpdateTime() != null) {
+            builder.put(LAST_UPDATE_TIME_FIELD, anomalyDetector.getLastUpdateTime().toEpochMilli());
+        }
+        if (anomalyDetector.getCategoryField() != null) {
+            builder.put(CATEGORY_FIELD, anomalyDetector.getCategoryField());
+        }
+        if (anomalyDetector.getUser() != null) {
+            builder.put(USER_FIELD, anomalyDetector.getUser() );
+        }
+        if (anomalyDetector.getDetectorType() != null) {
+            builder.put(DETECTOR_TYPE_FIELD, anomalyDetector.getDetectorType());
+        }
+        if (anomalyDetector.getDetectionDateRange() != null) {
+            builder.put(DETECTION_DATE_RANGE_FIELD, anomalyDetector.getDetectionDateRange());
+        }
+        if (anomalyDetector.getResultIndex() != null) {
+            builder.put(RESULT_INDEX_FIELD, anomalyDetector.getResultIndex());
+        }
+
+        return builder;
+
+    }
+
+    public XContentBuilder toXContent(XContentBuilder builder, AnomalyDetector anomalyDetector) throws IOException {
+        XContentBuilder xContentBuilder = builder
+                .startObject()
+                .field(NAME_FIELD,  anomalyDetector.getName())
+                .field(DESCRIPTION_FIELD, anomalyDetector.getDescription())
+                .field(TIMEFIELD_FIELD, anomalyDetector.getTimeField())
+                .field(INDICES_FIELD, anomalyDetector.getIndices())
+                .field(FILTER_QUERY_FIELD, anomalyDetector.getFilterQuery())
+                .field(DETECTION_INTERVAL_FIELD, anomalyDetector.getDetectionInterval())
+                .field(WINDOW_DELAY_FIELD, anomalyDetector.getWindowDelay())
+                .field(SHINGLE_SIZE_FIELD, anomalyDetector.getShingleSize())
+                .field(CommonName.SCHEMA_VERSION_FIELD, anomalyDetector.getSchemaVersion())
+                .field(FEATURE_ATTRIBUTES_FIELD, anomalyDetector.getFeatureAttributes());
+
+
+        if (anomalyDetector.getUiMetadata() != null && !anomalyDetector.getUiMetadata().isEmpty()) {
+            xContentBuilder.field(UI_METADATA_FIELD, anomalyDetector.getUiMetadata());
+        }
+        if (anomalyDetector.getLastUpdateTime() != null) {
+            xContentBuilder.field(LAST_UPDATE_TIME_FIELD, anomalyDetector.getLastUpdateTime().toEpochMilli());
+        }
+        if (anomalyDetector.getCategoryField() != null) {
+            xContentBuilder.field(CATEGORY_FIELD, anomalyDetector.getCategoryField());
+        }
+        if (anomalyDetector.getUser() != null) {
+            xContentBuilder.field(USER_FIELD, anomalyDetector.getUser() );
+        }
+        if (anomalyDetector.getDetectorType() != null) {
+            xContentBuilder.field(DETECTOR_TYPE_FIELD, anomalyDetector.getDetectorType());
+        }
+        if (anomalyDetector.getDetectionDateRange() != null) {
+            xContentBuilder.field(DETECTION_DATE_RANGE_FIELD, anomalyDetector.getDetectionDateRange());
+        }
+        if (anomalyDetector.getResultIndex() != null) {
+            xContentBuilder.field(RESULT_INDEX_FIELD, anomalyDetector.getResultIndex());
+        }
+        xContentBuilder.endObject();
+        return xContentBuilder;
+    }
+
+    public void fromXContent() {
+
+    }
+}

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexSerializeRequestBuilder.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexSerializeRequestBuilder.java
@@ -1,0 +1,94 @@
+package org.opensearch.ad.rest.handler;
+
+import jakarta.json.stream.JsonGenerator;
+import org.opensearch.ad.auth.UserIdentity;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.Feature;
+import org.opensearch.ad.model.TimeConfiguration;
+import org.opensearch.client.json.*;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilder;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builder class for IndexRequest
+ */
+public class IndexSerializeRequestBuilder extends IndexRequest.Builder implements JsonpSerializable {
+
+    private String detectorString;
+    private AnomalyDetector anomalyDetector;
+
+    @Nonnull
+    public final AnomalyDetector anomalyDetector() {
+        return this.anomalyDetector;
+    }
+
+    @Nonnull
+    public final String getDetectorString() {
+        return this.detectorString;
+    }
+
+    private IndexSerializeRequestBuilder() {}
+
+
+    public IndexSerializeRequestBuilder(Builder builder) {
+        this.detectorString = builder.detectorString;
+        this.anomalyDetector = builder.anomalyDetector;
+    }
+
+    @Override
+    public void serialize(JsonGenerator builder, JsonpMapper mapper) {
+        builder.writeStartObject();
+        builder.write("detector", this.detectorString);
+        builder.writeEnd();
+    }
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndexSerializeRequestBuilder> {
+        private String detectorString;
+        private AnomalyDetector anomalyDetector;
+
+        public final Builder detectorString(@Nonnull String v) {
+            this.detectorString = v;
+            return this;
+        }
+
+        public final Builder detector(@Nonnull AnomalyDetector anomalyDetector) {
+            this.anomalyDetector = anomalyDetector;
+            return this;
+        }
+
+        @Override
+        public IndexSerializeRequestBuilder build() {
+            _checkSingleUse();
+            return new IndexSerializeRequestBuilder(this);
+        }
+
+
+    }
+//
+//    XContentParser parser =
+//            XContentType.JSON.xContent().createParser(xContentRegistry,
+//                    LoggingDeprecationHandler.INSTANCE,
+//                    sourceJson);
+//
+//    public static final JsonpDeserializer<IndexSerializeRequestBuilder> _DESERIALIZER = ObjectBuilderDeserializer
+//            .lazy(IndexSerializeRequestBuilder.Builder::new, IndexSerializeRequestBuilder::setupCreateIndexRequestDeserializer);
+//
+//    protected static void setupCreateIndexRequestDeserializer(ObjectDeserializer<IndexSerializeRequestBuilder.Builder> op) {
+//        op.add(IndexSerializeRequestBuilder.Builder::detectorString, String._DESERIALIZER, "detectorString");
+//
+//        ObjectBuilderParser
+//    }
+
+}

--- a/src/main/java/org/opensearch/ad/rest/handler/JacksonDetector.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/JacksonDetector.java
@@ -1,0 +1,56 @@
+package org.opensearch.ad.rest.handler;
+
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentType;
+
+import static org.opensearch.ad.model.AnomalyDetector.*;
+
+/**
+ * Serializer for detector with String type
+ */
+
+public class JacksonDetector {
+    String detectorString;
+    AnomalyDetector anomalyDetector;
+
+    public JacksonDetector(AnomalyDetector anomalyDetector, String detectorString) {
+        this.anomalyDetector = anomalyDetector;
+        this.detectorString = detectorString;
+    }
+
+    JacksonDetector() {}
+
+    public XContentBuilder toXContent() {
+        XContentBuilder sources = null;
+        try {
+            sources = XContentBuilder.builder(XContentType.JSON.xContent()).startObject()
+                    .field(NAME_FIELD, anomalyDetector.getName())
+                    .field(DESCRIPTION_FIELD, anomalyDetector.getDescription())
+                    .field(TIMEFIELD_FIELD, anomalyDetector.getTimeField())
+                    .field(INDICES_FIELD, anomalyDetector.getIndices())
+                    .field(FILTER_QUERY_FIELD, anomalyDetector.getFilterQuery())
+                    .field(DETECTION_INTERVAL_FIELD, anomalyDetector.getDetectionInterval())
+                    .field(WINDOW_DELAY_FIELD, anomalyDetector.getWindowDelay())
+                    .field(SHINGLE_SIZE_FIELD, anomalyDetector.getShingleSize())
+                    .field(CommonName.SCHEMA_VERSION_FIELD, anomalyDetector.getSchemaVersion())
+                    .field(FEATURE_ATTRIBUTES_FIELD,anomalyDetector.getFeatureAttributes())
+                    .endObject();
+
+        } catch(Exception e) {
+            e.printStackTrace();;
+        }
+
+        try{
+            return  anomalyDetector.toXContent(sources);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
+
+    }
+}

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -17,8 +17,7 @@ import static org.opensearch.ad.constant.CommonErrorMessages.NO_PERMISSION_TO_AC
 import static org.opensearch.ad.constant.CommonName.DATE_HISTOGRAM;
 import static org.opensearch.ad.constant.CommonName.EPOCH_MILLIS_FORMAT;
 import static org.opensearch.ad.constant.CommonName.FEATURE_AGGS;
-import static org.opensearch.ad.model.AnomalyDetector.QUERY_PARAM_PERIOD_END;
-import static org.opensearch.ad.model.AnomalyDetector.QUERY_PARAM_PERIOD_START;
+import static org.opensearch.ad.model.AnomalyDetector.*;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PIECE_SIZE;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.search.aggregations.AggregationBuilders.dateRange;
@@ -26,17 +25,11 @@ import static org.opensearch.search.aggregations.AggregatorFactories.VALID_AGG_N
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -56,6 +49,9 @@ import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.client.Client;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.AggregateBuilders;
+import org.opensearch.client.opensearch._types.aggregations.AggregateVariant;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -120,6 +116,22 @@ public final class ParseUtils {
     public static AggregationBuilder toAggregationBuilder(XContentParser parser) throws IOException {
         AggregatorFactories.Builder parsed = AggregatorFactories.parseAggregators(parser);
         return parsed.getAggregatorFactories().iterator().next();
+    }
+
+    public static Aggregate toAggregare(XContentParser parser) throws IOException {
+        Map<String, Object> builder = new HashMap<>();
+
+
+        List<Map<String, Object>> parserList;
+        XContentParser.Token token = parser.nextToken();
+        if (token == XContentParser.Token.START_ARRAY) {
+            parserList = parser.listOrderedMap().stream().map(obj -> (Map<String, Object>) obj).collect(Collectors.toList());
+        } else {
+            parserList = Collections.singletonList(parser.mapOrdered());
+        }
+        builder.put(FEATURE_ATTRIBUTES_FIELD,parserList);
+        Aggregate aggregate = new Aggregate((AggregateVariant) builder);
+        return aggregate;
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
@@ -30,6 +30,7 @@ import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Feature;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -93,7 +94,7 @@ public final class RestHandlerUtils {
      * @return instance of {@link org.opensearch.search.fetch.subphase.FetchSourceContext}
      */
     public static FetchSourceContext getSourceContext(RestRequest request) {
-        String userAgent = Strings.coalesceToEmpty(request.header("User-Agent"));
+        String userAgent = coalesceToEmpty(request.header("User-Agent"));
         if (!userAgent.contains(OPENSEARCH_DASHBOARDS_USER_AGENT)) {
             return new FetchSourceContext(true, Strings.EMPTY_ARRAY, UI_METADATA_EXCLUDE);
         } else {
@@ -220,5 +221,9 @@ public final class RestHandlerUtils {
             return false;
         }
         return e instanceof OpenSearchStatusException || e instanceof IndexNotFoundException || e instanceof InvalidIndexNameException;
+    }
+
+    private static String coalesceToEmpty(@Nullable String s) {
+        return s == null ? "" : s;
     }
 }


### PR DESCRIPTION
### Description
This is a draft PR which covers the different serialization way for creating index on OpneSearch. The approaches this PR has are:
1. IndexLoader.java -  Serializer for detector with Map<String, Object> type and XContent
2. JacksonDetector.java - Serializer for detector with String type
3. IndexSerializeRequestBuilder.java - Builder class for IndexRequest
4. CreateIndexRequestBuilder.java - Builder class for CreateIndexRequest

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
