### PR TITLE
Fix the discrepancy between Profile API and real time tasks API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,8 @@ dependencies {
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${job_scheduler_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    implementation group: 'com.google.guava', name: 'guava', version:'31.0.1-jre'
-    implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
+    compileOnly group: 'com.google.guava', name: 'guava', version:'31.0.1-jre'
+    compileOnly group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     implementation group: 'org.javassist', name: 'javassist', version:'3.28.0-GA'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'

--- a/build.gradle
+++ b/build.gradle
@@ -121,10 +121,6 @@ dependencies {
     implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:3.0-rc3'
     implementation 'software.amazon.randomcutforest:randomcutforest-core:3.0-rc3'
 
-    // we inherit jackson-core from opensearch core
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.1"
-
     // used for serializing/deserializing rcf models.
     implementation group: 'io.protostuff', name: 'protostuff-core', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-runtime', version: '1.8.0'

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
@@ -560,14 +560,12 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
                         }, exception -> { log.error("JobRunner failed to update AD job as disabled for " + detectorId, exception); }));
                     } else {
                         log.info("AD Job was disabled for " + detectorId);
-                        // function.execute();
                     }
                 } catch (IOException e) {
                     log.error("JobRunner failed to stop detector job " + detectorId, e);
                 }
             } else {
                 log.info("AD Job was not found for " + detectorId);
-                // function.execute();
             }
         }, exception -> log.error("JobRunner failed to get detector job " + detectorId, exception));
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -762,7 +762,10 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             adTaskManager,
             nodeFilter,
             threadPool,
-            client
+            client,
+            stateManager,
+            adTaskCacheManager,
+            AnomalyDetectorSettings.NUM_MIN_SAMPLES
         );
 
         // return objects used by Guice to inject dependencies for e.g.,

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -451,7 +451,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 long enabledTime = job.getEnabledTime().toEpochMilli();
                 long totalUpdates = profileResponse.getTotalUpdates();
                 ProfileUtil
-                    .confirmDetectorInitStatus(
+                    .confirmDetectorRealtimeInitStatus(
                         detector,
                         enabledTime,
                         client,

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -40,7 +40,6 @@ import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
-import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.DetectorProfile;
 import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.DetectorState;
@@ -64,8 +63,6 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -451,14 +448,15 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
             if (profileResponse.getTotalUpdates() < requiredSamples) {
                 // need to double check since what ProfileResponse returns is the highest priority entity currently in memory, but
                 // another entity might have already been initialized and sit somewhere else (in memory or on disk).
-                confirmMultiEntityDetectorInitStatus(
-                    detector,
-                    job.getEnabledTime().toEpochMilli(),
-                    profileBuilder,
-                    profilesToCollect,
-                    profileResponse.getTotalUpdates(),
-                    listener
-                );
+                long enabledTime = job.getEnabledTime().toEpochMilli();
+                long totalUpdates = profileResponse.getTotalUpdates();
+                ProfileUtil
+                    .confirmDetectorInitStatus(
+                        detector,
+                        enabledTime,
+                        client,
+                        onInittedEver(enabledTime, profileBuilder, profilesToCollect, detector, totalUpdates, listener)
+                    );
             } else {
                 createRunningStateAndInitProgress(profilesToCollect, profileBuilder);
                 listener.onResponse(profileBuilder.build());
@@ -469,18 +467,6 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
             }
             listener.onResponse(profileBuilder.build());
         }
-    }
-
-    private void confirmMultiEntityDetectorInitStatus(
-        AnomalyDetector detector,
-        long enabledTime,
-        DetectorProfile.Builder profile,
-        Set<DetectorProfileName> profilesToCollect,
-        long totalUpdates,
-        MultiResponsesDelegateActionListener<DetectorProfile> listener
-    ) {
-        SearchRequest searchLatestResult = createInittedEverRequest(detector.getDetectorId(), enabledTime, detector.getResultIndex());
-        client.search(searchLatestResult, onInittedEver(enabledTime, profile, profilesToCollect, detector, totalUpdates, listener));
     }
 
     private ActionListener<SearchResponse> onInittedEver(
@@ -601,27 +587,5 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
         }
 
         listener.onResponse(builder.build());
-    }
-
-    /**
-     * Create search request to check if we have at least 1 anomaly score larger than 0 after AD job enabled time
-     * @param detectorId detector id
-     * @param enabledTime the time when AD job is enabled in milliseconds
-     * @return the search request
-     */
-    private SearchRequest createInittedEverRequest(String detectorId, long enabledTime, String resultIndex) {
-        BoolQueryBuilder filterQuery = new BoolQueryBuilder();
-        filterQuery.filter(QueryBuilders.termQuery(AnomalyResult.DETECTOR_ID_FIELD, detectorId));
-        filterQuery.filter(QueryBuilders.rangeQuery(AnomalyResult.EXECUTION_END_TIME_FIELD).gte(enabledTime));
-        filterQuery.filter(QueryBuilders.rangeQuery(AnomalyResult.ANOMALY_SCORE_FIELD).gt(0));
-
-        SearchSourceBuilder source = new SearchSourceBuilder().query(filterQuery).size(1);
-
-        SearchRequest request = new SearchRequest(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
-        request.source(source);
-        if (resultIndex != null) {
-            request.indices(resultIndex);
-        }
-        return request;
     }
 }

--- a/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
+++ b/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
@@ -356,9 +356,9 @@ public class ExecuteADResultResponseRecorder {
                     listener.onFailure(new AnomalyDetectionException(detectorId, "fail to get job"));
                     return;
                 }
-                adTaskCacheManager.markResultIndexQueried(detectorId);
+
                 ProfileUtil
-                    .confirmDetectorInitStatus(
+                    .confirmDetectorRealtimeInitStatus(
                         detectorOptional.get(),
                         jobOptional.get().getEnabledTime().toEpochMilli(),
                         client,
@@ -371,11 +371,13 @@ public class ExecuteADResultResponseRecorder {
                                     // so that the detector won't stay initialized
                                     correctedTotalUpdates = Long.valueOf(rcfMinSamples);
                                 }
+                                adTaskCacheManager.markResultIndexQueried(detectorId);
                                 return correctedTotalUpdates;
                             });
                         }, exception -> {
                             if (ExceptionUtil.isIndexNotAvailable(exception)) {
                                 // anomaly result index is not created yet
+                                adTaskCacheManager.markResultIndexQueried(detectorId);
                                 listener.onResponse(0L);
                             } else {
                                 listener.onFailure(exception);

--- a/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
+++ b/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
@@ -32,6 +34,7 @@ import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
+import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.ad.transport.AnomalyResultResponse;
 import org.opensearch.ad.transport.ProfileAction;
@@ -40,10 +43,12 @@ import org.opensearch.ad.transport.RCFPollingAction;
 import org.opensearch.ad.transport.RCFPollingRequest;
 import org.opensearch.ad.transport.handler.AnomalyIndexHandler;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
+import org.opensearch.ad.util.ExceptionUtil;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.commons.authuser.User;
+import org.opensearch.search.SearchHits;
 import org.opensearch.threadpool.ThreadPool;
 
 public class ExecuteADResultResponseRecorder {
@@ -55,6 +60,9 @@ public class ExecuteADResultResponseRecorder {
     private DiscoveryNodeFilterer nodeFilter;
     private ThreadPool threadPool;
     private Client client;
+    private NodeStateManager nodeStateManager;
+    private ADTaskCacheManager adTaskCacheManager;
+    private int rcfMinSamples;
 
     public ExecuteADResultResponseRecorder(
         AnomalyDetectionIndices anomalyDetectionIndices,
@@ -62,7 +70,10 @@ public class ExecuteADResultResponseRecorder {
         ADTaskManager adTaskManager,
         DiscoveryNodeFilterer nodeFilter,
         ThreadPool threadPool,
-        Client client
+        Client client,
+        NodeStateManager nodeStateManager,
+        ADTaskCacheManager adTaskCacheManager,
+        int rcfMinSamples
     ) {
         this.anomalyDetectionIndices = anomalyDetectionIndices;
         this.anomalyResultHandler = anomalyResultHandler;
@@ -70,6 +81,9 @@ public class ExecuteADResultResponseRecorder {
         this.nodeFilter = nodeFilter;
         this.threadPool = threadPool;
         this.client = client;
+        this.nodeStateManager = nodeStateManager;
+        this.adTaskCacheManager = adTaskCacheManager;
+        this.rcfMinSamples = rcfMinSamples;
     }
 
     public void indexAnomalyResult(
@@ -185,27 +199,66 @@ public class ExecuteADResultResponseRecorder {
         String error
     ) {
         // Don't need info as this will be printed repeatedly in each interval
-        adTaskManager
-            .updateLatestRealtimeTaskOnCoordinatingNode(
+        ActionListener<UpdateResponse> listener = ActionListener.wrap(r -> {
+            if (r != null) {
+                log.debug("Updated latest realtime task successfully for detector {}, taskState: {}", detectorId, taskState);
+            }
+        }, e -> {
+            if ((e instanceof ResourceNotFoundException) && e.getMessage().contains(CAN_NOT_FIND_LATEST_TASK)) {
+                // Clear realtime task cache, will recreate AD task in next run, check AnomalyResultTransportAction.
+                log.error("Can't find latest realtime task of detector " + detectorId);
+                adTaskManager.removeRealtimeTaskCache(detectorId);
+            } else {
+                log.error("Failed to update latest realtime task for detector " + detectorId, e);
+            }
+        });
+
+        // rcfTotalUpdates is null when we save exception messages
+        if (!adTaskCacheManager.hasQueriedResultIndex(detectorId) && rcfTotalUpdates != null && rcfTotalUpdates < rcfMinSamples) {
+            // confirm the total updates number since it is possible that we have already had results after job enabling time
+            // If yes, total updates should be at least rcfMinSamples so that the init progress reaches 100%.
+            confirmTotalRCFUpdatesFound(
                 detectorId,
                 taskState,
                 rcfTotalUpdates,
                 detectorIntervalInMinutes,
                 error,
-                ActionListener.wrap(r -> {
-                    if (r != null) {
-                        log.debug("Updated latest realtime task successfully for detector {}, taskState: {}", detectorId, taskState);
-                    }
-                }, e -> {
-                    if ((e instanceof ResourceNotFoundException) && e.getMessage().contains(CAN_NOT_FIND_LATEST_TASK)) {
-                        // Clear realtime task cache, will recreate AD task in next run, check AnomalyResultTransportAction.
-                        log.error("Can't find latest realtime task of detector " + detectorId);
-                        adTaskManager.removeRealtimeTaskCache(detectorId);
-                    } else {
-                        log.error("Failed to update latest realtime task for detector " + detectorId, e);
-                    }
-                })
+                ActionListener
+                    .wrap(
+                        r -> adTaskManager
+                            .updateLatestRealtimeTaskOnCoordinatingNode(
+                                detectorId,
+                                taskState,
+                                r,
+                                detectorIntervalInMinutes,
+                                error,
+                                listener
+                            ),
+                        e -> {
+                            log.error("Fail to confirm rcf update", e);
+                            adTaskManager
+                                .updateLatestRealtimeTaskOnCoordinatingNode(
+                                    detectorId,
+                                    taskState,
+                                    rcfTotalUpdates,
+                                    detectorIntervalInMinutes,
+                                    error,
+                                    listener
+                                );
+                        }
+                    )
             );
+        } else {
+            adTaskManager
+                .updateLatestRealtimeTaskOnCoordinatingNode(
+                    detectorId,
+                    taskState,
+                    rcfTotalUpdates,
+                    detectorIntervalInMinutes,
+                    error,
+                    listener
+                );
+        }
     }
 
     /**
@@ -285,4 +338,51 @@ public class ExecuteADResultResponseRecorder {
         }
     }
 
+    private void confirmTotalRCFUpdatesFound(
+        String detectorId,
+        String taskState,
+        Long rcfTotalUpdates,
+        Long detectorIntervalInMinutes,
+        String error,
+        ActionListener<Long> listener
+    ) {
+        nodeStateManager.getAnomalyDetector(detectorId, ActionListener.wrap(detectorOptional -> {
+            if (!detectorOptional.isPresent()) {
+                listener.onFailure(new AnomalyDetectionException(detectorId, "fail to get detector"));
+                return;
+            }
+            nodeStateManager.getAnomalyDetectorJob(detectorId, ActionListener.wrap(jobOptional -> {
+                if (!jobOptional.isPresent()) {
+                    listener.onFailure(new AnomalyDetectionException(detectorId, "fail to get job"));
+                    return;
+                }
+                adTaskCacheManager.markResultIndexQueried(detectorId);
+                ProfileUtil
+                    .confirmDetectorInitStatus(
+                        detectorOptional.get(),
+                        jobOptional.get().getEnabledTime().toEpochMilli(),
+                        client,
+                        ActionListener.wrap(searchResponse -> {
+                            ActionListener.completeWith(listener, () -> {
+                                SearchHits hits = searchResponse.getHits();
+                                Long correctedTotalUpdates = rcfTotalUpdates;
+                                if (hits.getTotalHits().value > 0L) {
+                                    // correct the number if we have already had results after job enabling time
+                                    // so that the detector won't stay initialized
+                                    correctedTotalUpdates = Long.valueOf(rcfMinSamples);
+                                }
+                                return correctedTotalUpdates;
+                            });
+                        }, exception -> {
+                            if (ExceptionUtil.isIndexNotAvailable(exception)) {
+                                // anomaly result index is not created yet
+                                listener.onResponse(0L);
+                            } else {
+                                listener.onFailure(exception);
+                            }
+                        })
+                    );
+            }, e -> listener.onFailure(new AnomalyDetectionException(detectorId, "fail to get job"))));
+        }, e -> listener.onFailure(new AnomalyDetectionException(detectorId, "fail to get detector"))));
+    }
 }

--- a/src/main/java/org/opensearch/ad/ProfileUtil.java
+++ b/src/main/java/org/opensearch/ad/ProfileUtil.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.client.Client;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+public class ProfileUtil {
+    /**
+     * Create search request to check if we have at least 1 anomaly score larger than 0 after AD job enabled time
+     * @param detectorId detector id
+     * @param enabledTime the time when AD job is enabled in milliseconds
+     * @return the search request
+     */
+    private static SearchRequest createInittedEverRequest(String detectorId, long enabledTime, String resultIndex) {
+        BoolQueryBuilder filterQuery = new BoolQueryBuilder();
+        filterQuery.filter(QueryBuilders.termQuery(AnomalyResult.DETECTOR_ID_FIELD, detectorId));
+        filterQuery.filter(QueryBuilders.rangeQuery(AnomalyResult.EXECUTION_END_TIME_FIELD).gte(enabledTime));
+        filterQuery.filter(QueryBuilders.rangeQuery(AnomalyResult.ANOMALY_SCORE_FIELD).gt(0));
+
+        SearchSourceBuilder source = new SearchSourceBuilder().query(filterQuery).size(1);
+
+        SearchRequest request = new SearchRequest(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        request.source(source);
+        if (resultIndex != null) {
+            request.indices(resultIndex);
+        }
+        return request;
+    }
+
+    public static void confirmDetectorInitStatus(
+        AnomalyDetector detector,
+        long enabledTime,
+        Client client,
+        ActionListener<SearchResponse> listener
+    ) {
+        SearchRequest searchLatestResult = createInittedEverRequest(detector.getDetectorId(), enabledTime, detector.getResultIndex());
+        client.search(searchLatestResult, listener);
+    }
+}

--- a/src/main/java/org/opensearch/ad/task/ADRealtimeTaskCache.java
+++ b/src/main/java/org/opensearch/ad/task/ADRealtimeTaskCache.java
@@ -38,12 +38,17 @@ public class ADRealtimeTaskCache {
     // detector interval in milliseconds.
     private long detectorIntervalInMillis;
 
+    // we query result index to check if there are any result generated for detector to tell whether it passed initialization of not.
+    // To avoid repeated query when there is no data, record whether we have done that or not.
+    private boolean queriedResultIndex;
+
     public ADRealtimeTaskCache(String state, Float initProgress, String error, long detectorIntervalInMillis) {
         this.state = state;
         this.initProgress = initProgress;
         this.error = error;
         this.lastJobRunTime = Instant.now().toEpochMilli();
         this.detectorIntervalInMillis = detectorIntervalInMillis;
+        this.queriedResultIndex = false;
     }
 
     public String getState() {
@@ -72,6 +77,14 @@ public class ADRealtimeTaskCache {
 
     public void setLastJobRunTime(long lastJobRunTime) {
         this.lastJobRunTime = lastJobRunTime;
+    }
+
+    public boolean hasQueriedResultIndex() {
+        return queriedResultIndex;
+    }
+
+    public void setQueriedResultIndex(boolean queriedResultIndex) {
+        this.queriedResultIndex = queriedResultIndex;
     }
 
     public boolean expired() {

--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -1013,33 +1013,38 @@ public class ADTaskCacheManager {
     }
 
     /**
-     * Check if realtime task field value changed or not by comparing with cache.
+     * Check if realtime task field value change needed or not by comparing with cache.
      * 1. If new field value is null, will consider this field as not changed.
-     * 2. If any field value changed, will consider the realtime task changed.
-     * 3. If realtime task cache not found, will consider the realtime task changed.
+     * 2. If init progress is larger or the old init progress is null, will consider the realtime task
+     *  change needed; for other fields, as long as field values changed, will consider the realtime
+     *  task changed. We did this so that the init progress won't go backwards.
+     * 3. If realtime task cache not found, will consider the realtime task change needed.
      *
      * @param detectorId detector id
      * @param newState new task state
      * @param newInitProgress new init progress
      * @param newError new error
-     * @return true if realtime task changed comparing with realtime task cache.
+     * @return true if realtime task change needed.
      */
-    public boolean isRealtimeTaskChanged(String detectorId, String newState, Float newInitProgress, String newError) {
+    public boolean isRealtimeTaskChangeNeeded(String detectorId, String newState, Float newInitProgress, String newError) {
         if (realtimeTaskCaches.containsKey(detectorId)) {
             ADRealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(detectorId);
             boolean stateChanged = false;
             if (newState != null && !newState.equals(realtimeTaskCache.getState())) {
                 stateChanged = true;
             }
-            boolean initProgressChanged = false;
-            if (newInitProgress != null && !newInitProgress.equals(realtimeTaskCache.getInitProgress())) {
-                initProgressChanged = true;
+            boolean initProgressChangeNeeded = false;
+            Float existingProgress = realtimeTaskCache.getInitProgress();
+            if (newInitProgress != null
+                && !newInitProgress.equals(existingProgress)
+                && (existingProgress == null || newInitProgress > existingProgress)) {
+                initProgressChangeNeeded = true;
             }
             boolean errorChanged = false;
             if (newError != null && !newError.equals(realtimeTaskCache.getError())) {
                 errorChanged = true;
             }
-            if (stateChanged || initProgressChanged || errorChanged) {
+            if (stateChanged || initProgressChangeNeeded || errorChanged) {
                 return true;
             }
             return false;
@@ -1350,5 +1355,34 @@ public class ADTaskCacheManager {
         } finally {
             cleanExpiredHCBatchTaskRunStatesSemaphore.release();
         }
+    }
+
+    /**
+     * We query result index to check if there are any result generated for detector to tell whether it passed initialization of not.
+     * To avoid repeated query when there is no data, record whether we have done that or not.
+     * @param id detector id
+     */
+    public void markResultIndexQueried(String id) {
+        ADRealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(id);
+        // we initialize a real time cache at the beginning of AnomalyResultTransportAction if it
+        // cannot be found. If the cache is empty, we will return early and wait it for it to be
+        // initialized.
+        if (realtimeTaskCache != null) {
+            realtimeTaskCache.setQueriedResultIndex(true);
+        }
+    }
+
+    /**
+     * We query result index to check if there are any result generated for detector to tell whether it passed initialization of not.
+     *
+     * @param id detector id
+     * @return whether we have queried result index or not.
+     */
+    public boolean hasQueriedResultIndex(String id) {
+        ADRealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(id);
+        if (realtimeTaskCache != null) {
+            return realtimeTaskCache.hasQueriedResultIndex();
+        }
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -2057,7 +2057,7 @@ public class ADTaskManager {
         }
 
         error = Optional.ofNullable(error).orElse("");
-        if (!adTaskCacheManager.isRealtimeTaskChanged(detectorId, newState, initProgress, error)) {
+        if (!adTaskCacheManager.isRealtimeTaskChangeNeeded(detectorId, newState, initProgress, error)) {
             // If task not changed, no need to update, just return
             listener.onResponse(null);
             return;
@@ -3091,5 +3091,4 @@ public class ADTaskManager {
             }
         }
     }
-
 }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -13,6 +13,7 @@ package org.opensearch.ad;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -22,8 +23,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_MIN_SAMPLES;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -40,6 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -48,19 +52,25 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
+import org.opensearch.ad.constant.CommonName;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.model.FeatureData;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.ad.transport.AnomalyResultAction;
+import org.opensearch.ad.transport.AnomalyResultResponse;
 import org.opensearch.ad.transport.handler.AnomalyIndexHandler;
 import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
-import org.opensearch.ad.util.IndexUtils;
 import org.opensearch.client.Client;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.Settings;
@@ -78,6 +88,8 @@ import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.threadpool.ThreadPool;
+
+import com.google.common.collect.ImmutableList;
 
 public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
 
@@ -114,15 +126,18 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
     @Mock
     private ADTaskManager adTaskManager;
 
-    @Mock
-    private AnomalyDetectionIndices indexUtil;
-
     private ExecuteADResultResponseRecorder recorder;
 
     @Mock
     private DiscoveryNodeFilterer nodeFilter;
 
     private AnomalyDetector detector;
+
+    @Mock
+    private ADTaskCacheManager adTaskCacheManager;
+
+    @Mock
+    private NodeStateManager nodeStateManager;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -161,10 +176,8 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
         runner.setSettings(settings);
 
         AnomalyDetectionIndices anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
-        IndexNameExpressionResolver indexNameResolver = mock(IndexNameExpressionResolver.class);
-        IndexUtils indexUtils = new IndexUtils(client, clientUtil, clusterService, indexNameResolver);
 
-        runner.setAnomalyDetectionIndices(indexUtil);
+        runner.setAnomalyDetectionIndices(anomalyDetectionIndices);
 
         lockService = new LockService(client, clusterService);
         doReturn(lockService).when(context).getLockService();
@@ -204,17 +217,28 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
             return null;
         }).when(client).index(any(), any());
 
-        recorder = new ExecuteADResultResponseRecorder(indexUtil, anomalyResultHandler, adTaskManager, nodeFilter, threadPool, client);
-        runner.setExecuteADResultResponseRecorder(recorder);
-        detector = TestHelpers.randomAnomalyDetectorWithEmptyFeature();
+        when(adTaskCacheManager.hasQueriedResultIndex(anyString())).thenReturn(false);
 
-        NodeStateManager stateManager = mock(NodeStateManager.class);
+        detector = TestHelpers.randomAnomalyDetectorWithEmptyFeature();
         doAnswer(invocation -> {
             ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
             listener.onResponse(Optional.of(detector));
             return null;
-        }).when(stateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
-        runner.setNodeStateManager(stateManager);
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        runner.setNodeStateManager(nodeStateManager);
+
+        recorder = new ExecuteADResultResponseRecorder(
+            anomalyDetectionIndices,
+            anomalyResultHandler,
+            adTaskManager,
+            nodeFilter,
+            threadPool,
+            client,
+            nodeStateManager,
+            adTaskCacheManager,
+            32
+        );
+        runner.setExecuteADResultResponseRecorder(recorder);
     }
 
     @Rule
@@ -499,4 +523,202 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
         when(jobParameter.getWindowDelay()).thenReturn(new IntervalTimeConfiguration(10, ChronoUnit.SECONDS));
     }
 
+    /**
+     * Test updateLatestRealtimeTask.confirmTotalRCFUpdatesFound
+     * @throws InterruptedException
+     */
+    public Instant confirmInitializedSetup() {
+        // clear the appender created in setUp before creating another association; otherwise
+        // we will have unexpected error (e.g., some appender does not record messages even
+        // though we have configured to do so).
+        super.tearDownLog4jForJUnit();
+        setUpLog4jForJUnit(ExecuteADResultResponseRecorder.class, true);
+        Schedule schedule = mock(IntervalSchedule.class);
+        when(jobParameter.getSchedule()).thenReturn(schedule);
+        Instant executionStartTime = Instant.now();
+        when(schedule.getNextExecutionTime(executionStartTime)).thenReturn(executionStartTime.plusSeconds(5));
+
+        AnomalyResultResponse response = new AnomalyResultResponse(
+            4d,
+            0.993,
+            1.01,
+            Collections.singletonList(new FeatureData("123", "abc", 0d)),
+            randomAlphaOfLength(4),
+            // not fully initialized
+            Long.valueOf(AnomalyDetectorSettings.NUM_MIN_SAMPLES - 1),
+            randomLong(),
+            // not an HC detector
+            false,
+            randomInt(),
+            new double[] { randomDoubleBetween(0, 1.0, true), randomDoubleBetween(0, 1.0, true) },
+            new double[] { randomDouble(), randomDouble() },
+            new double[][] { new double[] { randomDouble(), randomDouble() } },
+            new double[] { randomDouble() },
+            randomDoubleBetween(1.1, 10.0, true)
+        );
+        doAnswer(invocation -> {
+            ActionListener<AnomalyResultResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(AnomalyResultAction.INSTANCE), any(), any());
+        return executionStartTime;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testFailtoFindDetector() {
+        Instant executionStartTime = confirmInitializedSetup();
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException());
+            return null;
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+
+        LockModel lock = new LockModel(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, jobParameter.getName(), Instant.now(), 10, false);
+
+        runner.runAdJob(jobParameter, lockService, lock, Instant.now().minusSeconds(60), executionStartTime, recorder, detector);
+
+        verify(client, times(1)).execute(eq(AnomalyResultAction.INSTANCE), any(), any());
+        verify(adTaskCacheManager, times(1)).hasQueriedResultIndex(anyString());
+        verify(nodeStateManager, times(1)).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        verify(nodeStateManager, times(0)).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        assertEquals(1, testAppender.countMessage("Fail to confirm rcf update"));
+        assertTrue(testAppender.containExceptionMsg(AnomalyDetectionException.class, "fail to get detector"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testFailtoFindJob() {
+        Instant executionStartTime = confirmInitializedSetup();
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetectorJob>> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException());
+            return null;
+        }).when(nodeStateManager).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+
+        LockModel lock = new LockModel(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, jobParameter.getName(), Instant.now(), 10, false);
+
+        runner.runAdJob(jobParameter, lockService, lock, Instant.now().minusSeconds(60), executionStartTime, recorder, detector);
+
+        verify(client, times(1)).execute(eq(AnomalyResultAction.INSTANCE), any(), any());
+        verify(adTaskCacheManager, times(1)).hasQueriedResultIndex(anyString());
+        verify(nodeStateManager, times(1)).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        verify(nodeStateManager, times(1)).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        assertEquals(1, testAppender.countMessage("Fail to confirm rcf update"));
+        assertTrue(testAppender.containExceptionMsg(AnomalyDetectionException.class, "fail to get job"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testEmptyDetector() {
+        Instant executionStartTime = confirmInitializedSetup();
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.empty());
+            return null;
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+
+        LockModel lock = new LockModel(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, jobParameter.getName(), Instant.now(), 10, false);
+
+        runner.runAdJob(jobParameter, lockService, lock, Instant.now().minusSeconds(60), executionStartTime, recorder, detector);
+
+        verify(client, times(1)).execute(eq(AnomalyResultAction.INSTANCE), any(), any());
+        verify(adTaskCacheManager, times(1)).hasQueriedResultIndex(anyString());
+        verify(nodeStateManager, times(1)).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        verify(nodeStateManager, times(0)).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        assertEquals(1, testAppender.countMessage("Fail to confirm rcf update"));
+        assertTrue(testAppender.containExceptionMsg(AnomalyDetectionException.class, "fail to get detector"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testEmptyJob() {
+        Instant executionStartTime = confirmInitializedSetup();
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetectorJob>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.empty());
+            return null;
+        }).when(nodeStateManager).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+
+        LockModel lock = new LockModel(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, jobParameter.getName(), Instant.now(), 10, false);
+
+        runner.runAdJob(jobParameter, lockService, lock, Instant.now().minusSeconds(60), executionStartTime, recorder, detector);
+
+        verify(client, times(1)).execute(eq(AnomalyResultAction.INSTANCE), any(), any());
+        verify(adTaskCacheManager, times(1)).hasQueriedResultIndex(anyString());
+        verify(nodeStateManager, times(1)).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        verify(nodeStateManager, times(1)).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+        verify(adTaskManager, times(1)).updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), any(), any(), any(), any());
+        assertEquals(1, testAppender.countMessage("Fail to confirm rcf update"));
+        assertTrue(testAppender.containExceptionMsg(AnomalyDetectionException.class, "fail to get job"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testMarkResultIndexQueried() throws IOException {
+        detector = TestHelpers.AnomalyDetectorBuilder
+            .newInstance()
+            .setDetectionInterval(new IntervalTimeConfiguration(1, ChronoUnit.MINUTES))
+            .setCategoryFields(ImmutableList.of(randomAlphaOfLength(5)))
+            .setResultIndex(CommonName.CUSTOM_RESULT_INDEX_PREFIX + "index")
+            .build();
+        Instant executionStartTime = confirmInitializedSetup();
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetectorJob>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(TestHelpers.randomAnomalyDetectorJob(true, Instant.ofEpochMilli(1602401500000L), null)));
+            return null;
+        }).when(nodeStateManager).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
+
+            SearchResponse mockResponse = mock(SearchResponse.class);
+            int totalHits = 1001;
+            when(mockResponse.getHits()).thenReturn(TestHelpers.createSearchHits(totalHits));
+
+            listener.onResponse(mockResponse);
+
+            return null;
+        }).when(client).search(any(), any(ActionListener.class));
+
+        LockModel lock = new LockModel(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, jobParameter.getName(), Instant.now(), 10, false);
+
+        runner.runAdJob(jobParameter, lockService, lock, Instant.now().minusSeconds(60), executionStartTime, recorder, detector);
+
+        verify(client, times(1)).execute(eq(AnomalyResultAction.INSTANCE), any(), any());
+        verify(client, times(1)).search(any(), any());
+        verify(adTaskCacheManager, times(1)).hasQueriedResultIndex(anyString());
+        verify(nodeStateManager, times(1)).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        verify(nodeStateManager, times(1)).getAnomalyDetectorJob(any(String.class), any(ActionListener.class));
+
+        ArgumentCaptor<Long> totalUpdates = ArgumentCaptor.forClass(Long.class);
+        verify(adTaskManager, times(1))
+            .updateLatestRealtimeTaskOnCoordinatingNode(any(), any(), totalUpdates.capture(), any(), any(), any());
+        assertEquals(NUM_MIN_SAMPLES, totalUpdates.getValue().longValue());
+
+        verify(adTaskCacheManager, times(1)).markResultIndexQueried(anyString());
+    }
 }

--- a/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
@@ -313,12 +313,12 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
         String newState = ADTaskState.INIT.name();
         Float newInitProgress = 0.0f;
         String newError = randomAlphaOfLength(5);
-        assertTrue(adTaskCacheManager.isRealtimeTaskChanged(detectorId1, newState, newInitProgress, newError));
+        assertTrue(adTaskCacheManager.isRealtimeTaskChangeNeeded(detectorId1, newState, newInitProgress, newError));
         // Init realtime task cache.
         adTaskCacheManager.initRealtimeTaskCache(detectorId1, 60_000);
 
         adTaskCacheManager.updateRealtimeTaskCache(detectorId1, newState, newInitProgress, newError);
-        assertFalse(adTaskCacheManager.isRealtimeTaskChanged(detectorId1, newState, newInitProgress, newError));
+        assertFalse(adTaskCacheManager.isRealtimeTaskChangeNeeded(detectorId1, newState, newInitProgress, newError));
         assertArrayEquals(new String[] { detectorId1 }, adTaskCacheManager.getDetectorIdsInRealtimeTaskCache());
 
         String detectorId2 = randomAlphaOfLength(10);
@@ -331,7 +331,7 @@ public class ADTaskCacheManagerTests extends OpenSearchTestCase {
         newState = ADTaskState.RUNNING.name();
         newInitProgress = 1.0f;
         newError = "test error";
-        assertTrue(adTaskCacheManager.isRealtimeTaskChanged(detectorId1, newState, newInitProgress, newError));
+        assertTrue(adTaskCacheManager.isRealtimeTaskChangeNeeded(detectorId1, newState, newInitProgress, newError));
         adTaskCacheManager.updateRealtimeTaskCache(detectorId1, newState, newInitProgress, newError);
         assertEquals(newInitProgress, adTaskCacheManager.getRealtimeTaskCache(detectorId1).getInitProgress());
         assertEquals(newState, adTaskCacheManager.getRealtimeTaskCache(detectorId1).getState());

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -720,7 +720,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         String error = randomAlphaOfLength(5);
         ActionListener<UpdateResponse> actionListener = mock(ActionListener.class);
         doReturn(node1).when(clusterService).localNode();
-        when(adTaskCacheManager.isRealtimeTaskChanged(anyString(), anyString(), anyFloat(), anyString())).thenReturn(true);
+        when(adTaskCacheManager.isRealtimeTaskChangeNeeded(anyString(), anyString(), anyFloat(), anyString())).thenReturn(true);
         doAnswer(invocation -> {
             ActionListener<UpdateResponse> listener = invocation.getArgument(3);
             listener.onResponse(new UpdateResponse(ShardId.fromString("[test][1]"), "1", 0L, 1L, 1L, DocWriteResponse.Result.UPDATED));

--- a/src/test/java/org/opensearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
@@ -136,15 +136,19 @@ public class ADBatchAnomalyResultTransportActionTests extends HistoricalAnalysis
     }
 
     public void testDisableADPlugin() throws IOException {
-        updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, false));
-
-        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(new DetectionDateRange(startTime, endTime));
-        RuntimeException exception = expectThrowsAnyOf(
-            ImmutableList.of(NotSerializableExceptionWrapper.class, EndRunException.class),
-            () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(10000)
-        );
-        assertTrue(exception.getMessage().contains("AD plugin is disabled"));
-        updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, true));
+        try {
+            updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, false));
+            ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(new DetectionDateRange(startTime, endTime));
+            RuntimeException exception = expectThrowsAnyOf(
+                ImmutableList.of(NotSerializableExceptionWrapper.class, EndRunException.class),
+                () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(10000)
+            );
+            assertTrue(exception.getMessage(), exception.getMessage().contains("AD plugin is disabled"));
+            updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, false));
+        } finally {
+            // guarantee reset back to default
+            updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, true));
+        }
     }
 
     public void testMultipleTasks() throws IOException, InterruptedException {


### PR DESCRIPTION
### Description
This PR fixes the discrepancy by querying the result index when the total updates is less than 32. We have done similar things in profile API so I refactored reusable code to ProfileUtil. We also cached whether we have queried the result index and won't repeatedly issue the extra query.

Testing done:
1. repeated repro steps in https://github.com/opensearch-project/anomaly-detection/issues/502 and verified the issue has been resolved.
2. added unit tests.

Signed-off-by: Kaituo Li <kaituo@amazon.com>

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/502

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
