### PR TITLE
Dynamically set bwc current version from properties version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,6 +389,7 @@ String bwcBundleVersion = "1.3.2.0"
 Boolean bwcBundleTest = (project.findProperty('customDistributionDownloadType') != null &&
         project.properties['customDistributionDownloadType'] == "bundle");
 String bwcVersion = bwcBundleTest ? bwcBundleVersion : bwcMinVersion
+String currentBundleVersion = opensearch_version.replace("-SNAPSHOT","")
 String baseName = "adBwcCluster"
 String bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
 String bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
@@ -400,7 +401,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
             testDistribution = "ARCHIVE"
             numberOfNodes = 3
             if (bwcBundleTest) {
-                versions = ["1.3.2", "2.5.0"]
+                versions = ["1.3.2", currentBundleVersion]
                 nodes.each { node ->
                     node.extraConfigFile("kirk.pem", file("src/test/resources/security/kirk.pem"))
                     node.extraConfigFile("kirk-key.pem", file("src/test/resources/security/kirk-key.pem"))


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
As currently 2.x is bumped to 2.6, we should have also increment the version for bwc tests. 
Instead, this PR is to dynamically set bwc current version from properties version so we don't have to change this version every time we do version increment. 

Will also need to backport this PR to 2.5 branch. 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/2870

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
