### PR TITLE
Revert changes to exception message

### DIFF
--- a/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
+++ b/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
@@ -307,7 +307,7 @@ public class ExecuteADResultResponseRecorder {
                 anomalyResultHandler.index(anomalyResult, detectorId, resultIndex);
             }
 
-            if (errorMessage.contains(CommonErrorMessages.NO_CHECKPOINT_ERR_MSG) && !detector.isMultiCategoryDetector()) {
+            if (errorMessage.contains(CommonErrorMessages.NO_MODEL_ERR_MSG) && !detector.isMultiCategoryDetector()) {
                 // single stream detector raises ResourceNotFoundException containing CommonErrorMessages.NO_CHECKPOINT_ERR_MSG
                 // when there is no checkpoint.
                 // Delay real time cache update by one minute so we will have trained models by then and update the state

--- a/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/CommonErrorMessages.java
@@ -131,5 +131,7 @@ public class CommonErrorMessages {
     public static final String UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG =
         "Feature has an unknown exception caught while executing the feature query: ";
     public static final String VALIDATION_FEATURE_FAILURE = "Validation failed for feature(s) of detector %s";
+    public static final String NO_MODEL_ERR_MSG = "No RCF models are available either because RCF"
+        + " models are not ready or all nodes are unresponsive or the system might have bugs.";
 
 }

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -699,7 +699,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         }
         LOG.info("Trigger cold start for {}", detector.getDetectorId());
         coldStart(detector);
-        return previousException.orElse(exp);
+        return previousException.orElse(new InternalFailure(adID, NO_MODEL_ERR_MSG));
     }
 
     private void findException(Throwable cause, String adID, AtomicReference<Exception> failure, String nodeId) {

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -103,8 +103,6 @@ import org.opensearch.transport.TransportService;
 public class AnomalyResultTransportAction extends HandledTransportAction<ActionRequest, AnomalyResultResponse> {
 
     private static final Logger LOG = LogManager.getLogger(AnomalyResultTransportAction.class);
-    static final String NO_MODEL_ERR_MSG = "No RCF models are available either because RCF"
-        + " models are not ready or all nodes are unresponsive or the system might have bugs.";
     static final String WAIT_FOR_THRESHOLD_ERR_MSG = "Exception in waiting for threshold result";
     static final String NODE_UNRESPONSIVE_ERR_MSG = "Model node is unresponsive.  Mute node";
     static final String READ_WRITE_BLOCKED = "Cannot read/write due to global block.";
@@ -699,7 +697,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         }
         LOG.info("Trigger cold start for {}", detector.getDetectorId());
         coldStart(detector);
-        return previousException.orElse(new InternalFailure(adID, NO_MODEL_ERR_MSG));
+        return previousException.orElse(new InternalFailure(adID, CommonErrorMessages.NO_MODEL_ERR_MSG));
     }
 
     private void findException(Throwable cause, String adID, AtomicReference<Exception> failure, String nodeId) {
@@ -830,7 +828,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                         );
                 } else {
                     LOG.warn(NULL_RESPONSE + " {} for {}", modelID, rcfNodeID);
-                    listener.onFailure(new InternalFailure(adID, NO_MODEL_ERR_MSG));
+                    listener.onFailure(new InternalFailure(adID, CommonErrorMessages.NO_MODEL_ERR_MSG));
                 }
             } catch (Exception ex) {
                 LOG.error(new ParameterizedMessage("Unexpected exception for [{}]", adID), ex);

--- a/src/test/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandlerTests.java
@@ -37,6 +37,7 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.ad.ExecuteADResultResponseRecorder;
 import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonName;
@@ -341,7 +342,7 @@ public class IndexAnomalyDetectorJobActionHandlerTests extends OpenSearchTestCas
             Object[] args = invocation.getArguments();
             ActionListener<AnomalyResultResponse> listener = (ActionListener<AnomalyResultResponse>) args[2];
 
-            listener.onFailure(new ResourceNotFoundException(detectorId, CommonErrorMessages.NO_CHECKPOINT_ERR_MSG));
+            listener.onFailure(new InternalFailure(detectorId, CommonErrorMessages.NO_MODEL_ERR_MSG));
 
             return null;
         }).when(client).execute(any(AnomalyResultAction.class), any(), any());


### PR DESCRIPTION
### Description
We used to log "No RCF models are available either because RCF models are not ready..." and now we log "resource_not_found_exception: No checkpoints found for model id...". This change caused an integration test failure. This PR reverts it back.

Testing done:
1. verified that the original log is back.

Signed-off-by: Kaituo Li <kaituo@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
