### PR TITLE
[Feature/extension] Moved rest client instantiation to constructor

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -62,26 +62,26 @@ public class AnomalyDetectorExtension extends BaseExtension {
     public static final String AD_BASE_DETECTORS_URI = "/detectors";
 
     @Deprecated
-    private final SDKRestClient restClient;
+    private SDKRestClient restClient;
 
     public AnomalyDetectorExtension() {
         super(EXTENSION_SETTINGS_PATH);
-        this.restClient = new SDKClient().initializeRestClient(getExtensionSettings());
     }
 
     @Override
     public List<ExtensionRestHandler> getExtensionRestHandlers() {
         return List
             .of(
-                new RestIndexAnomalyDetectorAction(extensionsRunner(), restClient),
-                new RestValidateAnomalyDetectorAction(extensionsRunner(), restClient),
-                new RestGetAnomalyDetectorAction(extensionsRunner(), restClient)
+                new RestIndexAnomalyDetectorAction(extensionsRunner(), restClient()),
+                new RestValidateAnomalyDetectorAction(extensionsRunner(), restClient()),
+                new RestGetAnomalyDetectorAction(extensionsRunner(), restClient())
             );
     }
 
     @Override
     public Collection<Object> createComponents(ExtensionsRunner runner) {
 
+        this.restClient = createRestClient();
         SDKClusterService sdkClusterService = runner.getSdkClusterService();
         Settings environmentSettings = runner.getEnvironmentSettings();
         SDKNamedXContentRegistry xContentRegistry = runner.getNamedXContentRegistry();
@@ -192,7 +192,12 @@ public class AnomalyDetectorExtension extends BaseExtension {
     }
 
     @Deprecated
-    public SDKRestClient getRestClient() {
+    public SDKRestClient createRestClient() {
+        return new SDKClient().initializeRestClient(getExtensionSettings());
+    }
+
+    @Deprecated 
+    SDKRestClient restClient() {
         return this.restClient;
     }
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -192,12 +192,14 @@ public class AnomalyDetectorExtension extends BaseExtension {
     }
 
     @Deprecated
-    public SDKRestClient createRestClient() {
-        return new SDKClient().initializeRestClient(getExtensionSettings());
+    private SDKRestClient createRestClient() {
+        @SuppressWarnings("resource")
+        SDKRestClient client = new SDKClient().initializeRestClient(getExtensionSettings());
+        return client;
     }
 
     @Deprecated 
-    SDKRestClient restClient() {
+    public SDKRestClient restClient() {
         return this.restClient;
     }
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -62,7 +62,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
     public static final String AD_BASE_DETECTORS_URI = "/detectors";
 
     @Deprecated
-    private SDKRestClient restClient;
+    private SDKRestClient sdkRestClient;
 
     public AnomalyDetectorExtension() {
         super(EXTENSION_SETTINGS_PATH);
@@ -81,7 +81,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
     @Override
     public Collection<Object> createComponents(ExtensionsRunner runner) {
 
-        this.restClient = createRestClient();
+        this.sdkRestClient = createRestClient();
         SDKClusterService sdkClusterService = runner.getSdkClusterService();
         Settings environmentSettings = runner.getEnvironmentSettings();
         SDKNamedXContentRegistry xContentRegistry = runner.getNamedXContentRegistry();
@@ -102,7 +102,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
         ADTaskCacheManager adTaskCacheManager = new ADTaskCacheManager(environmentSettings, sdkClusterService, memoryTracker);
 
         AnomalyDetectionIndices anomalyDetectionIndices = new AnomalyDetectionIndices(
-            restClient,
+            sdkRestClient,
             sdkClusterService,
             threadPool,
             environmentSettings,
@@ -113,7 +113,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
         ADTaskManager adTaskManager = new ADTaskManager(
             environmentSettings,
             sdkClusterService,
-            restClient,
+            sdkRestClient,
             xContentRegistry,
             anomalyDetectionIndices,
             null, // nodeFilter
@@ -123,7 +123,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
         );
 
         return ImmutableList
-            .of(restClient, anomalyDetectionIndices, jvmService, adCircuitBreakerService, adTaskManager, adTaskCacheManager);
+            .of(sdkRestClient, anomalyDetectionIndices, jvmService, adCircuitBreakerService, adTaskManager, adTaskCacheManager);
     }
 
     @Override
@@ -200,7 +200,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
 
     @Deprecated
     public SDKRestClient restClient() {
-        return this.restClient;
+        return this.sdkRestClient;
     }
 
     // @Override

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -198,7 +198,7 @@ public class AnomalyDetectorExtension extends BaseExtension {
         return client;
     }
 
-    @Deprecated 
+    @Deprecated
     public SDKRestClient restClient() {
         return this.restClient;
     }

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -70,12 +70,12 @@ public class AnomalyDetectorExtension extends BaseExtension {
     }
 
     @Override
-    public List<ExtensionRestHandler> getExtensionRestHandlers(ExtensionsRunner extensionsRunner) {
+    public List<ExtensionRestHandler> getExtensionRestHandlers() {
         return List
             .of(
-                new RestIndexAnomalyDetectorAction(extensionsRunner, restClient),
-                new RestValidateAnomalyDetectorAction(extensionsRunner, restClient),
-                new RestGetAnomalyDetectorAction(extensionsRunner, restClient)
+                new RestIndexAnomalyDetectorAction(extensionsRunner(), restClient),
+                new RestValidateAnomalyDetectorAction(extensionsRunner(), restClient),
+                new RestGetAnomalyDetectorAction(extensionsRunner(), restClient)
             );
     }
 

--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -66,12 +66,12 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
     private SDKClusterService clusterService;
     private ExtensionsRunner extensionsRunner;
 
-    public RestGetAnomalyDetectorAction(ExtensionsRunner extensionsRunner, AnomalyDetectorExtension anomalyDetectorExtension) {
+    public RestGetAnomalyDetectorAction(ExtensionsRunner extensionsRunner, SDKRestClient client) {
         this.extensionsRunner = extensionsRunner;
         this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
         this.settings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
-        this.client = anomalyDetectorExtension.getRestClient();
+        this.client = client;
         this.clusterService = new SDKClusterService(extensionsRunner);
     }
 

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -70,12 +70,12 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
     private SDKRestClient restClient;
     private SDKClusterService sdkClusterService;
 
-    public RestIndexAnomalyDetectorAction(ExtensionsRunner extensionsRunner, AnomalyDetectorExtension anomalyDetectorExtension) {
+    public RestIndexAnomalyDetectorAction(ExtensionsRunner extensionsRunner, SDKRestClient restClient) {
         super(extensionsRunner);
         this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
         this.environmentSettings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
-        this.restClient = anomalyDetectorExtension.getRestClient();
+        this.restClient = restClient;
         this.sdkClusterService = new SDKClusterService(extensionsRunner);
     }
 

--- a/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
@@ -76,12 +76,12 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
         .map(aspect -> aspect.getName())
         .collect(Collectors.toSet());
 
-    public RestValidateAnomalyDetectorAction(ExtensionsRunner extensionsRunner, AnomalyDetectorExtension anomalyDetectorExtension) {
+    public RestValidateAnomalyDetectorAction(ExtensionsRunner extensionsRunner, SDKRestClient restClient) {
         super(extensionsRunner);
         this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
         this.environmentSettings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
-        this.restClient = anomalyDetectorExtension.getRestClient();
+        this.restClient = restClient;
         this.sdkClusterService = new SDKClusterService(extensionsRunner);
     }
 


### PR DESCRIPTION
### Description
Moves rest client instantiation to create components, which ensures that only one instance of the SDKRestClient is being passed around

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
