### PR TITLE
[Feature/extensions] Replace constructor usages of NamedXContentRegistry with SDK wrapper

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -60,7 +60,6 @@ import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -126,7 +125,11 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 try (
                     XContentParser xContentParser = XContentType.JSON
                         .xContent()
-                        .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, getDetectorResponse.getSourceAsString())
+                        .createParser(
+                            xContentRegistry.getRegistry(),
+                            LoggingDeprecationHandler.INSTANCE,
+                            getDetectorResponse.getSourceAsString()
+                        )
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, xContentParser.nextToken(), xContentParser);
                     AnomalyDetector detector = AnomalyDetector.parse(xContentParser, detectorId);

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -65,6 +65,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -80,7 +81,7 @@ import org.opensearch.transport.TransportService;
 public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
     private final Logger logger = LogManager.getLogger(AnomalyDetectorProfileRunner.class);
     private SDKRestClient client;
-    private NamedXContentRegistry xContentRegistry;
+    private SDKNamedXContentRegistry xContentRegistry;
     private DiscoveryNodeFilterer nodeFilter;
     private final TransportService transportService;
     private final ADTaskManager adTaskManager;
@@ -88,7 +89,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
 
     public AnomalyDetectorProfileRunner(
         SDKRestClient client,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         DiscoveryNodeFilterer nodeFilter,
         long requiredSamples,
         TransportService transportService,
@@ -125,7 +126,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 try (
                     XContentParser xContentParser = XContentType.JSON
                         .xContent()
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getDetectorResponse.getSourceAsString())
+                        .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, getDetectorResponse.getSourceAsString())
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, xContentParser.nextToken(), xContentParser);
                     AnomalyDetector detector = AnomalyDetector.parse(xContentParser, detectorId);
@@ -155,7 +156,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 try (
                     XContentParser parser = XContentType.JSON
                         .xContent()
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                        .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     AnomalyDetectorJob job = AnomalyDetectorJob.parse(parser);

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -46,7 +46,6 @@ import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.cluster.routing.Preference;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -54,6 +54,7 @@ import org.opensearch.index.query.NestedQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -64,9 +65,9 @@ public class EntityProfileRunner extends AbstractProfileRunner {
     static final String EMPTY_ENTITY_ATTRIBUTES = "Empty entity attributes";
     static final String NO_ENTITY = "Cannot find entity";
     private SDKRestClient client;
-    private NamedXContentRegistry xContentRegistry;
+    private SDKNamedXContentRegistry xContentRegistry;
 
-    public EntityProfileRunner(SDKRestClient client, NamedXContentRegistry xContentRegistry, long requiredSamples) {
+    public EntityProfileRunner(SDKRestClient client, SDKNamedXContentRegistry xContentRegistry, long requiredSamples) {
         super(requiredSamples);
         this.client = client;
         this.xContentRegistry = xContentRegistry;
@@ -97,7 +98,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                 try (
                     XContentParser parser = XContentType.JSON
                         .xContent()
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                        .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId);
@@ -213,7 +214,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                 try (
                     XContentParser parser = XContentType.JSON
                         .xContent()
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                        .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     AnomalyDetectorJob job = AnomalyDetectorJob.parse(parser);

--- a/src/main/java/org/opensearch/ad/NodeStateManager.java
+++ b/src/main/java/org/opensearch/ad/NodeStateManager.java
@@ -44,7 +44,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.sdk.SDKNamedXContentRegistry;
 
@@ -145,7 +144,9 @@ public class NodeStateManager implements MaintenanceState, CleanState {
             LOG.debug("Fetched anomaly detector: {}", xc);
 
             try (
-                XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
+                XContentParser parser = XContentType.JSON
+                    .xContent()
+                    .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
             ) {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                 AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId());

--- a/src/main/java/org/opensearch/ad/NodeStateManager.java
+++ b/src/main/java/org/opensearch/ad/NodeStateManager.java
@@ -46,6 +46,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 
 /**
  * NodeStateManager is used to manage states shared by transport and ml components
@@ -57,7 +58,7 @@ public class NodeStateManager implements MaintenanceState, CleanState {
     public static final String NO_ERROR = "no_error";
     private ConcurrentHashMap<String, NodeState> states;
     private Client client;
-    private NamedXContentRegistry xContentRegistry;
+    private SDKNamedXContentRegistry xContentRegistry;
     private ClientUtil clientUtil;
     // map from detector id to the map of ES node id to the node's backpressureMuter
     private Map<String, Map<String, BackPressureRouting>> backpressureMuter;
@@ -79,7 +80,7 @@ public class NodeStateManager implements MaintenanceState, CleanState {
      */
     public NodeStateManager(
         Client client,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         Settings settings,
         ClientUtil clientUtil,
         Clock clock,
@@ -144,7 +145,7 @@ public class NodeStateManager implements MaintenanceState, CleanState {
             LOG.debug("Fetched anomaly detector: {}", xc);
 
             try (
-                XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, xc)
+                XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, xc)
             ) {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                 AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId());

--- a/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
@@ -35,7 +35,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;

--- a/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/ad/feature/CompositeRetriever.java
@@ -39,6 +39,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.AggregatorFactories;
@@ -64,7 +65,7 @@ public class CompositeRetriever extends AbstractRetriever {
     private final long dataStartEpoch;
     private final long dataEndEpoch;
     private final AnomalyDetector anomalyDetector;
-    private final NamedXContentRegistry xContent;
+    private final SDKNamedXContentRegistry xContent;
     private final Client client;
     private int totalResults;
     private int maxEntities;
@@ -78,7 +79,7 @@ public class CompositeRetriever extends AbstractRetriever {
         long dataStartEpoch,
         long dataEndEpoch,
         AnomalyDetector anomalyDetector,
-        NamedXContentRegistry xContent,
+        SDKNamedXContentRegistry xContent,
         Client client,
         long expirationEpochMs,
         Clock clock,
@@ -107,7 +108,7 @@ public class CompositeRetriever extends AbstractRetriever {
         long dataStartEpoch,
         long dataEndEpoch,
         AnomalyDetector anomalyDetector,
-        NamedXContentRegistry xContent,
+        SDKNamedXContentRegistry xContent,
         Client client,
         long expirationEpochMs,
         Settings settings,
@@ -154,7 +155,7 @@ public class CompositeRetriever extends AbstractRetriever {
             .size(pageSize);
         for (Feature feature : anomalyDetector.getFeatureAttributes()) {
             AggregatorFactories.Builder internalAgg = ParseUtils
-                .parseAggregators(feature.getAggregation().toString(), xContent, feature.getId());
+                .parseAggregators(feature.getAggregation().toString(), xContent.getRegistry(), feature.getId());
             composite.subAggregation(internalAgg.getAggregatorFactories().iterator().next());
         }
 

--- a/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
@@ -58,6 +58,7 @@ import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
@@ -88,7 +89,7 @@ public class SearchFeatureDao extends AbstractRetriever {
 
     // Dependencies
     private final SDKRestClient client;
-    private final NamedXContentRegistry xContent;
+    private final SDKNamedXContentRegistry xContent;
     private final Interpolator interpolator;
     private final ClientUtil clientUtil;
     private volatile int maxEntitiesForPreview;
@@ -100,7 +101,7 @@ public class SearchFeatureDao extends AbstractRetriever {
     // used for testing as we can mock clock
     public SearchFeatureDao(
         SDKRestClient client,
-        NamedXContentRegistry xContent,
+        SDKNamedXContentRegistry xContent,
         Interpolator interpolator,
         ClientUtil clientUtil,
         Settings settings,
@@ -145,7 +146,7 @@ public class SearchFeatureDao extends AbstractRetriever {
      */
     public SearchFeatureDao(
         SDKRestClient client,
-        NamedXContentRegistry xContent,
+        SDKNamedXContentRegistry xContent,
         Interpolator interpolator,
         ClientUtil clientUtil,
         Settings settings,
@@ -564,7 +565,7 @@ public class SearchFeatureDao extends AbstractRetriever {
         long endTime,
         ActionListener<Map<Long, Optional<double[]>>> listener
     ) throws IOException {
-        SearchSourceBuilder searchSourceBuilder = batchFeatureQuery(detector, entity, startTime, endTime, xContent);
+        SearchSourceBuilder searchSourceBuilder = batchFeatureQuery(detector, entity, startTime, endTime, xContent.getRegistry());
         logger.debug("Batch query for detector {}: {} ", detector.getDetectorId(), searchSourceBuilder);
 
         SearchRequest searchRequest = new SearchRequest(detector.getIndices().toArray(new String[0])).source(searchSourceBuilder);
@@ -943,7 +944,7 @@ public class SearchFeatureDao extends AbstractRetriever {
     private SearchRequest createFeatureSearchRequest(AnomalyDetector detector, long startTime, long endTime, Optional<String> preference) {
         // TODO: FeatureQuery field is planned to be removed and search request creation will migrate to new api.
         try {
-            SearchSourceBuilder searchSourceBuilder = ParseUtils.generateInternalFeatureQuery(detector, startTime, endTime, xContent);
+            SearchSourceBuilder searchSourceBuilder = ParseUtils.generateInternalFeatureQuery(detector, startTime, endTime, xContent.getRegistry());
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder).preference(preference.orElse(null));
         } catch (IOException e) {
             logger
@@ -957,7 +958,7 @@ public class SearchFeatureDao extends AbstractRetriever {
 
     private SearchRequest createPreviewSearchRequest(AnomalyDetector detector, List<Entry<Long, Long>> ranges) throws IOException {
         try {
-            SearchSourceBuilder searchSourceBuilder = ParseUtils.generatePreviewQuery(detector, ranges, xContent);
+            SearchSourceBuilder searchSourceBuilder = ParseUtils.generatePreviewQuery(detector, ranges, xContent.getRegistry());
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder);
         } catch (IOException e) {
             logger.warn("Failed to create feature search request for " + detector.getDetectorId() + " for preview", e);
@@ -1011,7 +1012,7 @@ public class SearchFeatureDao extends AbstractRetriever {
 
     private SearchRequest createColdStartFeatureSearchRequest(AnomalyDetector detector, List<Entry<Long, Long>> ranges, Entity entity) {
         try {
-            SearchSourceBuilder searchSourceBuilder = ParseUtils.generateEntityColdStartQuery(detector, ranges, entity, xContent);
+            SearchSourceBuilder searchSourceBuilder = ParseUtils.generateEntityColdStartQuery(detector, ranges, entity, xContent.getRegistry());
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder);
         } catch (IOException e) {
             logger

--- a/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/ad/feature/SearchFeatureDao.java
@@ -51,7 +51,6 @@ import org.opensearch.ad.util.ClientUtil;
 import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
@@ -944,7 +943,8 @@ public class SearchFeatureDao extends AbstractRetriever {
     private SearchRequest createFeatureSearchRequest(AnomalyDetector detector, long startTime, long endTime, Optional<String> preference) {
         // TODO: FeatureQuery field is planned to be removed and search request creation will migrate to new api.
         try {
-            SearchSourceBuilder searchSourceBuilder = ParseUtils.generateInternalFeatureQuery(detector, startTime, endTime, xContent.getRegistry());
+            SearchSourceBuilder searchSourceBuilder = ParseUtils
+                .generateInternalFeatureQuery(detector, startTime, endTime, xContent.getRegistry());
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder).preference(preference.orElse(null));
         } catch (IOException e) {
             logger
@@ -1012,7 +1012,8 @@ public class SearchFeatureDao extends AbstractRetriever {
 
     private SearchRequest createColdStartFeatureSearchRequest(AnomalyDetector detector, List<Entry<Long, Long>> ranges, Entity entity) {
         try {
-            SearchSourceBuilder searchSourceBuilder = ParseUtils.generateEntityColdStartQuery(detector, ranges, entity, xContent.getRegistry());
+            SearchSourceBuilder searchSourceBuilder = ParseUtils
+                .generateEntityColdStartQuery(detector, ranges, entity, xContent.getRegistry());
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder);
         } catch (IOException e) {
             logger

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
@@ -43,6 +43,7 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.threadpool.ThreadPool;
 
 public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultBulkRequest, ADResultBulkResponse> {
@@ -50,7 +51,7 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
     public static final String WORKER_NAME = "result-write";
 
     private final MultiEntityResultHandler resultHandler;
-    private NamedXContentRegistry xContentRegistry;
+    private SDKNamedXContentRegistry xContentRegistry;
 
     public ResultWriteWorker(
         long heapSizeInBytes,
@@ -68,7 +69,7 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
         int maintenanceFreqConstant,
         Duration executionTtl,
         MultiEntityResultHandler resultHandler,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         NodeStateManager stateManager,
         Duration stateTtl
     ) {
@@ -203,7 +204,7 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
             XContentType indexContentType = indexRequest.getContentType();
             try (
                 XContentParser xContentParser = XContentHelper
-                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, indexSource, indexContentType)
+                    .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, indexSource, indexContentType)
             ) {
                 // the first character is null. Without skipping it, we get
                 // org.opensearch.common.ParsingException: Failed to parse object: expecting token of type [START_OBJECT] but found

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
@@ -41,7 +41,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.threadpool.ThreadPool;

--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -37,7 +37,6 @@ import org.opensearch.ad.transport.GetAnomalyDetectorTransportAction;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;

--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -48,6 +48,7 @@ import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.RouteHandler;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableList;
@@ -59,7 +60,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
 
     private static final String GET_ANOMALY_DETECTOR_ACTION = "get_anomaly_detector";
     private static final Logger logger = LogManager.getLogger(RestGetAnomalyDetectorAction.class);
-    private NamedXContentRegistry namedXContentRegistry;
+    private SDKNamedXContentRegistry namedXContentRegistry;
     private Settings settings;
     private TransportService transportService;
     private SDKRestClient client;
@@ -68,7 +69,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
 
     public RestGetAnomalyDetectorAction(ExtensionsRunner extensionsRunner, AnomalyDetectorExtension anomalyDetectorExtension) {
         this.extensionsRunner = extensionsRunner;
-        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
+        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
         this.settings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
         this.client = anomalyDetectorExtension.getRestClient();
@@ -133,8 +134,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
             clusterService,
             client,
             settings,
-            extensionsRunner.getNamedXContentRegistry().getRegistry(), // TODO:
-                                                                       // https://github.com/opensearch-project/opensearch-sdk-java/issues/447
+            extensionsRunner.getNamedXContentRegistry(),
             null // ADTaskManager adTaskManager
         );
 
@@ -226,7 +226,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
              *      }]
              * }
              */
-            Optional<Entity> entity = Entity.fromJsonObject(request.contentParser(namedXContentRegistry));
+            Optional<Entity> entity = Entity.fromJsonObject(request.contentParser(namedXContentRegistry.getRegistry()));
             if (entity.isPresent()) {
                 return entity.get();
             }

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -53,6 +53,7 @@ import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.RouteHandler;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableList;
@@ -64,7 +65,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
 
     private static final String INDEX_ANOMALY_DETECTOR_ACTION = "index_anomaly_detector_action";
     private final Logger logger = LogManager.getLogger(RestIndexAnomalyDetectorAction.class);
-    private NamedXContentRegistry namedXContentRegistry;
+    private SDKNamedXContentRegistry namedXContentRegistry;
     private Settings environmentSettings;
     private TransportService transportService;
     private SDKRestClient restClient;
@@ -72,7 +73,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
 
     public RestIndexAnomalyDetectorAction(ExtensionsRunner extensionsRunner, AnomalyDetectorExtension anomalyDetectorExtension) {
         super(extensionsRunner);
-        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
+        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
         this.environmentSettings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
         this.restClient = anomalyDetectorExtension.getRestClient();
@@ -116,7 +117,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
         String detectorId = request.param(DETECTOR_ID, AnomalyDetector.NO_ID);
         logger.info("AnomalyDetector {} action for detectorId {}", request.method(), detectorId);
 
-        XContentParser parser = request.contentParser(this.namedXContentRegistry);
+        XContentParser parser = request.contentParser(this.namedXContentRegistry.getRegistry());
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         // TODO: check detection interval < modelTTL
         AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId, null, detectionInterval, detectionWindowDelay);

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -41,7 +41,6 @@ import org.opensearch.ad.transport.IndexAnomalyDetectorResponse;
 import org.opensearch.ad.transport.IndexAnomalyDetectorTransportAction;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.extensions.rest.ExtensionRestRequest;

--- a/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
@@ -55,6 +55,7 @@ import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.RouteHandler;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableList;
@@ -64,7 +65,7 @@ import com.google.common.collect.ImmutableList;
  */
 public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAction {
     private static final String VALIDATE_ANOMALY_DETECTOR_ACTION = "validate_anomaly_detector_action";
-    private NamedXContentRegistry namedXContentRegistry;
+    private SDKNamedXContentRegistry namedXContentRegistry;
     private Settings environmentSettings;
     private TransportService transportService;
     private SDKRestClient restClient;
@@ -78,7 +79,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
 
     public RestValidateAnomalyDetectorAction(ExtensionsRunner extensionsRunner, AnomalyDetectorExtension anomalyDetectorExtension) {
         super(extensionsRunner);
-        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
+        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
         this.environmentSettings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
         this.restClient = anomalyDetectorExtension.getRestClient();
@@ -134,7 +135,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
         if (!EnabledSetting.isADPluginEnabled()) {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
         }
-        XContentParser parser = request.contentParser(this.namedXContentRegistry);
+        XContentParser parser = request.contentParser(this.namedXContentRegistry.getRegistry());
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         String typesStr = request.param(TYPE);
 

--- a/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
@@ -44,7 +44,6 @@ import org.opensearch.ad.transport.ValidateAnomalyDetectorResponse;
 import org.opensearch.ad.transport.ValidateAnomalyDetectorTransportAction;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.extensions.rest.ExtensionRestRequest;

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -71,7 +71,6 @@ import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.client.indices.CreateIndexResponse;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -430,7 +429,10 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, RestStatus.NOT_FOUND));
             return;
         }
-        try (XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getSourceAsBytesRef())) {
+        try (
+            XContentParser parser = RestHandlerUtils
+                .createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getSourceAsBytesRef())
+        ) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             AnomalyDetector existingDetector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
             // If detector category field changed, frontend may not be able to render AD result for different detector types correctly.

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -20,7 +20,6 @@ import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.ad.transport.IndexAnomalyDetectorResponse;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;

--- a/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -24,6 +24,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.transport.TransportService;
 
 /**
@@ -72,7 +73,7 @@ public class IndexAnomalyDetectorActionHandler extends AbstractAnomalyDetectorAc
         Integer maxMultiEntityAnomalyDetectors,
         Integer maxAnomalyFeatures,
         RestRequest.Method method,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         UserIdentity user,
         ADTaskManager adTaskManager,
         SearchFeatureDao searchFeatureDao

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -50,7 +50,6 @@ import org.opensearch.ad.transport.ValidateAnomalyDetectorResponse;
 import org.opensearch.ad.util.MultiResponsesDelegateActionListener;
 import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -58,6 +58,7 @@ import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.Aggregations;
@@ -92,7 +93,7 @@ public class ModelValidationActionHandler {
     protected final TimeValue requestTimeout;
     protected final AnomalyDetectorActionHandler handler = new AnomalyDetectorActionHandler();
     protected final SDKRestClient client;
-    protected final NamedXContentRegistry xContentRegistry;
+    protected final SDKNamedXContentRegistry xContentRegistry;
     protected final ActionListener<ValidateAnomalyDetectorResponse> listener;
     protected final SearchFeatureDao searchFeatureDao;
     protected final Clock clock;
@@ -117,7 +118,7 @@ public class ModelValidationActionHandler {
         ActionListener<ValidateAnomalyDetectorResponse> listener,
         AnomalyDetector anomalyDetector,
         TimeValue requestTimeout,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         SearchFeatureDao searchFeatureDao,
         String validationType,
         Clock clock
@@ -688,7 +689,7 @@ public class ModelValidationActionHandler {
                 (IntervalTimeConfiguration) anomalyDetector.getDetectionInterval()
             );
             BoolQueryBuilder query = QueryBuilders.boolQuery().filter(anomalyDetector.getFilterQuery());
-            List<String> featureFields = ParseUtils.getFieldNamesForFeature(feature, xContentRegistry);
+            List<String> featureFields = ParseUtils.getFieldNamesForFeature(feature, xContentRegistry.getRegistry());
             for (String featureField : featureFields) {
                 query.filter(QueryBuilders.existsQuery(featureField));
             }

--- a/src/main/java/org/opensearch/ad/rest/handler/ValidateAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ValidateAnomalyDetectorActionHandler.java
@@ -20,7 +20,6 @@ import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.transport.ValidateAnomalyDetectorResponse;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;

--- a/src/main/java/org/opensearch/ad/rest/handler/ValidateAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ValidateAnomalyDetectorActionHandler.java
@@ -24,6 +24,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 
 /**
  * Anomaly detector REST action handler to process POST request.
@@ -61,7 +62,7 @@ public class ValidateAnomalyDetectorActionHandler extends AbstractAnomalyDetecto
         Integer maxMultiEntityAnomalyDetectors,
         Integer maxAnomalyFeatures,
         RestRequest.Method method,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         UserIdentity user,
         SearchFeatureDao searchFeatureDao,
         String validationType,

--- a/src/main/java/org/opensearch/ad/transport/ADJobParameterTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADJobParameterTransportAction.java
@@ -12,7 +12,6 @@ import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.extensions.action.ExtensionActionRequest;
 import org.opensearch.extensions.action.ExtensionActionResponse;
@@ -52,7 +51,12 @@ public class ADJobParameterTransportAction extends HandledTransportAction<Extens
         try {
             jobParameterRequest = new JobParameterRequest(request.getRequestBytes());
             XContentParser parser = XContentHelper
-                .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, jobParameterRequest.getJobSource(), XContentType.JSON);
+                .createParser(
+                    xContentRegistry.getRegistry(),
+                    LoggingDeprecationHandler.INSTANCE,
+                    jobParameterRequest.getJobSource(),
+                    XContentType.JSON
+                );
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             ScheduledJobParameter scheduledJobParameter = AnomalyDetectorJob.parse(parser);
             JobParameterResponse jobParameterResponse = new JobParameterResponse(new ExtensionJobParameter(scheduledJobParameter));

--- a/src/main/java/org/opensearch/ad/transport/ADJobParameterTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADJobParameterTransportAction.java
@@ -21,6 +21,7 @@ import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
 import org.opensearch.jobscheduler.transport.request.JobParameterRequest;
 import org.opensearch.jobscheduler.transport.response.ExtensionJobActionResponse;
 import org.opensearch.jobscheduler.transport.response.JobParameterResponse;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -31,12 +32,12 @@ public class ADJobParameterTransportAction extends HandledTransportAction<Extens
 
     private static final Logger LOG = LogManager.getLogger(ADJobParameterTransportAction.class);
 
-    private final NamedXContentRegistry xContentRegistry;
+    private final SDKNamedXContentRegistry xContentRegistry;
 
     protected ADJobParameterTransportAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        NamedXContentRegistry xContentRegistry
+        SDKNamedXContentRegistry xContentRegistry
     ) {
         super(ADJobParameterAction.NAME, transportService, actionFilters, ExtensionActionRequest::new);
         this.xContentRegistry = xContentRegistry;
@@ -51,7 +52,7 @@ public class ADJobParameterTransportAction extends HandledTransportAction<Extens
         try {
             jobParameterRequest = new JobParameterRequest(request.getRequestBytes());
             XContentParser parser = XContentHelper
-                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, jobParameterRequest.getJobSource(), XContentType.JSON);
+                .createParser(xContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, jobParameterRequest.getJobSource(), XContentType.JSON);
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             ScheduledJobParameter scheduledJobParameter = AnomalyDetectorJob.parse(parser);
             JobParameterResponse jobParameterResponse = new JobParameterResponse(new ExtensionJobParameter(scheduledJobParameter));

--- a/src/main/java/org/opensearch/ad/transport/ADJobRunnerTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADJobRunnerTransportAction.java
@@ -20,7 +20,6 @@ import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.util.RestHandlerUtils;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.extensions.action.ExtensionActionRequest;
 import org.opensearch.extensions.action.ExtensionActionResponse;
@@ -126,7 +125,11 @@ public class ADJobRunnerTransportAction extends HandledTransportAction<Extension
                     try {
                         XContentParser parser = XContentType.JSON
                             .xContent()
-                            .createParser(namedXContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, response.getSourceAsString());
+                            .createParser(
+                                namedXContentRegistry.getRegistry(),
+                                LoggingDeprecationHandler.INSTANCE,
+                                response.getSourceAsString()
+                            );
                         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         listener.onResponse(AnomalyDetectorJob.parse(parser));
                     } catch (IOException e) {

--- a/src/main/java/org/opensearch/ad/transport/ADJobRunnerTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADJobRunnerTransportAction.java
@@ -30,6 +30,7 @@ import org.opensearch.jobscheduler.transport.response.ExtensionJobActionResponse
 import org.opensearch.jobscheduler.transport.response.JobRunnerResponse;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -44,7 +45,7 @@ public class ADJobRunnerTransportAction extends HandledTransportAction<Extension
 
     private AnomalyDetectorJob scheduledJobParameter;
 
-    private final NamedXContentRegistry namedXContentRegistry;
+    private final SDKNamedXContentRegistry namedXContentRegistry;
 
     protected ADJobRunnerTransportAction(
         TransportService transportService,
@@ -54,7 +55,7 @@ public class ADJobRunnerTransportAction extends HandledTransportAction<Extension
     ) {
         super(ADJobRunnerAction.NAME, transportService, actionFilters, ExtensionActionRequest::new);
         this.client = client;
-        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
+        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
     }
 
     @Override
@@ -125,7 +126,7 @@ public class ADJobRunnerTransportAction extends HandledTransportAction<Extension
                     try {
                         XContentParser parser = XContentType.JSON
                             .xContent()
-                            .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, response.getSourceAsString());
+                            .createParser(namedXContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, response.getSourceAsString());
                         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                         listener.onResponse(AnomalyDetectorJob.parse(parser));
                     } catch (IOException e) {

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -86,7 +86,6 @@ import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.NetworkExceptionHelper;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.rest.RestStatus;

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -90,6 +90,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.ActionNotFoundTransportException;
@@ -132,7 +133,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     // detector id to this field when start to run realtime detection and remove detector
     // id once realtime detection done.
     private final Set<String> hcDetectors;
-    private NamedXContentRegistry xContentRegistry;
+    private SDKNamedXContentRegistry xContentRegistry;
     private Settings settings;
     // within an interval, how many percents are used to process requests.
     // 1.0 means we use all of the detection interval to process requests.
@@ -156,7 +157,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         ADCircuitBreakerService adCircuitBreakerService,
         ADStats adStats,
         ThreadPool threadPool,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         ADTaskManager adTaskManager
     ) {
         super(AnomalyResultAction.NAME, transportService, actionFilters, AnomalyResultRequest::new);

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -62,7 +62,6 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.Strings;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
@@ -314,7 +313,10 @@ public class GetAnomalyDetectorTransportAction {
                         if (!response.getResponse().isSourceEmpty()) {
                             try (
                                 XContentParser parser = RestHandlerUtils
-                                    .createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getResponse().getSourceAsBytesRef())
+                                    .createXContentParserFromRegistry(
+                                        xContentRegistry.getRegistry(),
+                                        response.getResponse().getSourceAsBytesRef()
+                                    )
                             ) {
                                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                                 detector = parser.namedObject(AnomalyDetector.class, AnomalyDetector.PARSE_FIELD_NAME, null);
@@ -332,7 +334,10 @@ public class GetAnomalyDetectorTransportAction {
                             && !response.getResponse().isSourceEmpty()) {
                             try (
                                 XContentParser parser = RestHandlerUtils
-                                    .createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getResponse().getSourceAsBytesRef())
+                                    .createXContentParserFromRegistry(
+                                        xContentRegistry.getRegistry(),
+                                        response.getResponse().getSourceAsBytesRef()
+                                    )
                             ) {
                                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                                 adJob = AnomalyDetectorJob.parse(parser);

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -67,6 +67,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -86,7 +87,7 @@ public class GetAnomalyDetectorTransportAction {
     private final Set<String> allEntityProfileTypeStrs;
     private final Set<EntityProfileName> allEntityProfileTypes;
     private final Set<EntityProfileName> defaultEntityProfileTypes;
-    private final NamedXContentRegistry xContentRegistry;
+    private final SDKNamedXContentRegistry xContentRegistry;
     private final DiscoveryNodeFilterer nodeFilter;
     private final TransportService transportService;
     private volatile Boolean filterByEnabled;
@@ -100,7 +101,7 @@ public class GetAnomalyDetectorTransportAction {
         SDKClusterService clusterService,
         SDKRestClient client,
         Settings settings,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         ADTaskManager adTaskManager
     ) {
         // super(GetAnomalyDetectorAction.NAME, transportService, actionFilters, GetAnomalyDetectorRequest::new);
@@ -141,7 +142,7 @@ public class GetAnomalyDetectorTransportAction {
                 (anomalyDetector) -> getExecute(request, listener),
                 client,
                 clusterService,
-                xContentRegistry
+                xContentRegistry.getRegistry()
             );
         } catch (Exception e) {
             LOG.error(e);
@@ -313,7 +314,7 @@ public class GetAnomalyDetectorTransportAction {
                         if (!response.getResponse().isSourceEmpty()) {
                             try (
                                 XContentParser parser = RestHandlerUtils
-                                    .createXContentParserFromRegistry(xContentRegistry, response.getResponse().getSourceAsBytesRef())
+                                    .createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getResponse().getSourceAsBytesRef())
                             ) {
                                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                                 detector = parser.namedObject(AnomalyDetector.class, AnomalyDetector.PARSE_FIELD_NAME, null);
@@ -331,7 +332,7 @@ public class GetAnomalyDetectorTransportAction {
                             && !response.getResponse().isSourceEmpty()) {
                             try (
                                 XContentParser parser = RestHandlerUtils
-                                    .createXContentParserFromRegistry(xContentRegistry, response.getResponse().getSourceAsBytesRef())
+                                    .createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getResponse().getSourceAsBytesRef())
                             ) {
                                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                                 adJob = AnomalyDetectorJob.parse(parser);

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -44,6 +44,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -55,7 +56,7 @@ public class IndexAnomalyDetectorTransportAction {
     private final TransportService transportService;
     private final AnomalyDetectionIndices anomalyDetectionIndices;
     private final SDKClusterService clusterService;
-    private final NamedXContentRegistry xContentRegistry;
+    private final SDKNamedXContentRegistry xContentRegistry;
     private final ADTaskManager adTaskManager;
     private volatile Boolean filterByEnabled;
     private final SearchFeatureDao searchFeatureDao;
@@ -68,7 +69,7 @@ public class IndexAnomalyDetectorTransportAction {
         SDKClusterService sdkClusterService,
         Settings settings,
         AnomalyDetectionIndices anomalyDetectionIndices,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry namedXContentRegistry,
         ADTaskManager adTaskManager,
         SearchFeatureDao searchFeatureDao
     ) {
@@ -77,7 +78,7 @@ public class IndexAnomalyDetectorTransportAction {
         this.transportService = transportService;
         this.clusterService = sdkClusterService;
         this.anomalyDetectionIndices = anomalyDetectionIndices;
-        this.xContentRegistry = xContentRegistry;
+        this.xContentRegistry = namedXContentRegistry;
         this.adTaskManager = adTaskManager;
         this.searchFeatureDao = searchFeatureDao;
         filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
@@ -121,7 +122,7 @@ public class IndexAnomalyDetectorTransportAction {
                 boolean filterByBackendRole = requestedUser == null ? false : filterByEnabled;
                 // Update detector request, check if user has permissions to update the detector
                 // Get detector and verify backend roles
-                getDetector(requestedUser, detectorId, listener, function, client, clusterService, xContentRegistry, filterByBackendRole);
+                getDetector(requestedUser, detectorId, listener, function, client, clusterService, xContentRegistry.getRegistry(), filterByBackendRole);
             } else {
                 // Create Detector. No need to get current detector.
                 function.accept(null);

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -39,7 +39,6 @@ import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
@@ -122,7 +121,16 @@ public class IndexAnomalyDetectorTransportAction {
                 boolean filterByBackendRole = requestedUser == null ? false : filterByEnabled;
                 // Update detector request, check if user has permissions to update the detector
                 // Get detector and verify backend roles
-                getDetector(requestedUser, detectorId, listener, function, client, clusterService, xContentRegistry.getRegistry(), filterByBackendRole);
+                getDetector(
+                    requestedUser,
+                    detectorId,
+                    listener,
+                    function,
+                    client,
+                    clusterService,
+                    xContentRegistry.getRegistry(),
+                    filterByBackendRole
+                );
             } else {
                 // Create Detector. No need to get current detector.
                 function.accept(null);

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -50,7 +50,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.SDKNamedXContentRegistry;

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -53,6 +53,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -62,7 +63,7 @@ public class PreviewAnomalyDetectorTransportAction extends
     private final AnomalyDetectorRunner anomalyDetectorRunner;
     private final ClusterService clusterService;
     private final Client client;
-    private final NamedXContentRegistry xContentRegistry;
+    private final SDKNamedXContentRegistry xContentRegistry;
     private volatile Integer maxAnomalyFeatures;
     private volatile Boolean filterByEnabled;
     private final ADCircuitBreakerService adCircuitBreakerService;
@@ -76,7 +77,7 @@ public class PreviewAnomalyDetectorTransportAction extends
         ActionFilters actionFilters,
         Client client,
         AnomalyDetectorRunner anomalyDetectorRunner,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry xContentRegistry,
         ADCircuitBreakerService adCircuitBreakerService
     ) {
         super(PreviewAnomalyDetectorAction.NAME, transportService, actionFilters, PreviewAnomalyDetectorRequest::new);
@@ -113,7 +114,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                 // TODO: Switch these to SDKRestClient and SDKClusterService when implementing this
                 null, // client,
                 null, // clusterService,
-                xContentRegistry
+                xContentRegistry.getRegistry()
             );
         } catch (Exception e) {
             logger.error(e);
@@ -224,7 +225,7 @@ public class PreviewAnomalyDetectorTransportAction extends
 
                 try {
                     XContentParser parser = RestHandlerUtils
-                        .createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef());
+                        .createXContentParserFromRegistry(xContentRegistry.getRegistry(), response.getSourceAsBytesRef());
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -41,7 +41,6 @@ import org.opensearch.ad.rest.handler.ValidateAnomalyDetectorActionHandler;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -47,6 +47,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -57,7 +58,7 @@ public class ValidateAnomalyDetectorTransportAction {
 
     private final SDKRestClient client;
     private final SDKClusterService clusterService;
-    private final NamedXContentRegistry xContentRegistry;
+    private final SDKNamedXContentRegistry xContentRegistry;
     private final AnomalyDetectionIndices anomalyDetectionIndices;
     private final SearchFeatureDao searchFeatureDao;
     private volatile Boolean filterByEnabled;
@@ -67,7 +68,7 @@ public class ValidateAnomalyDetectorTransportAction {
     public ValidateAnomalyDetectorTransportAction(
         SDKRestClient client,
         SDKClusterService clusterService,
-        NamedXContentRegistry xContentRegistry,
+        SDKNamedXContentRegistry namedXContentRegistry,
         Settings settings,
         AnomalyDetectionIndices anomalyDetectionIndices,
         ActionFilters actionFilters,
@@ -77,7 +78,7 @@ public class ValidateAnomalyDetectorTransportAction {
         // super(ValidateAnomalyDetectorAction.NAME, transportService, actionFilters, ValidateAnomalyDetectorRequest::new);
         this.client = client;
         this.clusterService = clusterService;
-        this.xContentRegistry = xContentRegistry;
+        this.xContentRegistry = namedXContentRegistry;
         this.anomalyDetectionIndices = anomalyDetectionIndices;
         this.filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
         try {

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -61,6 +61,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -94,6 +95,8 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
     private RestRequest.Method method;
     private ADTaskManager adTaskManager;
     private SearchFeatureDao searchFeatureDao;
+
+    private SDKNamedXContentRegistry mockSdkXContentRegistry;
 
     @BeforeClass
     public static void beforeClass() {
@@ -145,6 +148,9 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
 
         searchFeatureDao = mock(SearchFeatureDao.class);
 
+        this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
         handler = new IndexAnomalyDetectorActionHandler(
             clusterService,
             clientMock,
@@ -161,7 +167,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -209,7 +215,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -284,7 +290,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -369,7 +375,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -466,7 +472,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             RestRequest.Method.PUT,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -570,7 +576,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -658,7 +664,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             RestRequest.Method.PUT,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao
@@ -740,7 +746,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             RestRequest.Method.PUT,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             adTaskManager,
             searchFeatureDao

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
@@ -42,6 +42,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -68,6 +69,8 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
     protected ADTaskManager adTaskManager;
     protected SearchFeatureDao searchFeatureDao;
     protected Clock clock;
+
+    private SDKNamedXContentRegistry mockSdkXContentRegistry;
 
     @Mock
     private SDKRestClient clientMock;
@@ -107,6 +110,9 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
         method = RestRequest.Method.POST;
         adTaskManager = mock(ADTaskManager.class);
         searchFeatureDao = mock(SearchFeatureDao.class);
+
+        this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
     }
 
     @SuppressWarnings("unchecked")
@@ -139,7 +145,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             searchFeatureDao,
             ValidationAspect.DETECTOR.getName(),
@@ -191,7 +197,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractADTest {
             maxMultiEntityAnomalyDetectors,
             maxAnomalyFeatures,
             method,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             null,
             searchFeatureDao,
             "",

--- a/src/test/java/org/opensearch/ad/AbstractProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AbstractProfileRunnerTests.java
@@ -41,6 +41,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.transport.TransportService;
 
 public class AbstractProfileRunnerTests extends AbstractADTest {
@@ -164,7 +165,18 @@ public class AbstractProfileRunnerTests extends AbstractADTest {
             function.accept(Optional.of(TestHelpers.randomAdTask()));
             return null;
         }).when(adTaskManager).getAndExecuteOnLatestDetectorLevelTask(any(), any(), any(), any(), anyBoolean(), any());
-        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, transportService, adTaskManager);
+
+        SDKNamedXContentRegistry mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
+        runner = new AnomalyDetectorProfileRunner(
+            client,
+            mockSdkXContentRegistry,
+            nodeFilter,
+            requiredSamples,
+            transportService,
+            adTaskManager
+        );
 
         detectorIntervalMin = 3;
         detectorGetReponse = mock(GetResponse.class);

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -14,6 +14,7 @@ package org.opensearch.ad;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
@@ -42,6 +43,7 @@ import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.DetectorState;
 import org.opensearch.ad.model.InitProgressProfile;
 import org.opensearch.ad.model.IntervalTimeConfiguration;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 
 // @anomaly-detection.create-detector Commented this code until we have support of Job Scheduler for extensibility
 public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTests {
@@ -602,9 +604,11 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
     // }
 
     public void testInvalidRequiredSamples() {
+        SDKNamedXContentRegistry mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, 0, transportService, adTaskManager)
+            () -> new AnomalyDetectorProfileRunner(client, mockSdkXContentRegistry, nodeFilter, 0, transportService, adTaskManager)
         );
     }
 

--- a/src/test/java/org/opensearch/ad/EntityProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/EntityProfileRunnerTests.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.opensearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 
@@ -42,6 +43,7 @@ import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
 import org.opensearch.ad.model.EntityState;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -100,7 +102,9 @@ public class EntityProfileRunnerTests extends AbstractADTest {
         requiredSamples = 128;
         client = mock(SDKRestClient.class);
 
-        runner = new EntityProfileRunner(client, xContentRegistry(), requiredSamples);
+        SDKNamedXContentRegistry mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+        runner = new EntityProfileRunner(client, mockSdkXContentRegistry, requiredSamples);
 
         categoryField = "a";
         detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(categoryField));

--- a/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
+++ b/src/test/java/org/opensearch/ad/NodeStateManagerTests.java
@@ -57,6 +57,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.SearchModule;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
@@ -85,6 +86,12 @@ public class NodeStateManagerTests extends AbstractADTest {
     protected NamedXContentRegistry xContentRegistry() {
         SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
         return new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    private SDKNamedXContentRegistry sdkXContentRegistry() {
+        SDKNamedXContentRegistry sdkRegistry = SDKNamedXContentRegistry.EMPTY;
+        sdkRegistry.setRegistry(xContentRegistry());
+        return sdkRegistry;
     }
 
     @BeforeClass
@@ -126,7 +133,7 @@ public class NodeStateManagerTests extends AbstractADTest {
         );
 
         clusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
-        stateManager = new NodeStateManager(client, xContentRegistry(), settings, clientUtil, clock, duration, clusterService);
+        stateManager = new NodeStateManager(client, sdkXContentRegistry(), settings, clientUtil, clock, duration, clusterService);
 
         checkpointResponse = mock(GetResponse.class);
         // jobToCheck = TestHelpers.randomAnomalyDetectorJob(true, Instant.ofEpochMilli(1602401500000L), null);
@@ -235,7 +242,7 @@ public class NodeStateManagerTests extends AbstractADTest {
     public void testHasRunningQuery() throws IOException {
         stateManager = new NodeStateManager(
             client,
-            xContentRegistry(),
+            sdkXContentRegistry(),
             settings,
             new ClientUtil(settings, client, throttler),
             clock,

--- a/src/test/java/org/opensearch/ad/feature/NoPowermockSearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/ad/feature/NoPowermockSearchFeatureDaoTests.java
@@ -69,6 +69,7 @@ import org.opensearch.common.util.MockBigArrays;
 import org.opensearch.common.util.MockPageCacheRecycler;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -116,6 +117,8 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractADTest {
     private String detectorId;
     private Map<String, Object> attrs1, attrs2;
 
+    private SDKNamedXContentRegistry mockSdkXContentRegistry;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -151,11 +154,14 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractADTest {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         clock = mock(Clock.class);
 
+        this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
         searchFeatureDao = new SearchFeatureDao(
             // FIXME: Replace with SDK equivalents when re-enabling tests
             // https://github.com/opensearch-project/opensearch-sdk-java/issues/288
             null, // client,
-            xContentRegistry(), // Important. Without this, ParseUtils cannot parse anything
+            mockSdkXContentRegistry, // Important. Without this, ParseUtils cannot parse anything
             interpolator,
             clientUtil,
             settings,
@@ -348,7 +354,7 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractADTest {
             // FIXME: Replace with SDK equivalents when re-enabling tests
             // https://github.com/opensearch-project/opensearch-sdk-java/issues/288
             null, // client,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             interpolator,
             clientUtil,
             settings,
@@ -398,7 +404,7 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractADTest {
             // FIXME: Replace with SDK equivalents when re-enabling tests
             // https://github.com/opensearch-project/opensearch-sdk-java/issues/288
             null, // client,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             interpolator,
             clientUtil,
             settings,

--- a/src/test/java/org/opensearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/ad/feature/SearchFeatureDaoTests.java
@@ -88,12 +88,12 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.script.ScriptService;
 import org.opensearch.script.TemplateScript;
 import org.opensearch.script.TemplateScript.Factory;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -136,7 +136,7 @@ public class SearchFeatureDaoTests {
     @Mock
     private ScriptService scriptService;
     @Mock
-    private NamedXContentRegistry xContent;
+    private SDKNamedXContentRegistry xContent;
     @Mock
     private ClientUtil clientUtil;
 
@@ -233,7 +233,7 @@ public class SearchFeatureDaoTests {
         when(detector.getCategoryField()).thenReturn(Collections.singletonList("a"));
 
         searchSourceBuilder = SearchSourceBuilder
-            .fromXContent(XContentType.JSON.xContent().createParser(xContent, LoggingDeprecationHandler.INSTANCE, "{}"));
+            .fromXContent(XContentType.JSON.xContent().createParser(xContent.getRegistry(), LoggingDeprecationHandler.INSTANCE, "{}"));
         searchRequest = new SearchRequest(detector.getIndices().toArray(new String[0]));
         aggsMap = new HashMap<>();
 
@@ -391,7 +391,8 @@ public class SearchFeatureDaoTests {
         long end = 200L;
 
         // pre-conditions
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
+        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent.getRegistry())))
+            .thenReturn(searchSourceBuilder);
         when(searchResponse.getAggregations()).thenReturn(new Aggregations(aggs));
         when(detector.getEnabledFeatureIds()).thenReturn(featureIds);
 
@@ -438,7 +439,8 @@ public class SearchFeatureDaoTests {
 
         long start = 100L;
         long end = 200L;
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
+        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent.getRegistry())))
+            .thenReturn(searchSourceBuilder);
         when(searchResponse.getAggregations()).thenReturn(new Aggregations(aggs));
         when(detector.getEnabledFeatureIds()).thenReturn(featureIds);
         doAnswer(invocation -> {
@@ -462,7 +464,8 @@ public class SearchFeatureDaoTests {
 
         long start = 100L;
         long end = 200L;
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
+        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent.getRegistry())))
+            .thenReturn(searchSourceBuilder);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onFailure(new RuntimeException());
@@ -481,7 +484,8 @@ public class SearchFeatureDaoTests {
 
         long start = 100L;
         long end = 200L;
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
+        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent.getRegistry())))
+            .thenReturn(searchSourceBuilder);
         when(detector.getEnabledFeatureIds()).thenReturn(null);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
@@ -501,7 +505,8 @@ public class SearchFeatureDaoTests {
         long end = 200L;
 
         // pre-conditions
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
+        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent.getRegistry())))
+            .thenReturn(searchSourceBuilder);
         when(searchResponse.getAggregations()).thenReturn(null);
 
         // test
@@ -517,7 +522,8 @@ public class SearchFeatureDaoTests {
         long end = 200L;
 
         // pre-conditions
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
+        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent.getRegistry())))
+            .thenReturn(searchSourceBuilder);
         when(searchResponse.getHits()).thenReturn(new SearchHits(new SearchHit[0], new TotalHits(0L, TotalHits.Relation.EQUAL_TO), 1f));
 
         List<Aggregation> aggList = new ArrayList<>(1);

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -78,6 +78,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -183,9 +184,12 @@ public class EntityColdStarterTests extends AbstractADTest {
 
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
 
+        SDKNamedXContentRegistry mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
         stateManager = new NodeStateManager(
             client,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             settings,
             clientUtil,
             clock,

--- a/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
@@ -49,6 +49,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.threadpool.ThreadPool;
 
 public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
@@ -82,6 +83,8 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
         setUpADThreadPool(threadPool);
 
         resultHandler = mock(MultiEntityResultHandler.class);
+        SDKNamedXContentRegistry mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
 
         resultWriteQueue = new ResultWriteWorker(
             Integer.MAX_VALUE,
@@ -99,7 +102,7 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
             AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
             AnomalyDetectorSettings.QUEUE_MAINTENANCE,
             resultHandler,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             nodeStateManager,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE
         );

--- a/src/test/java/org/opensearch/ad/transport/ADJobParameterTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADJobParameterTransportActionTests.java
@@ -24,6 +24,7 @@ import org.opensearch.jobscheduler.spi.JobDocVersion;
 import org.opensearch.jobscheduler.transport.request.ExtensionJobActionRequest;
 import org.opensearch.jobscheduler.transport.request.JobParameterRequest;
 import org.opensearch.jobscheduler.transport.response.JobParameterResponse;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.transport.TransportService;
@@ -47,7 +48,9 @@ public class ADJobParameterTransportActionTests extends OpenSearchIntegTestCase 
     public void setUp() throws Exception {
         super.setUp();
 
-        action = new ADJobParameterTransportAction(mock(TransportService.class), mock(ActionFilters.class), xContentRegistry());
+        SDKNamedXContentRegistry mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+        action = new ADJobParameterTransportAction(mock(TransportService.class), mock(ActionFilters.class), mockSdkXContentRegistry);
         task = mock(Task.class);
         jobDocVersion = new JobDocVersion(1L, 1L, 1L);
         response = new ActionListener<>() {

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -108,12 +108,12 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.NodeNotConnectedException;
 import org.opensearch.transport.RemoteTransportException;
@@ -361,7 +361,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -484,7 +484,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -535,7 +535,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -578,7 +578,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -697,7 +697,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -738,7 +738,7 @@ public class AnomalyResultTests extends AbstractADTest {
             breakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -806,7 +806,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -858,7 +858,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
         AnomalyResultRequest request = new AnomalyResultRequest(adID, 100, 200);
@@ -898,7 +898,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1079,7 +1079,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
         AnomalyResultTransportAction.RCFActionListener listener = action.new RCFActionListener(
@@ -1172,7 +1172,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1210,7 +1210,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1253,7 +1253,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1296,7 +1296,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1346,7 +1346,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1433,7 +1433,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1481,7 +1481,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
         AnomalyResultTransportAction.RCFActionListener listener = action.new RCFActionListener(
@@ -1507,7 +1507,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
         ActionListener<AnomalyResultResponse> listener = mock(ActionListener.class);
@@ -1540,7 +1540,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
         ActionListener<AnomalyResultResponse> listener = mock(ActionListener.class);
@@ -1581,7 +1581,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1644,7 +1644,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1696,7 +1696,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1739,7 +1739,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1779,7 +1779,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 
@@ -1817,7 +1817,7 @@ public class AnomalyResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            NamedXContentRegistry.EMPTY,
+            SDKNamedXContentRegistry.EMPTY,
             adTaskManager
         );
 

--- a/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
@@ -50,6 +50,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.sdk.SDKClusterService.SDKClusterSettings;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
@@ -68,6 +69,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
     private ADTaskManager adTaskManager;
     private SDKRestClient client = mock(SDKRestClient.class);
     private SearchFeatureDao searchFeatureDao;
+    private SDKNamedXContentRegistry mockSdkXContentRegistry;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -102,6 +104,10 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
 
         adTaskManager = mock(ADTaskManager.class);
         searchFeatureDao = mock(SearchFeatureDao.class);
+
+        this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
         action = new IndexAnomalyDetectorTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
@@ -109,7 +115,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
             clusterService,
             indexSettings(),
             mock(AnomalyDetectionIndices.class),
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager,
             searchFeatureDao
         );
@@ -202,7 +208,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
             clusterService,
             settings,
             mock(AnomalyDetectionIndices.class),
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager,
             searchFeatureDao
 
@@ -222,7 +228,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
             clusterService,
             settings,
             mock(AnomalyDetectionIndices.class),
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager,
             searchFeatureDao
         );

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -107,6 +107,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregation;
@@ -165,6 +166,7 @@ public class MultiEntityResultTests extends AbstractADTest {
     private Map<String, Object> attrs1, attrs2, attrs3;
     private EntityCache entityCache;
     private ADTaskManager adTaskManager;
+    private SDKNamedXContentRegistry mockSdkXContentRegistry;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -257,6 +259,8 @@ public class MultiEntityResultTests extends AbstractADTest {
                 any(TransportService.class),
                 any(ActionListener.class)
             );
+        this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
 
         action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
@@ -272,7 +276,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager
         );
 
@@ -420,7 +424,7 @@ public class MultiEntityResultTests extends AbstractADTest {
 
         stateManager = new NodeStateManager(
             client,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             settings,
             clientUtil,
             clock,
@@ -442,7 +446,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager
         );
     }
@@ -681,7 +685,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             threadPool,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager
         );
     }
@@ -718,7 +722,7 @@ public class MultiEntityResultTests extends AbstractADTest {
 
         stateManager = new NodeStateManager(
             client,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             settings,
             clientUtil,
             clock,
@@ -740,7 +744,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             adCircuitBreakerService,
             adStats,
             mockThreadPool,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             adTaskManager
         );
 
@@ -1080,7 +1084,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             0,
             10,
             detector,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             client,
             100,
             clock,
@@ -1106,7 +1110,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             0,
             10,
             detector,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             client,
             100,
             clock,

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -70,6 +70,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.transport.TransportService;
@@ -85,6 +86,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
     private ModelManager modelManager;
     private Task task;
     private ADCircuitBreakerService circuitBreaker;
+    private SDKNamedXContentRegistry mockSdkXContentRegistry;
 
     @Override
     @Before
@@ -130,6 +132,10 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
         runner = new AnomalyDetectorRunner(modelManager, featureManager, AnomalyDetectorSettings.MAX_PREVIEW_RESULTS);
         circuitBreaker = mock(ADCircuitBreakerService.class);
         when(circuitBreaker.isOpen()).thenReturn(false);
+
+        this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
+        when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
         action = new PreviewAnomalyDetectorTransportAction(
             Settings.EMPTY,
             mock(TransportService.class),
@@ -137,7 +143,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
             mock(ActionFilters.class),
             client(),
             runner,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             circuitBreaker
         );
     }
@@ -295,7 +301,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
             mock(ActionFilters.class),
             client,
             runner,
-            xContentRegistry(),
+            mockSdkXContentRegistry,
             circuitBreaker
         );
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());


### PR DESCRIPTION
### Description

PR Submitted to support multiple REST API migrations but isolates class changes to a single PR for ease of review.

`s/NamedXContentRegistry/SDKNamedXContentRegistry/g` in constructors.  

Add `.getRegistry()` when passing as parameters to util methods.

Updates tests to use a mock which returns the default registry used in `OpenSearchTestCase`'s `xContentRegistry()` method.

### Issues Resolved

Fixes [SDK #518](https://github.com/opensearch-project/opensearch-sdk-java/issues/518)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
