### PR TITLE
[Feature/Extensions] Use parameterized SDKClusterSettings in tests

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorExtension.java
@@ -44,6 +44,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.monitor.jvm.JvmService;
+import org.opensearch.sdk.ActionExtension;
 import org.opensearch.sdk.BaseExtension;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.sdk.ExtensionsRunner;
@@ -55,7 +56,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableList;
 
-public class AnomalyDetectorExtension extends BaseExtension {
+public class AnomalyDetectorExtension extends BaseExtension implements ActionExtension {
 
     private static final String EXTENSION_SETTINGS_PATH = "/ad-extension.yml";
 

--- a/src/test/java/org/opensearch/ad/indices/CustomIndexTests.java
+++ b/src/test/java/org/opensearch/ad/indices/CustomIndexTests.java
@@ -15,10 +15,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import org.opensearch.Version;
@@ -33,14 +32,17 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.sdk.Extension;
+import org.opensearch.sdk.ExtensionsRunner;
+import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKClusterService.SDKClusterSettings;
 
 public class CustomIndexTests extends AbstractADTest {
     AnomalyDetectionIndices adIndices;
     Client client;
-    ClusterService clusterService;
+    SDKClusterService clusterService;
     DiscoveryNodeFilterer nodeFilter;
     ClusterState clusterState;
     String customIndexName;
@@ -52,31 +54,28 @@ public class CustomIndexTests extends AbstractADTest {
 
         client = mock(Client.class);
 
-        clusterService = mock(ClusterService.class);
+        clusterService = mock(SDKClusterService.class);
 
         clusterName = new ClusterName("test");
 
         customIndexName = "opensearch-ad-plugin-result-a";
-        // clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().build()).build();
+        clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().build()).build();
         when(clusterService.state()).thenReturn(clusterState);
 
         Settings settings = Settings.EMPTY;
-        ClusterSettings clusterSettings = new ClusterSettings(
-            settings,
-            Collections
-                .unmodifiableSet(
-                    new HashSet<>(
-                        Arrays
-                            .asList(
-                                AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS_PER_SHARD,
-                                AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD,
-                                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
-                                AnomalyDetectorSettings.MAX_PRIMARY_SHARDS
-                            )
-                    )
-                )
-        );
-
+        List<Setting<?>> settingsList = List
+            .of(
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS_PER_SHARD,
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD,
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
+                AnomalyDetectorSettings.MAX_PRIMARY_SHARDS
+            );
+        ExtensionsRunner mockRunner = mock(ExtensionsRunner.class);
+        Extension mockExtension = mock(Extension.class);
+        when(mockRunner.getEnvironmentSettings()).thenReturn(settings);
+        when(mockRunner.getExtension()).thenReturn(mockExtension);
+        when(mockExtension.getSettings()).thenReturn(settingsList);
+        SDKClusterSettings clusterSettings = new SDKClusterService(mockRunner).getClusterSettings();
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         nodeFilter = mock(DiscoveryNodeFilterer.class);
@@ -85,7 +84,7 @@ public class CustomIndexTests extends AbstractADTest {
             // FIXME: Replace with SDK equivalents when re-enabling tests
             // https://github.com/opensearch-project/opensearch-sdk-java/issues/288
             null, // client,
-            null, // clusterService,
+            clusterService,
             threadPool,
             settings,
             nodeFilter,

--- a/src/test/java/org/opensearch/ad/indices/RolloverTests.java
+++ b/src/test/java/org/opensearch/ad/indices/RolloverTests.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.opensearch.action.ActionListener;
@@ -34,11 +35,15 @@ import org.opensearch.ad.util.DiscoveryNodeFilterer;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.sdk.Extension;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClient.SDKClusterAdminClient;
 import org.opensearch.sdk.SDKClient.SDKIndicesClient;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
+import org.opensearch.sdk.SDKClusterService.SDKClusterSettings;
 import org.opensearch.threadpool.ThreadPool;
 
 public class RolloverTests extends AbstractADTest {
@@ -58,30 +63,26 @@ public class RolloverTests extends AbstractADTest {
         indicesClient = mock(SDKIndicesClient.class);
         SDKRestClient adminClient = mock(SDKRestClient.class);
         clusterService = mock(SDKClusterService.class);
-        // FIXME: Improve Cluster Settings
-        // https://github.com/opensearch-project/opensearch-sdk-java/issues/354
-        // ClusterSettings clusterSettings = new ClusterSettings(
-        // Settings.EMPTY,
-        // Collections
-        // .unmodifiableSet(
-        // new HashSet<>(
-        // Arrays
-        // .asList(
-        // AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS_PER_SHARD,
-        // AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD,
-        // AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
-        // AnomalyDetectorSettings.MAX_PRIMARY_SHARDS
-        // )
-        // )
-        // )
-        // );
+
+        Settings settings = Settings.EMPTY;
+        List<Setting<?>> settingsList = List
+            .of(
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS_PER_SHARD,
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD,
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
+                AnomalyDetectorSettings.MAX_PRIMARY_SHARDS
+            );
+        ExtensionsRunner mockRunner = mock(ExtensionsRunner.class);
+        Extension mockExtension = mock(Extension.class);
+        when(mockRunner.getEnvironmentSettings()).thenReturn(settings);
+        when(mockRunner.getExtension()).thenReturn(mockExtension);
+        when(mockExtension.getSettings()).thenReturn(settingsList);
+        SDKClusterSettings clusterSettings = new SDKClusterService(mockRunner).getClusterSettings();
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         clusterName = new ClusterName("test");
 
-        // when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-
         ThreadPool threadPool = mock(ThreadPool.class);
-        Settings settings = Settings.EMPTY;
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.indices()).thenReturn(indicesClient);
 


### PR DESCRIPTION
### Description

Updates tests which needed SDKClusterSettings instantiated with a list of settings following merge of [SDK #559](https://github.com/opensearch-project/opensearch-sdk-java/pull/559).

### Issues Resolved
Fixes [SDK #503](https://github.com/opensearch-project/opensearch-sdk-java/issues/503)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
