### PR TITLE
[Feature/extensions] Update Rest handlers to use RestRequest

### DIFF
--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -38,7 +38,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.ToXContent;
-import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
@@ -47,7 +46,6 @@ import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.RouteHandler;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
-import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableList;
@@ -59,7 +57,6 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
 
     private static final String GET_ANOMALY_DETECTOR_ACTION = "get_anomaly_detector";
     private static final Logger logger = LogManager.getLogger(RestGetAnomalyDetectorAction.class);
-    private SDKNamedXContentRegistry namedXContentRegistry;
     private Settings settings;
     private TransportService transportService;
     private SDKRestClient client;
@@ -68,7 +65,6 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
 
     public RestGetAnomalyDetectorAction(ExtensionsRunner extensionsRunner, SDKRestClient client) {
         this.extensionsRunner = extensionsRunner;
-        this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
         this.settings = extensionsRunner.getEnvironmentSettings();
         this.transportService = extensionsRunner.getExtensionTransportService();
         this.client = client;
@@ -93,7 +89,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
             );
     }
 
-    private Function<ExtensionRestRequest, ExtensionRestResponse> handleRequest = (request) -> {
+    private Function<RestRequest, ExtensionRestResponse> handleRequest = (request) -> {
         try {
             return prepareRequest(request);
         } catch (Exception e) {
@@ -102,7 +98,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
         }
     };
 
-    protected ExtensionRestResponse prepareRequest(ExtensionRestRequest request) throws IOException {
+    protected ExtensionRestResponse prepareRequest(RestRequest request) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
         }
@@ -203,7 +199,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
             );
     }*/
 
-    private Entity buildEntity(ExtensionRestRequest request, String detectorId) throws IOException {
+    private Entity buildEntity(RestRequest request, String detectorId) throws IOException {
         if (Strings.isEmpty(detectorId)) {
             throw new IllegalStateException(CommonErrorMessages.AD_ID_MISSING_MSG);
         }
@@ -225,7 +221,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
              *      }]
              * }
              */
-            Optional<Entity> entity = Entity.fromJsonObject(request.contentParser(namedXContentRegistry.getRegistry()));
+            Optional<Entity> entity = Entity.fromJsonObject(request.contentParser());
             if (entity.isPresent()) {
                 return entity.get();
             }
@@ -234,8 +230,7 @@ public class RestGetAnomalyDetectorAction extends BaseExtensionRestHandler {
         return null;
     }
 
-    private ExtensionRestResponse getAnomalyDetectorResponse(ExtensionRestRequest request, GetAnomalyDetectorResponse response)
-        throws IOException {
+    private ExtensionRestResponse getAnomalyDetectorResponse(RestRequest request, GetAnomalyDetectorResponse response) throws IOException {
         RestStatus restStatus = RestStatus.OK;
         ExtensionRestResponse extensionRestResponse = new ExtensionRestResponse(
             request,

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -43,7 +43,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.rest.RestRequest;
@@ -99,7 +98,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
             );
     }
 
-    private Function<ExtensionRestRequest, ExtensionRestResponse> handleRequest = (request) -> {
+    private Function<RestRequest, ExtensionRestResponse> handleRequest = (request) -> {
         try {
             return prepareRequest(request);
         } catch (Exception e) {
@@ -108,7 +107,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
         }
     };
 
-    protected ExtensionRestResponse prepareRequest(ExtensionRestRequest request) throws Exception {
+    protected ExtensionRestResponse prepareRequest(RestRequest request) throws Exception {
         if (!EnabledSetting.isADPluginEnabled()) {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
         }
@@ -116,7 +115,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
         String detectorId = request.param(DETECTOR_ID, AnomalyDetector.NO_ID);
         logger.info("AnomalyDetector {} action for detectorId {}", request.method(), detectorId);
 
-        XContentParser parser = request.contentParser(this.namedXContentRegistry.getRegistry());
+        XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         // TODO: check detection interval < modelTTL
         AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId, null, detectionInterval, detectionWindowDelay);
@@ -188,7 +187,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
         return indexAnomalyDetectorResponse(request, response);
     }
 
-    private ExtensionRestResponse indexAnomalyDetectorResponse(ExtensionRestRequest request, IndexAnomalyDetectorResponse response)
+    private ExtensionRestResponse indexAnomalyDetectorResponse(RestRequest request, IndexAnomalyDetectorResponse response)
         throws IOException {
         RestStatus restStatus = RestStatus.CREATED;
         if (request.method() == RestRequest.Method.PUT) {

--- a/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
@@ -46,7 +46,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
@@ -107,7 +106,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
             );
     }
 
-    private Function<ExtensionRestRequest, ExtensionRestResponse> handleRequest = (request) -> {
+    private Function<RestRequest, ExtensionRestResponse> handleRequest = (request) -> {
         try {
             return prepareRequest(request);
         } catch (Exception e) {
@@ -116,7 +115,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
         }
     };
 
-    protected ExtensionRestResponse sendAnomalyDetectorValidationParseResponse(ExtensionRestRequest request, DetectorValidationIssue issue)
+    protected ExtensionRestResponse sendAnomalyDetectorValidationParseResponse(RestRequest request, DetectorValidationIssue issue)
         throws IOException {
         return new ExtensionRestResponse(
             request,
@@ -130,11 +129,11 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
         return (!Collections.disjoint(typesInRequest, ALL_VALIDATION_ASPECTS_STRS));
     }
 
-    protected ExtensionRestResponse prepareRequest(ExtensionRestRequest request) throws IOException {
+    protected ExtensionRestResponse prepareRequest(RestRequest request) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
         }
-        XContentParser parser = request.contentParser(this.namedXContentRegistry.getRegistry());
+        XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         String typesStr = request.param(TYPE);
 
@@ -216,7 +215,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
         return validateAnomalyDetectorResponse(request, response);
     }
 
-    private ExtensionRestResponse validateAnomalyDetectorResponse(ExtensionRestRequest request, ValidateAnomalyDetectorResponse response)
+    private ExtensionRestResponse validateAnomalyDetectorResponse(RestRequest request, ValidateAnomalyDetectorResponse response)
         throws IOException {
         RestStatus restStatus = RestStatus.OK;
         ExtensionRestResponse extensionRestResponse = new ExtensionRestResponse(


### PR DESCRIPTION
Companion PRs (this one must be merged after Core and SDK):
 - Core: https://github.com/opensearch-project/OpenSearch/pull/6874
 - SDK: https://github.com/opensearch-project/opensearch-sdk-java/pull/623

### Description

Extensions do not use all the internal components of a `RestRequest` and initial implementation double-purposed the `ExtensionsRestRequest` object used in transport as the object that Extensions would need to handle.  However, increasing use of the methods on this object are ending up duplicating a lot of code.  It makes a lot more sense to just recreate a `RestRequest` object from the parameters passed in this request.

### Issues Resolved

Part of [SDK #431](https://github.com/opensearch-project/opensearch-sdk-java/issues/431).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
