### PR TITLE
Giving admin priority over backendrole filtering

### DIFF
--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -559,7 +559,7 @@ public final class ParseUtils {
                 AnomalyDetector detector = AnomalyDetector.parse(parser);
                 User resourceUser = detector.getUser();
 
-                if (!filterByBackendRole || checkUserPermissions(requestUser, resourceUser, detectorId)) {
+                if (!filterByBackendRole || checkUserPermissions(requestUser, resourceUser, detectorId) || isAdmin(requestUser)) {
                     function.accept(detector);
                 } else {
                     logger.debug("User: " + requestUser.getName() + " does not have permissions to access detector: " + detectorId);
@@ -571,6 +571,16 @@ public final class ParseUtils {
         } else {
             listener.onFailure(new ResourceNotFoundException(detectorId, FAIL_TO_FIND_DETECTOR_MSG + detectorId));
         }
+    }
+
+    /**
+     *  'all_access' role users are treated as admins.
+     */
+    public static boolean isAdmin(User user) {
+        if (user == null) {
+            return false;
+        }
+        return user.getRoles().contains("all_access");
     }
 
     private static boolean checkUserPermissions(User requestedUser, User resourceUser, String detectorId) throws Exception {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -247,7 +247,6 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             ),
             null
         );
-        enableFilterBy();
         // User client has admin all access, and has "opensearch" backend role so client should be able to update detector
         // But the detector's backend role should not be replaced as client's backend roles (all_access).
         Response response = updateAnomalyDetector(aliceDetector.getDetectorId(), newDetector, client());

--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.ad.util;
 
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
+import static org.opensearch.ad.util.ParseUtils.isAdmin;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -286,5 +287,30 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         List<String> fieldNames = ParseUtils.getFeatureFieldNames(detector, TestHelpers.xContentRegistry());
         assertTrue(fieldNames.contains("field-name1"));
         assertTrue(fieldNames.contains("field-name2"));
+    }
+
+    public void testIsAdmin() {
+        User user1 = new User(
+            randomAlphaOfLength(5),
+            ImmutableList.of(),
+            ImmutableList.of("all_access"),
+            ImmutableList.of(randomAlphaOfLength(5))
+        );
+        assertTrue(isAdmin(user1));
+    }
+
+    public void testIsAdminBackendRoleIsAllAccess() {
+        String backendRole1 = "all_access";
+        User user1 = new User(
+            randomAlphaOfLength(5),
+            ImmutableList.of(backendRole1),
+            ImmutableList.of(randomAlphaOfLength(5)),
+            ImmutableList.of(randomAlphaOfLength(5))
+        );
+        assertFalse(isAdmin(user1));
+    }
+
+    public void testIsAdminNull() {
+        assertFalse(isAdmin(null));
     }
 }


### PR DESCRIPTION
### Description
Prioritizing admin role over backend role filtering for all AD operations.

Validated manually that admins can now perform all AD APIs on given detector even if the backend roles don't match. Also if an admin updates a detector, it won't rewrite the backend role.

Security tests pass against a 2.6 cluster, 3.0 distribution has other issues that are being solved by other plugins.

### Issues Resolved

resolves #842 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
