### PR TITLE
Changing exception in AnomalyDetectionIndices to ExecutionException

### DIFF
--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -1144,15 +1145,13 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
                 listener.onResponse(null);
             }, listener::onFailure));
 
+        } catch (ExecutionException e) {
+            // new index will be created with auto expand replica setting
+            jobIndexState.settingUpToDate = true;
+            logger.info(new ParameterizedMessage("Mark [{}]'s mapping up-to-date", ADIndex.JOB.getIndexName()));
+            listener.onResponse(null);
         } catch (Exception e) {
-            if (e instanceof IndexNotFoundException) {
-                // new index will be created with auto expand replica setting
-                jobIndexState.settingUpToDate = true;
-                logger.info(new ParameterizedMessage("Mark [{}]'s mapping up-to-date", ADIndex.JOB.getIndexName()));
-                listener.onResponse(null);
-            } else {
-                listener.onFailure(e);
-            }
+            listener.onFailure(e);
         }
     }
 


### PR DESCRIPTION
### Description
Whenever a detector is created or started, the `AnomalyDetectorIndices `object is used to update the mappings or settings of various anomaly detector indices. In the case for the anomaly detector job index, the settings are updated [here](https://github.com/opensearch-project/anomaly-detection/blob/bf7c75a206111db46fc7ed7e3bb63aca5bab3485/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java#L1148), and if not found, then the exception is caught and handled by skipping the update for these indices. 

Since the OpenSearchAsyncClient has been used to send the `GetIndicesSettingsRequest`, the exception thrown is `ExecutionException`, which has a nested exception of type `OpenSearchException`, which logs the index not found exception. 

The index not found exception is never actually thrown, so this PR catches the ExceutionException instead.

```
00:28:12.909 [opensearch[ad-extension][generic][T#4]] INFO  org.opensearch.ad.indices.AnomalyDetectionIndices - Exception e : class java.util.concurrent.ExecutionException
00:28:12.909 [opensearch[ad-extension][generic][T#4]] INFO  org.opensearch.ad.indices.AnomalyDetectionIndices - Exception e.getCause() : class org.opensearch.client.opensearch._types.OpenSearchException
00:28:12.909 [opensearch[ad-extension][generic][T#4]] INFO  org.opensearch.ad.indices.AnomalyDetectionIndices - Exception e.getCause().getMessage() :Request failed: [index_not_found_exception] no such index [.opendistro-anomaly-detector-jobs]
00:28:12.909 [opensearch[ad-extension][generic][T#4]] INFO  org.opensearch.ad.indices.AnomalyDetectionIndices - Check [.opendistro-anomaly-checkpoints]'s setting
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
