### PR TITLE
[Extensions] Replaces ADTransportGetFieldsMappingsAction with SDK indices client call

### DIFF
--- a/dataGeneration/generate-cosine-data-multi-entity.py
+++ b/dataGeneration/generate-cosine-data-multi-entity.py
@@ -90,7 +90,7 @@ def create_index(os, INDEX_NAME, shard_number):
           "number_of_shards":shard_number,
           "number_of_replicas": 0, # increase this number after indexing
           "translog.durability":"async", # default: request
-          "refresh_interval":-1, # default: 1, remember to change this after finishing indexing process or just _refresh once at least if index wont be changed again
+          "refresh_interval":"1s", # default: 1, remember to change this after finishing indexing process or just _refresh once at least if index wont be changed again
        },
        "mappings":{
           "properties":{

--- a/dataGeneration/generate-cosine-data-multi-entity.py
+++ b/dataGeneration/generate-cosine-data-multi-entity.py
@@ -90,7 +90,7 @@ def create_index(os, INDEX_NAME, shard_number):
           "number_of_shards":shard_number,
           "number_of_replicas": 0, # increase this number after indexing
           "translog.durability":"async", # default: request
-          "refresh_interval":"1s", # default: 1, remember to change this after finishing indexing process or just _refresh once at least if index wont be changed again
+          "refresh_interval":-1, # default: 1, remember to change this after finishing indexing process or just _refresh once at least if index wont be changed again
        },
        "mappings":{
           "properties":{


### PR DESCRIPTION
### Description
Adds field mapping validation check for validate detector API .

note : Valid detector/model configuration returns an empty response : `{}`

**Validate Single Entity Detector (valid detector)**
```
 curl -X POST "localhost:9200/_extensions/_ad-extension/detectors/_validate" -H "Content-Type:application/json" --data
'{
  "name": "test-detector",
  "description": "Test detector",
  "time_field": "@timestamp",
  "indices": [
    "server_log"
  ],
  "feature_attributes": [
    {
      "feature_name": "test",
      "feature_enabled": true,
      "aggregation_query": {
        "test": {
          "avg": {
            "field": "jvmGcTime"
          }
        }
      }
    }
  ],
  "detection_interval": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  }
}'
{}
```
**Validate Single Entity Detector (invalid detector mapping : time field)**
```
 curl -X POST "localhost:9200/_extensions/_ad-extension/detectors/_validate" -H "Content-Type:application/json" --data
'{
  "name": "test-detector",
  "description": "Test detector",
  "time_field": "timestamp",
  "indices": [
    "server_log"
  ],
  "feature_attributes": [
    {
      "feature_name": "test",
      "feature_enabled": true,
      "aggregation_query": {
        "test": {
          "avg": {
            "field": "jvmGcTime"
          }
        }
      }
    }
  ],
  "detection_interval": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  }
}'
{
  "detector": {
    "time_field": {
      "message": "Timestamp field: (timestamp) is not found in index mapping"
    }
  }
}
```

**Validate Multi Entity Detector (valid detector)**
```
curl -X POST "localhost:9200/_extensions/_ad-extension/detectors/_validate" -H "Content-Type:application/json" --data
`{
  "name": "test-multi-detector",
  "description": "Test detector",
  "time_field": "@timestamp",
  "indices": [
    "server_log"
  ],
  "feature_attributes": [
    {
      "feature_name": "test",
      "feature_enabled": true,
      "aggregation_query": {
        "test": {
          "avg": {
            "field": "cpuTime"
          }
        }
      }
    }
  ],
  "detection_interval": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "category_field": [
    "process"
  ]
}`
{}
```
**Validate Multi Entity Detector (invalid detector mapping : aggregation query field)**
```
curl -X POST "localhost:9200/_extensions/_ad-extension/detectors/_validate" -H "Content-Type:application/json" --data
`{
  "name": "test-multi-detector",
  "description": "Test detector",
  "time_field": "@timestamp",
  "indices": [
    "server_log"
  ],
  "feature_attributes": [
    {
      "feature_name": "test",
      "feature_enabled": true,
      "aggregation_query": {
        "test": {
          "avg": {
            "field": "wrongField"
          }
        }
      }
    }
  ],
  "detection_interval": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "category_field": [
    "process"
  ]
}`
{
  "detector": {
    "feature_attributes": {
      "message": "Feature has an invalid query returning empty aggregated data: test",
      "sub_issues": {
        "test": "Feature has an invalid query returning empty aggregated data"
      }
    }
  }
}
```
**Validate detector model (detection interval of 10 minutes)**
```
-X POST "localhost:9200/_extensions/_ad-extension/detectors/_validate/model" -H "Content-Type:application/json" --data
`
{
  "name": "test-multi-detector",
  "description": "Test detector",
  "time_field": "@timestamp",
  "indices": [
    "server_log"
  ],
  "feature_attributes": [
    {
      "feature_name": "test",
      "feature_enabled": true,
      "aggregation_query": {
        "test": {
          "avg": {
            "field": "cpuTime"
          }
        }
      }
    }
  ],
  "detection_interval": {
    "period": {
      "interval": 10,
      "unit": "Minutes"
    }
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "category_field": [
    "process"
  ]
}`
{
  "model": {
    "detection_interval": {
      "message": "The selected detector interval might collect sparse data. Consider changing interval length to: 6",
      "suggested_value": {
        "period": {
          "interval": 6,
          "unit": "Minutes"
        }
      }
    }
  }
}
```
**Validate detector model (suggested detection interval of 6 minutes)**
```
curl -X POST "localhost:9200/_extensions/_ad-extension/detectors/_validate/model" -H "Content-Type:application/json" --data
'{
  "name": "test-multi-detector",
  "description": "Test detector",
  "time_field": "@timestamp",
  "indices": [
    "server_log"
  ],
  "feature_attributes": [
    {
      "feature_name": "test",
      "feature_enabled": true,
      "aggregation_query": {
        "test": {
          "avg": {
            "field": "cpuTime"
          }
        }
      }
    }
  ],
  "detection_interval": {
    "period": {
      "interval": 6,
      "unit": "Minutes"
    }
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  },
  "category_field": [
    "process"
  ]
}'
{}
```
### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/361

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
