### PR TITLE
Sync up CODEOWNERS with MAINTAINERS.md.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/anomaly-detection
+* @jmazanec15 @jngz-es @kaituo @wnbts @saratvemulapalli @ohltyler @vamshin @VijayanB @ylwu-amzn
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer              | GitHub ID                                               | Affiliation |
 | ----------------------- | ------------------------------------------------------- | ----------- |
-| Hanguang Zhang          | [zhanghg08](https://github.com/zhanghg08)               | Amazon      |
 | Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15)             | Amazon      |
 | Jing Zhang              | [jngz-es](https://github.com/jngz-es)                   | Amazon      |
 | Kaituo Li               | [kaituo](https://github.com/kaituo)                     | Amazon      |
@@ -16,4 +15,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)                   | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)                 | Amazon      |
 | Yaliang Wu              | [ylwu-amzn](https://github.com/ylwu-amzn)               | Amazon      |
-| Yizhe Liu               | [yizheliu-amazon](https://github.com/yizheliu-amazon)   | Amazon      |
+
+## Emeritus
+
+| Maintainer     | GitHub ID                                             | Affiliation |
+| -------------- | ----------------------------------------------------- | ----------- |
+| Hanguang Zhang | [zhanghg08](https://github.com/zhanghg08)             | Amazon      |
+| Yizhe Liu      | [yizheliu-amazon](https://github.com/yizheliu-amazon) | Amazon      |


### PR DESCRIPTION
### Description

Sync up CODEOWNERS with MAINTAINERS.md.

Moved @zhanghg08 and @yizheliu-amazon to emeritus as they aren't members of the org anymore.

Closes #808.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
