### PR TITLE
Code Refactoring for CommonMessages

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -11,11 +11,11 @@
 
 package org.opensearch.ad;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_PARSE_DETECTOR_MSG;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_PARSE_DETECTOR_MSG;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestStatus.BAD_REQUEST;
 import static org.opensearch.rest.RestStatus.INTERNAL_SERVER_ERROR;
+import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 
 import java.util.List;
 import java.util.Map;
@@ -33,8 +33,8 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.common.exception.NotSerializedADExceptionName;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
@@ -109,7 +109,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
 
     public void profile(String detectorId, ActionListener<DetectorProfile> listener, Set<DetectorProfileName> profilesToCollect) {
         if (profilesToCollect.isEmpty()) {
-            listener.onFailure(new IllegalArgumentException(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
+            listener.onFailure(new IllegalArgumentException(ADCommonMessages.EMPTY_PROFILES_COLLECT));
             return;
         }
         calculateTotalResponsesToWait(detectorId, profilesToCollect, listener);
@@ -136,11 +136,11 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                     listener.onFailure(new OpenSearchStatusException(FAIL_TO_PARSE_DETECTOR_MSG + detectorId, BAD_REQUEST));
                 }
             } else {
-                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, BAD_REQUEST));
+                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_CONFIG_MSG + detectorId, BAD_REQUEST));
             }
         }, exception -> {
-            logger.error(FAIL_TO_FIND_DETECTOR_MSG + detectorId, exception);
-            listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, INTERNAL_SERVER_ERROR));
+            logger.error(FAIL_TO_FIND_CONFIG_MSG + detectorId, exception);
+            listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_CONFIG_MSG + detectorId, INTERNAL_SERVER_ERROR));
         }));
     }
 
@@ -207,7 +207,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                         new MultiResponsesDelegateActionListener<DetectorProfile>(
                             listener,
                             totalResponsesToWait,
-                            CommonErrorMessages.FAIL_FETCH_ERR_MSG + detectorId,
+                            ADCommonMessages.FAIL_FETCH_ERR_MSG + detectorId,
                             false
                         );
                     if (profilesToCollect.contains(DetectorProfileName.ERROR)) {
@@ -266,7 +266,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                     }
 
                 } catch (Exception e) {
-                    logger.error(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG, e);
+                    logger.error(ADCommonMessages.FAIL_TO_GET_PROFILE_MSG, e);
                     listener.onFailure(e);
                 }
             } else {
@@ -277,7 +277,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 logger.info(exception.getMessage());
                 onGetDetectorForPrepare(detectorId, listener, profilesToCollect);
             } else {
-                logger.error(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG + detectorId);
+                logger.error(ADCommonMessages.FAIL_TO_GET_PROFILE_MSG + detectorId);
                 listener.onFailure(exception);
             }
         }));
@@ -304,7 +304,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                     DetectorProfile profile = profileBuilder.totalEntities(value).build();
                     listener.onResponse(profile);
                 }, searchException -> {
-                    logger.warn(CommonErrorMessages.FAIL_TO_GET_TOTAL_ENTITIES + detector.getDetectorId());
+                    logger.warn(ADCommonMessages.FAIL_TO_GET_TOTAL_ENTITIES + detector.getDetectorId());
                     listener.onFailure(searchException);
                 });
                 // using the original context in listener as user roles have no permissions for internal operations like fetching a
@@ -353,7 +353,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                     DetectorProfile profile = profileBuilder.totalEntities(Long.valueOf(compositeAgg.getBuckets().size())).build();
                     listener.onResponse(profile);
                 }, searchException -> {
-                    logger.warn(CommonErrorMessages.FAIL_TO_GET_TOTAL_ENTITIES + detector.getDetectorId());
+                    logger.warn(ADCommonMessages.FAIL_TO_GET_TOTAL_ENTITIES + detector.getDetectorId());
                     listener.onFailure(searchException);
                 });
                 // using the original context in listener as user roles have no permissions for internal operations like fetching a

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -25,8 +25,8 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.AnomalyResult;
@@ -56,6 +56,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 
 public class EntityProfileRunner extends AbstractProfileRunner {
@@ -90,7 +91,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
         ActionListener<EntityProfile> listener
     ) {
         if (profilesToCollect == null || profilesToCollect.size() == 0) {
-            listener.onFailure(new IllegalArgumentException(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
+            listener.onFailure(new IllegalArgumentException(ADCommonMessages.EMPTY_PROFILES_COLLECT));
             return;
         }
         GetRequest getDetectorRequest = new GetRequest(CommonName.CONFIG_INDEX, detectorId);
@@ -109,8 +110,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                     if (categoryFields == null || categoryFields.size() == 0) {
                         listener.onFailure(new IllegalArgumentException(NOT_HC_DETECTOR_ERR_MSG));
                     } else if (categoryFields.size() > maxCategoryFields) {
-                        listener
-                            .onFailure(new IllegalArgumentException(CommonErrorMessages.getTooManyCategoricalFieldErr(maxCategoryFields)));
+                        listener.onFailure(new IllegalArgumentException(CommonMessages.getTooManyCategoricalFieldErr(maxCategoryFields)));
                     } else {
                         validateEntity(entityValue, categoryFields, detectorId, profilesToCollect, detector, listener);
                     }
@@ -118,7 +118,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                     listener.onFailure(t);
                 }
             } else {
-                listener.onFailure(new IllegalArgumentException(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG + detectorId));
+                listener.onFailure(new IllegalArgumentException(CommonMessages.FAIL_TO_FIND_CONFIG_MSG + detectorId));
             }
         }, listener::onFailure));
     }
@@ -245,7 +245,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                         new MultiResponsesDelegateActionListener<EntityProfile>(
                             listener,
                             totalResponsesToWait,
-                            CommonErrorMessages.FAIL_FETCH_ERR_MSG + entityValue + " of detector " + detectorId,
+                            ADCommonMessages.FAIL_FETCH_ERR_MSG + entityValue + " of detector " + detectorId,
                             false
                         );
 
@@ -308,7 +308,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                         }));
                     }
                 } catch (Exception e) {
-                    logger.error(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG, e);
+                    logger.error(ADCommonMessages.FAIL_TO_GET_PROFILE_MSG, e);
                     listener.onFailure(e);
                 }
             } else {
@@ -319,7 +319,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
                 logger.info(exception.getMessage());
                 sendUnknownState(profilesToCollect, entityValue, true, listener);
             } else {
-                logger.error(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG + detectorId, exception);
+                logger.error(ADCommonMessages.FAIL_TO_GET_PROFILE_MSG + detectorId, exception);
                 listener.onFailure(exception);
             }
         }));

--- a/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
+++ b/src/main/java/org/opensearch/ad/ExecuteADResultResponseRecorder.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_LATEST_TASK;
+import static org.opensearch.ad.constant.ADCommonMessages.CAN_NOT_FIND_LATEST_TASK;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.indices.ADIndex;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -307,7 +307,7 @@ public class ExecuteADResultResponseRecorder {
                 anomalyResultHandler.index(anomalyResult, detectorId, resultIndex);
             }
 
-            if (errorMessage.contains(CommonErrorMessages.NO_MODEL_ERR_MSG) && !detector.isMultiCategoryDetector()) {
+            if (errorMessage.contains(ADCommonMessages.NO_MODEL_ERR_MSG) && !detector.isMultiCategoryDetector()) {
                 // single stream detector raises ResourceNotFoundException containing CommonErrorMessages.NO_CHECKPOINT_ERR_MSG
                 // when there is no checkpoint.
                 // Delay real time cache update by one minute so we will have trained models by then and update the state

--- a/src/main/java/org/opensearch/ad/NodeStateManager.java
+++ b/src/main/java/org/opensearch/ad/NodeStateManager.java
@@ -32,7 +32,6 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.SingleStreamModelIdMapper;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
@@ -48,6 +47,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 
 /**
@@ -153,10 +153,7 @@ public class NodeStateManager implements MaintenanceState, CleanState {
                 AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId());
                 // end execution if all features are disabled
                 if (detector.getEnabledFeatureIds().isEmpty()) {
-                    listener
-                        .onFailure(
-                            new EndRunException(adID, CommonErrorMessages.ALL_FEATURES_DISABLED_ERR_MSG, true).countedInStats(false)
-                        );
+                    listener.onFailure(new EndRunException(adID, CommonMessages.ALL_FEATURES_DISABLED_ERR_MSG, true).countedInStats(false));
                     return;
                 }
                 NodeState state = states.computeIfAbsent(adID, id -> new NodeState(id, clock));

--- a/src/main/java/org/opensearch/ad/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityCache.java
@@ -44,7 +44,6 @@ import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.MemoryTracker.Origin;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.LimitExceededException;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.CheckpointDao;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelManager.ModelType;
@@ -63,6 +62,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -482,7 +482,7 @@ public class PriorityCache implements EntityCache {
                 // Put tryClearUpMemory after consumeMemory to prevent that.
                 tryClearUpMemory();
             } else {
-                throw new LimitExceededException(detectorId, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG);
+                throw new LimitExceededException(detectorId, CommonMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG);
             }
 
         }

--- a/src/main/java/org/opensearch/ad/constant/ADCommonMessages.java
+++ b/src/main/java/org/opensearch/ad/constant/ADCommonMessages.java
@@ -12,33 +12,16 @@
 package org.opensearch.ad.constant;
 
 import static org.opensearch.ad.constant.ADCommonName.CUSTOM_RESULT_INDEX_PREFIX;
-import static org.opensearch.ad.model.AnomalyDetector.MAX_RESULT_INDEX_NAME_SIZE;
-import static org.opensearch.ad.rest.handler.AbstractAnomalyDetectorActionHandler.MAX_DETECTOR_NAME_SIZE;
 
-import java.util.Locale;
-
-public class CommonErrorMessages {
+public class ADCommonMessages {
     public static final String AD_ID_MISSING_MSG = "AD ID is missing";
     public static final String MODEL_ID_MISSING_MSG = "Model ID is missing";
-    public static final String WAIT_ERR_MSG = "Exception in waiting for result";
     public static final String HASH_ERR_MSG = "Cannot find an RCF node.  Hashing does not work.";
     public static final String NO_CHECKPOINT_ERR_MSG = "No checkpoints found for model id ";
-    public static final String MEMORY_LIMIT_EXCEEDED_ERR_MSG = "AD models memory usage exceeds our limit.";
     public static final String FEATURE_NOT_AVAILABLE_ERR_MSG = "No Feature in current detection window.";
-    public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
-    public static final String DISABLED_ERR_MSG = "AD plugin is disabled. To enable update plugins.anomaly_detection.enabled to true";
-    public static final String CAN_NOT_CHANGE_CATEGORY_FIELD = "Can't change detector category field";
-    public static final String CAN_NOT_CHANGE_RESULT_INDEX = "Can't change detector result index";
-    public static final String CREATE_INDEX_NOT_ACKNOWLEDGED = "Create index %S not acknowledged";
-    // We need this invalid query tag to show proper error message on frontend
-    // refer to AD Dashboard code: https://tinyurl.com/8b5n8hat
-    public static final String INVALID_SEARCH_QUERY_MSG = "Invalid search query.";
-    public static final String ALL_FEATURES_DISABLED_ERR_MSG =
-        "Having trouble querying data because all of your features have been disabled.";
-    public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
+    public static final String DISABLED_ERR_MSG =
+        "AD functionality is disabled. To enable update plugins.anomaly_detection.enabled to true";
     public static String FAIL_TO_PARSE_DETECTOR_MSG = "Fail to parse detector with id: ";
-    // change this error message to make it compatible with old version's integration(nexus) test
-    public static String FAIL_TO_FIND_DETECTOR_MSG = "Can't find detector with id: ";
     public static String FAIL_TO_GET_PROFILE_MSG = "Fail to get profile for detector ";
     public static String FAIL_TO_GET_TOTAL_ENTITIES = "Failed to get total entities for detector ";
     public static String FAIL_TO_GET_USER_INFO = "Unable to get user information from detector ";
@@ -49,21 +32,11 @@ public class CommonErrorMessages {
     public static String DETECTOR_IS_RUNNING = "Detector is already running";
     public static String DETECTOR_MISSING = "Detector is missing";
     public static String AD_TASK_ACTION_MISSING = "AD task action is missing";
-    public static final String BUG_RESPONSE = "We might have bugs.";
     public static final String INDEX_NOT_FOUND = "index does not exist";
     public static final String NOT_EXISTENT_VALIDATION_TYPE = "The given validation type doesn't exist";
     public static final String UNSUPPORTED_PROFILE_TYPE = "Unsupported profile types";
 
-    private static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT = "We can have only %d categorical field/s.";
-
-    public static String getTooManyCategoricalFieldErr(int limit) {
-        return String.format(Locale.ROOT, TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT, limit);
-    }
-
     public static final String REQUEST_THROTTLED_MSG = "Request throttled. Please try again later.";
-    public static String EMPTY_DETECTOR_NAME = "Detector name should be set";
-    public static String NULL_TIME_FIELD = "Time field should be set";
-    public static String EMPTY_INDICES = "Indices should be set";
     public static String NULL_DETECTION_INTERVAL = "Detection interval should be set";
     public static String INVALID_SHINGLE_SIZE = "Shingle size must be a positive integer";
     public static String INVALID_DETECTION_INTERVAL = "Detection interval must be a positive integer";
@@ -74,14 +47,8 @@ public class CommonErrorMessages {
     public static String NO_ENTITY_FOUND = "No entity found";
     public static String HISTORICAL_ANALYSIS_CANCELLED = "Historical analysis cancelled by user";
     public static String HC_DETECTOR_TASK_IS_UPDATING = "HC detector task is updating";
-    public static String NEGATIVE_TIME_CONFIGURATION = "should be non-negative";
     public static String INVALID_TIME_CONFIGURATION_UNITS = "Time unit %s is not supported";
-    public static String INVALID_DETECTOR_NAME =
-        "Valid characters for detector name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
     public static String DUPLICATE_FEATURE_AGGREGATION_NAMES = "Detector has duplicate feature aggregation query names: ";
-    public static String INVALID_TIMESTAMP = "Timestamp field: (%s) must be of type date";
-    public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping";
-
     public static String FAIL_TO_GET_DETECTOR = "Fail to get detector";
     public static String FAIL_TO_GET_DETECTOR_INFO = "Fail to get detector info";
     public static String FAIL_TO_CREATE_DETECTOR = "Fail to create detector";
@@ -93,18 +60,6 @@ public class CommonErrorMessages {
     public static String FAIL_TO_DELETE_AD_RESULT = "Fail to delete anomaly result";
     public static String FAIL_TO_GET_STATS = "Fail to get stats";
     public static String FAIL_TO_SEARCH = "Fail to search";
-
-    public static String CAN_NOT_FIND_RESULT_INDEX = "Can't find result index ";
-    public static String INVALID_RESULT_INDEX_PREFIX = "Result index must start with " + CUSTOM_RESULT_INDEX_PREFIX;
-    public static String INVALID_RESULT_INDEX_NAME_SIZE = "Result index name size must contains less than "
-        + MAX_RESULT_INDEX_NAME_SIZE
-        + " characters";
-    public static String INVALID_CHAR_IN_RESULT_INDEX_NAME =
-        "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";
-    public static String INVALID_RESULT_INDEX_MAPPING = "Result index mapping is not correct for index: ";
-    public static String INVALID_DETECTOR_NAME_SIZE = "Name should be shortened. The maximum limit is "
-        + MAX_DETECTOR_NAME_SIZE
-        + " characters.";
 
     public static String WINDOW_DELAY_REC =
         "Latest seen data point is at least %d minutes ago, consider changing window delay to at least %d minutes.";
@@ -124,14 +79,8 @@ public class CommonErrorMessages {
         "Data is most likely too sparse when given feature queries are applied. Consider revising feature queries.";
     public static String TIMEOUT_ON_INTERVAL_REC = "Timed out getting interval recommendation";
 
-    // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction
-    public static final String FEATURE_INVALID_MSG_PREFIX = "Feature has an invalid query";
-    public static final String FEATURE_WITH_EMPTY_DATA_MSG = FEATURE_INVALID_MSG_PREFIX + " returning empty aggregated data: ";
-    public static final String FEATURE_WITH_INVALID_QUERY_MSG = FEATURE_INVALID_MSG_PREFIX + " causing a runtime exception: ";
-    public static final String UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG =
-        "Feature has an unknown exception caught while executing the feature query: ";
-    public static final String VALIDATION_FEATURE_FAILURE = "Validation failed for feature(s) of detector %s";
     public static final String NO_MODEL_ERR_MSG = "No RCF models are available either because RCF"
         + " models are not ready or all nodes are unresponsive or the system might have bugs.";
+    public static String INVALID_RESULT_INDEX_PREFIX = "Result index must start with " + CUSTOM_RESULT_INDEX_PREFIX;
 
 }

--- a/src/main/java/org/opensearch/ad/feature/FeatureManager.java
+++ b/src/main/java/org/opensearch/ad/feature/FeatureManager.java
@@ -42,11 +42,11 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.ad.CleanState;
 import org.opensearch.ad.common.exception.EndRunException;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.dataprocessor.Interpolator;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 
 /**
  * A facade managing feature data operations and buffers.
@@ -165,7 +165,7 @@ public class FeatureManager implements CleanState {
                     updateUnprocessedFeatures(detector, shingle, featuresMap, endTime, listener);
                 }, listener::onFailure));
             } catch (IOException e) {
-                listener.onFailure(new EndRunException(detector.getDetectorId(), CommonErrorMessages.INVALID_SEARCH_QUERY_MSG, e, true));
+                listener.onFailure(new EndRunException(detector.getDetectorId(), CommonMessages.INVALID_SEARCH_QUERY_MSG, e, true));
             }
         } else {
             listener.onResponse(getProcessedFeatures(shingle, detector, endTime));
@@ -309,7 +309,7 @@ public class FeatureManager implements CleanState {
                         new ThreadedActionListener<>(logger, threadPool, adThreadPoolName, getFeaturesListener, false)
                     );
             } catch (IOException e) {
-                listener.onFailure(new EndRunException(detector.getDetectorId(), CommonErrorMessages.INVALID_SEARCH_QUERY_MSG, e, true));
+                listener.onFailure(new EndRunException(detector.getDetectorId(), CommonMessages.INVALID_SEARCH_QUERY_MSG, e, true));
             }
         } else {
             listener.onResponse(Optional.empty());

--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -12,7 +12,6 @@
 package org.opensearch.ad.indices;
 
 import static org.opensearch.ad.constant.ADCommonName.DUMMY_AD_RESULT_ID;
-import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_RESULT_INDEX;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS_PER_SHARD;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD;
@@ -22,6 +21,7 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.ANOMALY_DETECTO
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.ANOMALY_RESULTS_INDEX_MAPPING_FILE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_INDEX_MAPPING_FILE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_PRIMARY_SHARDS;
+import static org.opensearch.timeseries.constant.CommonMessages.CAN_NOT_FIND_RESULT_INDEX;
 
 import java.io.IOException;
 import java.net.URL;
@@ -60,7 +60,6 @@ import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.rest.handler.AnomalyDetectorFunction;
@@ -87,6 +86,7 @@ import org.opensearch.core.xcontent.XContentParser.Token;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 
 import com.google.common.base.Charsets;
@@ -355,7 +355,7 @@ public class AnomalyDetectionIndices implements LocalNodeClusterManagerListener 
         try {
             if (!isValidResultIndexMapping(resultIndex)) {
                 logger.warn("Can't create detector with custom result index {} as its mapping is invalid", resultIndex);
-                listener.onFailure(new IllegalArgumentException(CommonErrorMessages.INVALID_RESULT_INDEX_MAPPING + resultIndex));
+                listener.onFailure(new IllegalArgumentException(CommonMessages.INVALID_RESULT_INDEX_MAPPING + resultIndex));
                 return;
             }
 
@@ -760,7 +760,6 @@ public class AnomalyDetectionIndices implements LocalNodeClusterManagerListener 
             String latestToDelete = null;
             long latest = Long.MIN_VALUE;
             for (IndexMetadata indexMetaData : clusterStateResponse.getState().metadata().indices().values()) {
-                // IndexMetadata indexMetaData = cursor.value;
                 long creationTime = indexMetaData.getCreationDate();
 
                 if ((Instant.now().toEpochMilli() - creationTime) > historyRetentionPeriod.millis()) {

--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -36,7 +36,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.ad.DetectorModelSize;
 import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Entity;
@@ -299,7 +299,7 @@ public class ModelManager implements DetectorModelSize {
             forests.put(modelId, model.get());
             getTRcfResult(model.get(), point, listener);
         } else {
-            throw new ResourceNotFoundException(detectorId, CommonErrorMessages.NO_CHECKPOINT_ERR_MSG + modelId);
+            throw new ResourceNotFoundException(detectorId, ADCommonMessages.NO_CHECKPOINT_ERR_MSG + modelId);
         }
     }
 
@@ -323,7 +323,7 @@ public class ModelManager implements DetectorModelSize {
             if (model.get().getModel() != null && model.get().getModel().getForest() != null)
                 listener.onResponse(model.get().getModel().getForest().getTotalUpdates());
         } else {
-            listener.onFailure(new ResourceNotFoundException(detectorId, CommonErrorMessages.NO_CHECKPOINT_ERR_MSG + modelId));
+            listener.onFailure(new ResourceNotFoundException(detectorId, ADCommonMessages.NO_CHECKPOINT_ERR_MSG + modelId));
         }
     }
 
@@ -379,7 +379,7 @@ public class ModelManager implements DetectorModelSize {
             thresholds.put(modelId, model.get());
             getThresholdingResult(model.get(), score, listener);
         } else {
-            throw new ResourceNotFoundException(detectorId, CommonErrorMessages.NO_CHECKPOINT_ERR_MSG + modelId);
+            throw new ResourceNotFoundException(detectorId, ADCommonMessages.NO_CHECKPOINT_ERR_MSG + modelId);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/model/DetectorProfileName.java
+++ b/src/main/java/org/opensearch/ad/model/DetectorProfileName.java
@@ -15,8 +15,8 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.opensearch.ad.Name;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 
 public enum DetectorProfileName implements Name {
     STATE(ADCommonName.STATE),
@@ -69,7 +69,7 @@ public enum DetectorProfileName implements Name {
             case ADCommonName.AD_TASK:
                 return AD_TASK;
             default:
-                throw new IllegalArgumentException(CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
+                throw new IllegalArgumentException(ADCommonMessages.UNSUPPORTED_PROFILE_TYPE);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/model/EntityProfileName.java
+++ b/src/main/java/org/opensearch/ad/model/EntityProfileName.java
@@ -15,8 +15,8 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.opensearch.ad.Name;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 
 public enum EntityProfileName implements Name {
     INIT_PROGRESS(ADCommonName.INIT_PROGRESS),
@@ -51,7 +51,7 @@ public enum EntityProfileName implements Name {
             case ADCommonName.MODELS:
                 return MODELS;
             default:
-                throw new IllegalArgumentException(CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
+                throw new IllegalArgumentException(ADCommonMessages.UNSUPPORTED_PROFILE_TYPE);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
+++ b/src/main/java/org/opensearch/ad/model/IntervalTimeConfiguration.java
@@ -18,10 +18,11 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.opensearch.ad.annotation.Generated;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
@@ -42,11 +43,11 @@ public class IntervalTimeConfiguration extends TimeConfiguration {
     public IntervalTimeConfiguration(long interval, ChronoUnit unit) {
         if (interval < 0) {
             throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Interval %s %s", interval, CommonErrorMessages.NEGATIVE_TIME_CONFIGURATION)
+                String.format(Locale.ROOT, "Interval %s %s", interval, CommonMessages.NEGATIVE_TIME_CONFIGURATION)
             );
         }
         if (!SUPPORTED_UNITS.contains(unit)) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIME_CONFIGURATION_UNITS, unit));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, ADCommonMessages.INVALID_TIME_CONFIGURATION_UNITS, unit));
         }
         this.interval = interval;
         this.unit = unit;

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
@@ -38,7 +38,6 @@ import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.indices.ADIndex;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.ml.CheckpointDao;
@@ -57,6 +56,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.stats.StatNames;
 
 /**
@@ -246,7 +246,7 @@ public class CheckpointReadWorker extends BatchWorker<EntityFeatureRequest, Mult
                         nodeStateManager
                             .setException(
                                 adID,
-                                new EndRunException(adID, CommonErrorMessages.BUG_RESPONSE, stopDetectorRequests.get(modelId.get()), false)
+                                new EndRunException(adID, CommonMessages.BUG_RESPONSE, stopDetectorRequests.get(modelId.get()), false)
                             );
                     }
                 }

--- a/src/main/java/org/opensearch/ad/rest/AbstractSearchAction.java
+++ b/src/main/java/org/opensearch/ad/rest/AbstractSearchAction.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.xcontent.ToXContentObject;
@@ -67,7 +67,7 @@ public abstract class AbstractSearchAction<T extends ToXContentObject> extends B
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());

--- a/src/main/java/org/opensearch/ad/rest/RestAnomalyDetectorJobAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestAnomalyDetectorJobAction.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.DetectionDateRange;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.AnomalyDetectorJobAction;
@@ -62,7 +62,7 @@ public class RestAnomalyDetectorJobAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         String detectorId = request.param(DETECTOR_ID);

--- a/src/main/java/org/opensearch/ad/rest/RestDeleteAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestDeleteAnomalyDetectorAction.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.rest.handler.AnomalyDetectorActionHandler;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.DeleteAnomalyDetectorAction;
@@ -52,7 +52,7 @@ public class RestDeleteAnomalyDetectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         String detectorId = request.param(DETECTOR_ID);

--- a/src/main/java/org/opensearch/ad/rest/RestDeleteAnomalyResultsAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestDeleteAnomalyResultsAction.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.DeleteAnomalyResultsAction;
 import org.opensearch.client.node.NodeClient;
@@ -63,7 +63,7 @@ public class RestDeleteAnomalyResultsAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser());

--- a/src/main/java/org/opensearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.AnomalyResultAction;
@@ -66,7 +66,7 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
         AnomalyDetectorExecutionInput input = getAnomalyDetectorExecutionInput(request);
         return channel -> {

--- a/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -23,8 +23,8 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.GetAnomalyDetectorAction;
@@ -57,7 +57,7 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
         String detectorId = request.param(DETECTOR_ID);
         String typesStr = request.param(TYPE);
@@ -132,7 +132,7 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
 
     private Entity buildEntity(RestRequest request, String detectorId) throws IOException {
         if (Strings.isEmpty(detectorId)) {
-            throw new IllegalStateException(CommonErrorMessages.AD_ID_MISSING_MSG);
+            throw new IllegalStateException(ADCommonMessages.AD_ID_MISSING_MSG);
         }
 
         String entityName = request.param(ADCommonName.CATEGORICAL_FIELD);

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.IndexAnomalyDetectorAction;
@@ -66,7 +66,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         String detectorId = request.param(DETECTOR_ID, AnomalyDetector.NO_ID);

--- a/src/main/java/org/opensearch/ad/rest/RestPreviewAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestPreviewAnomalyDetectorAction.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.PreviewAnomalyDetectorAction;
@@ -55,7 +55,7 @@ public class RestPreviewAnomalyDetectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, org.opensearch.client.node.NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         AnomalyDetectorExecutionInput input = getAnomalyDetectorExecutionInput(request);

--- a/src/main/java/org/opensearch/ad/rest/RestSearchAnomalyDetectorInfoAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestSearchAnomalyDetectorInfoAction.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.SearchAnomalyDetectorInfoAction;
 import org.opensearch.ad.transport.SearchAnomalyDetectorInfoRequest;
@@ -48,7 +48,7 @@ public class RestSearchAnomalyDetectorInfoAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, org.opensearch.client.node.NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         String detectorName = request.param("name", null);

--- a/src/main/java/org/opensearch/ad/rest/RestSearchAnomalyResultAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestSearchAnomalyResultAction.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.SearchAnomalyResultAction;
@@ -58,7 +58,7 @@ public class RestSearchAnomalyResultAction extends AbstractSearchAction<AnomalyR
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         // resultIndex could be concrete index or index pattern

--- a/src/main/java/org/opensearch/ad/rest/RestSearchTopAnomalyResultAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestSearchTopAnomalyResultAction.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.ad.AnomalyDetectorPlugin;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.transport.SearchTopAnomalyResultAction;
 import org.opensearch.ad.transport.SearchTopAnomalyResultRequest;
@@ -59,7 +59,7 @@ public class RestSearchTopAnomalyResultAction extends BaseRestHandler {
 
         // Throw error if disabled
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
 
         // Get the typed request
@@ -75,7 +75,7 @@ public class RestSearchTopAnomalyResultAction extends BaseRestHandler {
         if (request.hasParam(RestHandlerUtils.DETECTOR_ID)) {
             detectorId = request.param(RestHandlerUtils.DETECTOR_ID);
         } else {
-            throw new IllegalStateException(CommonErrorMessages.AD_ID_MISSING_MSG);
+            throw new IllegalStateException(ADCommonMessages.AD_ID_MISSING_MSG);
         }
         boolean historical = request.paramAsBoolean("historical", false);
         XContentParser parser = request.contentParser();

--- a/src/main/java/org/opensearch/ad/rest/RestStatsAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestStatsAnomalyDetectorAction.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.settings.EnabledSetting;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.transport.ADStatsRequest;
@@ -65,7 +65,7 @@ public class RestStatsAnomalyDetectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
         ADStatsRequest adStatsRequest = getRequest(request);
         return channel -> client.execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest, new RestToXContentListener<>(channel));

--- a/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestValidateAnomalyDetectorAction.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.common.exception.ADValidationException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorValidationIssue;
 import org.opensearch.ad.model.ValidationAspect;
@@ -104,7 +104,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+            throw new IllegalStateException(ADCommonMessages.DISABLED_ERR_MSG);
         }
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
@@ -113,7 +113,7 @@ public class RestValidateAnomalyDetectorAction extends AbstractAnomalyDetectorAc
         // if type param isn't blank and isn't a part of possible validation types throws exception
         if (!StringUtils.isBlank(typesStr)) {
             if (!validationTypesAreAccepted(typesStr)) {
-                throw new IllegalStateException(CommonErrorMessages.NOT_EXISTENT_VALIDATION_TYPE);
+                throw new IllegalStateException(ADCommonMessages.NOT_EXISTENT_VALIDATION_TYPE);
             }
         }
 

--- a/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/ModelValidationActionHandler.java
@@ -36,7 +36,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.common.exception.ADValidationException;
 import org.opensearch.ad.common.exception.EndRunException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorValidationIssueType;
@@ -76,6 +76,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.timeseries.constant.CommonMessages;
 
 /**
  * <p>This class executes all validation checks that are not blocking on the 'model' level.
@@ -275,7 +276,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.TIME_FIELD_NOT_ENOUGH_HISTORICAL_DATA,
+                        ADCommonMessages.TIME_FIELD_NOT_ENOUGH_HISTORICAL_DATA,
                         DetectorValidationIssueType.TIMEFIELD_FIELD,
                         ValidationAspect.MODEL
                     )
@@ -286,7 +287,7 @@ public class ModelValidationActionHandler {
         try {
             getBucketAggregates(timeRangeEnd, listener, topEntity);
         } catch (IOException e) {
-            listener.onFailure(new EndRunException(detector.getDetectorId(), CommonErrorMessages.INVALID_SEARCH_QUERY_MSG, e, true));
+            listener.onFailure(new EndRunException(detector.getDetectorId(), CommonMessages.INVALID_SEARCH_QUERY_MSG, e, true));
         }
     }
 
@@ -305,7 +306,7 @@ public class ModelValidationActionHandler {
                 listener
                     .onFailure(
                         new ADValidationException(
-                            CommonErrorMessages.CATEGORY_FIELD_TOO_SPARSE,
+                            ADCommonMessages.CATEGORY_FIELD_TOO_SPARSE,
                             DetectorValidationIssueType.CATEGORY,
                             ValidationAspect.MODEL
                         )
@@ -421,12 +422,12 @@ public class ModelValidationActionHandler {
                     listener
                         .onFailure(
                             new ADValidationException(
-                                CommonErrorMessages.TIMEOUT_ON_INTERVAL_REC,
+                                ADCommonMessages.TIMEOUT_ON_INTERVAL_REC,
                                 DetectorValidationIssueType.TIMEOUT,
                                 ValidationAspect.MODEL
                             )
                         );
-                    logger.info(CommonErrorMessages.TIMEOUT_ON_INTERVAL_REC);
+                    logger.info(ADCommonMessages.TIMEOUT_ON_INTERVAL_REC);
                     // keep trying higher intervals as new interval is below max, and we aren't decreasing yet
                 } else if (newIntervalMinute < MAX_INTERVAL_REC_LENGTH_IN_MINUTES && !decreasingInterval) {
                     searchWithDifferentInterval(newIntervalMinute);
@@ -507,7 +508,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.MODEL_VALIDATION_FAILED_UNEXPECTEDLY,
+                        ADCommonMessages.MODEL_VALIDATION_FAILED_UNEXPECTEDLY,
                         DetectorValidationIssueType.AGGREGATION,
                         ValidationAspect.MODEL
                     )
@@ -537,7 +538,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.DETECTOR_INTERVAL_REC + interval.getInterval(),
+                        ADCommonMessages.DETECTOR_INTERVAL_REC + interval.getInterval(),
                         DetectorValidationIssueType.DETECTION_INTERVAL,
                         ValidationAspect.MODEL,
                         interval
@@ -590,7 +591,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.MODEL_VALIDATION_FAILED_UNEXPECTEDLY,
+                        ADCommonMessages.MODEL_VALIDATION_FAILED_UNEXPECTEDLY,
                         DetectorValidationIssueType.AGGREGATION,
                         ValidationAspect.MODEL
                     )
@@ -615,7 +616,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.RAW_DATA_TOO_SPARSE,
+                        ADCommonMessages.RAW_DATA_TOO_SPARSE,
                         DetectorValidationIssueType.INDICES,
                         ValidationAspect.MODEL
                     )
@@ -657,7 +658,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.FILTER_QUERY_TOO_SPARSE,
+                        ADCommonMessages.FILTER_QUERY_TOO_SPARSE,
                         DetectorValidationIssueType.FILTER_QUERY,
                         ValidationAspect.MODEL
                     )
@@ -722,7 +723,7 @@ public class ModelValidationActionHandler {
             listener
                 .onFailure(
                     new ADValidationException(
-                        CommonErrorMessages.CATEGORY_FIELD_TOO_SPARSE,
+                        ADCommonMessages.CATEGORY_FIELD_TOO_SPARSE,
                         DetectorValidationIssueType.CATEGORY,
                         ValidationAspect.MODEL
                     )
@@ -753,7 +754,7 @@ public class ModelValidationActionHandler {
             new MultiResponsesDelegateActionListener<>(
                 validateFeatureQueriesListener,
                 anomalyDetector.getFeatureAttributes().size(),
-                CommonErrorMessages.FEATURE_QUERY_TOO_SPARSE,
+                ADCommonMessages.FEATURE_QUERY_TOO_SPARSE,
                 false
             );
 
@@ -780,7 +781,7 @@ public class ModelValidationActionHandler {
                     multiFeatureQueriesResponseListener
                         .onFailure(
                             new ADValidationException(
-                                CommonErrorMessages.FEATURE_QUERY_TOO_SPARSE,
+                                ADCommonMessages.FEATURE_QUERY_TOO_SPARSE,
                                 DetectorValidationIssueType.FEATURE_ATTRIBUTES,
                                 ValidationAspect.MODEL
                             )
@@ -792,7 +793,7 @@ public class ModelValidationActionHandler {
             }, e -> {
                 logger.error(e);
                 multiFeatureQueriesResponseListener
-                    .onFailure(new OpenSearchStatusException(CommonErrorMessages.FEATURE_QUERY_TOO_SPARSE, RestStatus.BAD_REQUEST, e));
+                    .onFailure(new OpenSearchStatusException(ADCommonMessages.FEATURE_QUERY_TOO_SPARSE, RestStatus.BAD_REQUEST, e));
             });
             // using the original context in listener as user roles have no permissions for internal operations like fetching a
             // checkpoint
@@ -812,7 +813,7 @@ public class ModelValidationActionHandler {
         listener
             .onFailure(
                 new ADValidationException(
-                    String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, minutesSinceLastStamp, minutesSinceLastStamp),
+                    String.format(Locale.ROOT, ADCommonMessages.WINDOW_DELAY_REC, minutesSinceLastStamp, minutesSinceLastStamp),
                     DetectorValidationIssueType.WINDOW_DELAY,
                     ValidationAspect.MODEL,
                     new IntervalTimeConfiguration(minutesSinceLastStamp, ChronoUnit.MINUTES)
@@ -836,17 +837,13 @@ public class ModelValidationActionHandler {
         // we have no more insight regarding the root cause of the lower density.
         listener
             .onFailure(
-                new ADValidationException(
-                    CommonErrorMessages.RAW_DATA_TOO_SPARSE,
-                    DetectorValidationIssueType.INDICES,
-                    ValidationAspect.MODEL
-                )
+                new ADValidationException(ADCommonMessages.RAW_DATA_TOO_SPARSE, DetectorValidationIssueType.INDICES, ValidationAspect.MODEL)
             );
     }
 
     private LongBounds getTimeRangeBounds(long endMillis, IntervalTimeConfiguration detectorIntervalInMinutes) {
         Long detectorInterval = timeConfigToMilliSec(detectorIntervalInMinutes);
-        Long startMillis = endMillis - ((long) getNumberOfSamples() * detectorInterval);
+        Long startMillis = endMillis - (getNumberOfSamples() * detectorInterval);
         return new LongBounds(startMillis, endMillis);
     }
 

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -13,9 +13,9 @@ package org.opensearch.ad.task;
 
 import static org.opensearch.ad.AnomalyDetectorPlugin.AD_BATCH_TASK_THREAD_POOL_NAME;
 import static org.opensearch.ad.breaker.MemoryCircuitBreaker.DEFAULT_JVM_HEAP_USAGE_THRESHOLD;
+import static org.opensearch.ad.constant.ADCommonMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
 import static org.opensearch.ad.constant.ADCommonName.AGG_NAME_MAX_TIME;
 import static org.opensearch.ad.constant.ADCommonName.AGG_NAME_MIN_TIME;
-import static org.opensearch.ad.constant.CommonErrorMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
 import static org.opensearch.ad.model.ADTask.CURRENT_PIECE_FIELD;
 import static org.opensearch.ad.model.ADTask.EXECUTION_END_TIME_FIELD;
 import static org.opensearch.ad.model.ADTask.INIT_PROGRESS_FIELD;
@@ -60,7 +60,7 @@ import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.feature.SinglePointFeatures;
@@ -873,7 +873,7 @@ public class ADBatchTaskRunner {
 
     private void checkADPluginEnabled(String detectorId) {
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new EndRunException(detectorId, CommonErrorMessages.DISABLED_ERR_MSG, true).countedInStats(false);
+            throw new EndRunException(detectorId, ADCommonMessages.DISABLED_ERR_MSG, true).countedInStats(false);
         }
     }
 

--- a/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskCacheManager.java
@@ -12,8 +12,8 @@
 package org.opensearch.ad.task;
 
 import static org.opensearch.ad.MemoryTracker.Origin.HISTORICAL_SINGLE_ENTITY_DETECTOR;
-import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
-import static org.opensearch.ad.constant.CommonErrorMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
+import static org.opensearch.ad.constant.ADCommonMessages.DETECTOR_IS_RUNNING;
+import static org.opensearch.ad.constant.ADCommonMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CACHED_DELETED_TASKS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_TREES;

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -13,14 +13,12 @@ package org.opensearch.ad.task;
 
 import static org.opensearch.action.DocWriteResponse.Result.CREATED;
 import static org.opensearch.ad.AnomalyDetectorPlugin.AD_BATCH_TASK_THREAD_POOL_NAME;
+import static org.opensearch.ad.constant.ADCommonMessages.CAN_NOT_FIND_LATEST_TASK;
+import static org.opensearch.ad.constant.ADCommonMessages.DETECTOR_IS_RUNNING;
+import static org.opensearch.ad.constant.ADCommonMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
+import static org.opensearch.ad.constant.ADCommonMessages.HC_DETECTOR_TASK_IS_UPDATING;
+import static org.opensearch.ad.constant.ADCommonMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
 import static org.opensearch.ad.constant.ADCommonName.DETECTION_STATE_INDEX;
-import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_LATEST_TASK;
-import static org.opensearch.ad.constant.CommonErrorMessages.CREATE_INDEX_NOT_ACKNOWLEDGED;
-import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
-import static org.opensearch.ad.constant.CommonErrorMessages.EXCEED_HISTORICAL_ANALYSIS_LIMIT;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
-import static org.opensearch.ad.constant.CommonErrorMessages.HC_DETECTOR_TASK_IS_UPDATING;
-import static org.opensearch.ad.constant.CommonErrorMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
 import static org.opensearch.ad.indices.AnomalyDetectionIndices.ALL_AD_RESULTS_INDEX_PATTERN;
 import static org.opensearch.ad.model.ADTask.COORDINATING_NODE_FIELD;
 import static org.opensearch.ad.model.ADTask.DETECTOR_ID_FIELD;
@@ -58,6 +56,8 @@ import static org.opensearch.ad.util.ParseUtils.isNullOrEmpty;
 import static org.opensearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static org.opensearch.ad.util.RestHandlerUtils.createXContentParserFromRegistry;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.timeseries.constant.CommonMessages.CREATE_INDEX_NOT_ACKNOWLEDGED;
+import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -296,7 +296,7 @@ public class ADTaskManager {
 
         getDetector(detectorId, (detector) -> {
             if (!detector.isPresent()) {
-                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, RestStatus.NOT_FOUND));
+                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_CONFIG_MSG + detectorId, RestStatus.NOT_FOUND));
                 return;
             }
 
@@ -836,7 +836,7 @@ public class ADTaskManager {
     ) {
         getDetector(detectorId, (detector) -> {
             if (!detector.isPresent()) {
-                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, RestStatus.NOT_FOUND));
+                listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_CONFIG_MSG + detectorId, RestStatus.NOT_FOUND));
                 return;
             }
             if (historical) {

--- a/src/main/java/org/opensearch/ad/transport/ADCancelTaskRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ADCancelTaskRequest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
@@ -56,7 +56,7 @@ public class ADCancelTaskRequest extends BaseNodesRequest<ADCancelTaskRequest> {
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(detectorId)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.HISTORICAL_ANALYSIS_CANCELLED;
+import static org.opensearch.ad.constant.ADCommonMessages.HISTORICAL_ANALYSIS_CANCELLED;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileRequest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
@@ -41,7 +41,7 @@ public class ADTaskProfileRequest extends BaseNodesRequest<ADTaskProfileRequest>
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(detectorId)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_START_DETECTOR;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_STOP_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_START_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_STOP_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultRequest.java
@@ -20,8 +20,8 @@ import java.util.Locale;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
 import org.opensearch.common.io.stream.OutputStreamStreamOutput;
@@ -29,6 +29,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 
 public class AnomalyResultRequest extends ActionRequest implements ToXContentObject {
@@ -75,11 +76,11 @@ public class AnomalyResultRequest extends ActionRequest implements ToXContentObj
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (start <= 0 || end <= 0 || start > end) {
             validationException = addValidationError(
-                String.format(Locale.ROOT, "%s: start %d, end %d", CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG, start, end),
+                String.format(Locale.ROOT, "%s: start %d, end %d", CommonMessages.INVALID_TIMESTAMP_ERR_MSG, start, end),
                 validationException
             );
         }

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorRequest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -50,7 +50,7 @@ public class DeleteAnomalyDetectorRequest extends ActionRequest {
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(detectorID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_DELETE_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_DELETE_DETECTOR;
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_DELETE_AD_RESULT;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_DELETE_AD_RESULT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;

--- a/src/main/java/org/opensearch/ad/transport/DeleteModelRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteModelRequest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
@@ -61,7 +61,7 @@ public class DeleteModelRequest extends BaseNodesRequest<DeleteModelRequest> imp
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/EntityProfileRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityProfileRequest.java
@@ -19,8 +19,8 @@ import java.util.Set;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
 import org.opensearch.common.Strings;
@@ -86,13 +86,13 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (entityValue == null) {
             validationException = addValidationError("Entity value is missing", validationException);
         }
         if (profilesToCollect == null || profilesToCollect.isEmpty()) {
-            validationException = addValidationError(CommonErrorMessages.EMPTY_PROFILES_COLLECT, validationException);
+            validationException = addValidationError(ADCommonMessages.EMPTY_PROFILES_COLLECT, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultRequest.java
@@ -21,14 +21,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 
 public class EntityResultRequest extends ActionRequest implements ToXContentObject {
@@ -91,11 +92,11 @@ public class EntityResultRequest extends ActionRequest implements ToXContentObje
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(detectorId)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (start <= 0 || end <= 0 || start > end) {
             validationException = addValidationError(
-                String.format(Locale.ROOT, "%s: start %d, end %d", CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG, start, end),
+                String.format(Locale.ROOT, "%s: start %d, end %d", CommonMessages.INVALID_TIMESTAMP_ERR_MSG, start, end),
                 validationException
             );
         }

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -34,7 +34,6 @@ import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.indices.ADIndex;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.ml.EntityModel;
@@ -57,6 +56,7 @@ import org.opensearch.ad.util.ParseUtils;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.transport.TransportService;
 
@@ -128,8 +128,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
     protected void doExecute(Task task, EntityResultRequest request, ActionListener<AcknowledgedResponse> listener) {
         if (adCircuitBreakerService.isOpen()) {
             threadPool.executor(AnomalyDetectorPlugin.AD_THREAD_POOL_NAME).execute(() -> cache.get().releaseMemoryForOpenCircuitBreaker());
-            listener
-                .onFailure(new LimitExceededException(request.getDetectorId(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG, false));
+            listener.onFailure(new LimitExceededException(request.getDetectorId(), CommonMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG, false));
             return;
         }
 

--- a/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
@@ -21,7 +21,7 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.common.exception.ADVersionException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.ADTaskAction;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -154,15 +154,15 @@ public class ForwardADTaskRequest extends ActionRequest {
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (detector == null) {
-            validationException = addValidationError(CommonErrorMessages.DETECTOR_MISSING, validationException);
+            validationException = addValidationError(ADCommonMessages.DETECTOR_MISSING, validationException);
         } else if (detector.getDetectorId() == null) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (adTaskAction == null) {
-            validationException = addValidationError(CommonErrorMessages.AD_TASK_ACTION_MISSING, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_TASK_ACTION_MISSING, validationException);
         }
         if (adTaskAction == ADTaskAction.CLEAN_STALE_RUNNING_ENTITIES && (staleRunningEntities == null || staleRunningEntities.isEmpty())) {
-            validationException = addValidationError(CommonErrorMessages.EMPTY_STALE_RUNNING_ENTITIES, validationException);
+            validationException = addValidationError(ADCommonMessages.EMPTY_STALE_RUNNING_ENTITIES, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -11,8 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_GET_DETECTOR;
 import static org.opensearch.ad.model.ADTaskType.ALL_DETECTOR_TASK_TYPES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;
@@ -20,6 +19,7 @@ import static org.opensearch.ad.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.ad.util.RestHandlerUtils.PROFILE;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -305,7 +305,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                 for (MultiGetItemResponse response : responses) {
                     if (CommonName.CONFIG_INDEX.equals(response.getIndex())) {
                         if (response.getResponse() == null || !response.getResponse().isExists()) {
-                            listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_DETECTOR_MSG + detectorId, RestStatus.NOT_FOUND));
+                            listener.onFailure(new OpenSearchStatusException(FAIL_TO_FIND_CONFIG_MSG + detectorId, RestStatus.NOT_FOUND));
                             return;
                         }
                         id = response.getId();

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_CREATE_DETECTOR;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_UPDATE_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_CREATE_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_UPDATE_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.ad.util.ParseUtils.getDetector;

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_PREVIEW_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_PREVIEW_DETECTOR;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CONCURRENT_PREVIEW;
@@ -39,7 +39,7 @@ import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.ClientException;
 import org.opensearch.ad.common.exception.LimitExceededException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
@@ -55,6 +55,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.transport.TransportService;
 
@@ -127,13 +128,12 @@ public class PreviewAnomalyDetectorTransportAction extends
         ActionListener<PreviewAnomalyDetectorResponse> listener
     ) {
         if (adCircuitBreakerService.isOpen()) {
-            listener
-                .onFailure(new LimitExceededException(request.getDetectorId(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG, false));
+            listener.onFailure(new LimitExceededException(request.getDetectorId(), CommonMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG, false));
             return;
         }
         try {
             if (!lock.tryAcquire()) {
-                listener.onFailure(new ClientException(request.getDetectorId(), CommonErrorMessages.REQUEST_THROTTLED_MSG));
+                listener.onFailure(new ClientException(request.getDetectorId(), ADCommonMessages.REQUEST_THROTTLED_MSG));
                 return;
             }
 

--- a/src/main/java/org/opensearch/ad/transport/RCFPollingRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/RCFPollingRequest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -52,7 +52,7 @@ public class RCFPollingRequest extends ActionRequest implements ToXContentObject
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/RCFResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/RCFResultRequest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -82,10 +82,10 @@ public class RCFResultRequest extends ActionRequest implements ToXContentObject 
             validationException = addValidationError(RCFResultRequest.INVALID_FEATURE_MSG, validationException);
         }
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (Strings.isEmpty(modelID)) {
-            validationException = addValidationError(CommonErrorMessages.MODEL_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.MODEL_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/RCFResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/RCFResultTransportAction.java
@@ -24,12 +24,12 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.LimitExceededException;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.tasks.Task;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.transport.TransportService;
 
@@ -60,7 +60,7 @@ public class RCFResultTransportAction extends HandledTransportAction<RCFResultRe
     @Override
     protected void doExecute(Task task, RCFResultRequest request, ActionListener<RCFResultResponse> listener) {
         if (adCircuitBreakerService.isOpen()) {
-            listener.onFailure(new LimitExceededException(request.getAdID(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
+            listener.onFailure(new LimitExceededException(request.getAdID(), CommonMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
             return;
         }
         Optional<DiscoveryNode> remoteNode = hashRing.getNodeByAddress(request.remoteAddress());

--- a/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_DETECTOR_INFO;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_GET_DETECTOR_INFO;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_STATS;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_GET_STATS;
 import static org.opensearch.ad.util.RestHandlerUtils.wrapRestActionListener;
 
 import java.util.HashMap;

--- a/src/main/java/org/opensearch/ad/transport/StopDetectorRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/StopDetectorRequest.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
 import org.opensearch.common.io.stream.OutputStreamStreamOutput;
@@ -64,7 +64,7 @@ public class StopDetectorRequest extends ActionRequest implements ToXContentObje
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/opensearch/ad/transport/StopDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StopDetectorTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_STOP_DETECTOR;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_STOP_DETECTOR;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/opensearch/ad/transport/ThresholdResultRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ThresholdResultRequest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -73,10 +73,10 @@ public class ThresholdResultRequest extends ActionRequest implements ToXContentO
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (Strings.isEmpty(adID)) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (Strings.isEmpty(modelID)) {
-            validationException = addValidationError(CommonErrorMessages.MODEL_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.MODEL_ID_MISSING_MSG, validationException);
         }
 
         return validationException;

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -28,7 +28,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.common.exception.ADValidationException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.feature.SearchFeatureDao;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -244,7 +244,7 @@ public class ValidateAnomalyDetectorTransportAction extends
                 // the user as a response indicating index doesn't exist
                 DetectorValidationIssue issue = parseADValidationException(
                     new ADValidationException(
-                        CommonErrorMessages.INDEX_NOT_FOUND,
+                        ADCommonMessages.INDEX_NOT_FOUND,
                         DetectorValidationIssueType.INDICES,
                         ValidationAspect.DETECTOR
                     )

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport.handler;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_SEARCH;
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_SEARCH;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.ad.util.ParseUtils.getUserContext;

--- a/src/main/java/org/opensearch/ad/transport/handler/AnomalyIndexHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/AnomalyIndexHandler.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.ad.transport.handler;
 
-import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_RESULT_INDEX;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.timeseries.constant.CommonMessages.CAN_NOT_FIND_RESULT_INDEX;
 
 import java.util.Iterator;
 import java.util.Locale;

--- a/src/main/java/org/opensearch/ad/transport/handler/AnomalyResultBulkIndexHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/AnomalyResultBulkIndexHandler.java
@@ -12,8 +12,8 @@
 package org.opensearch.ad.transport.handler;
 
 import static org.opensearch.ad.constant.ADCommonName.ANOMALY_RESULT_INDEX_ALIAS;
-import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_RESULT_INDEX;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.timeseries.constant.CommonMessages.CAN_NOT_FIND_RESULT_INDEX;
 
 import java.util.List;
 

--- a/src/main/java/org/opensearch/ad/util/ClientUtil.java
+++ b/src/main/java/org/opensearch/ad/util/ClientUtil.java
@@ -39,7 +39,6 @@ import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.client.Client;
 import org.opensearch.common.inject.Inject;
@@ -50,6 +49,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskId;
 import org.opensearch.tasks.TaskInfo;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 
 public class ClientUtil {
     private volatile TimeValue requestTimeout;
@@ -104,7 +104,7 @@ public class ClientUtil {
             }
             return Optional.ofNullable(respReference.get());
         } catch (InterruptedException e1) {
-            LOG.error(CommonErrorMessages.WAIT_ERR_MSG);
+            LOG.error(CommonMessages.WAIT_ERR_MSG);
             throw new IllegalStateException(e1);
         }
     }
@@ -226,7 +226,7 @@ public class ClientUtil {
             }
             return Optional.ofNullable(respReference.get());
         } catch (InterruptedException e1) {
-            LOG.error(CommonErrorMessages.WAIT_ERR_MSG);
+            LOG.error(CommonMessages.WAIT_ERR_MSG);
             throw new IllegalStateException(e1);
         }
     }

--- a/src/main/java/org/opensearch/ad/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/ad/util/ParseUtils.java
@@ -11,18 +11,18 @@
 
 package org.opensearch.ad.util;
 
+import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_GET_USER_INFO;
+import static org.opensearch.ad.constant.ADCommonMessages.NO_PERMISSION_TO_ACCESS_DETECTOR;
 import static org.opensearch.ad.constant.ADCommonName.DATE_HISTOGRAM;
 import static org.opensearch.ad.constant.ADCommonName.EPOCH_MILLIS_FORMAT;
 import static org.opensearch.ad.constant.ADCommonName.FEATURE_AGGS;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_GET_USER_INFO;
-import static org.opensearch.ad.constant.CommonErrorMessages.NO_PERMISSION_TO_ACCESS_DETECTOR;
 import static org.opensearch.ad.model.AnomalyDetector.QUERY_PARAM_PERIOD_END;
 import static org.opensearch.ad.model.AnomalyDetector.QUERY_PARAM_PERIOD_START;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PIECE_SIZE;
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.search.aggregations.AggregationBuilders.dateRange;
 import static org.opensearch.search.aggregations.AggregatorFactories.VALID_AGG_NAME;
+import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -570,7 +570,7 @@ public final class ParseUtils {
                 listener.onFailure(new AnomalyDetectionException(FAIL_TO_GET_USER_INFO + detectorId));
             }
         } else {
-            listener.onFailure(new ResourceNotFoundException(detectorId, FAIL_TO_FIND_DETECTOR_MSG + detectorId));
+            listener.onFailure(new ResourceNotFoundException(detectorId, FAIL_TO_FIND_CONFIG_MSG + detectorId));
         }
     }
 

--- a/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/ad/util/RestHandlerUtils.java
@@ -28,7 +28,7 @@ import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.Feature;
 import org.opensearch.common.Nullable;
@@ -170,7 +170,7 @@ public final class RestHandlerUtils {
             errorMsgBuilder.append(". ");
         }
         if (duplicateFeatureAggNames.size() > 0) {
-            errorMsgBuilder.append(CommonErrorMessages.DUPLICATE_FEATURE_AGGREGATION_NAMES);
+            errorMsgBuilder.append(ADCommonMessages.DUPLICATE_FEATURE_AGGREGATION_NAMES);
             errorMsgBuilder.append(String.join(", ", duplicateFeatureAggNames));
         }
         return errorMsgBuilder.toString();

--- a/src/main/java/org/opensearch/forecast/constant/ForecastCommonMessages.java
+++ b/src/main/java/org/opensearch/forecast/constant/ForecastCommonMessages.java
@@ -45,7 +45,6 @@ public class ForecastCommonMessages {
     // ======================================
     // Used for custom forecast result index
     // ======================================
-    public static String CAN_NOT_FIND_RESULT_INDEX = "Can't find result index ";
     public static String INVALID_RESULT_INDEX_PREFIX = "Result index must start with " + CUSTOM_RESULT_INDEX_PREFIX;
     public static String INVALID_CHAR_IN_RESULT_INDEX_NAME =
         "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";

--- a/src/main/java/org/opensearch/forecast/constant/ForecastCommonMessages.java
+++ b/src/main/java/org/opensearch/forecast/constant/ForecastCommonMessages.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast.constant;
+
+import static org.opensearch.forecast.constant.ForecastCommonName.CUSTOM_RESULT_INDEX_PREFIX;
+
+public class ForecastCommonMessages {
+    // ======================================
+    // Validation message
+    // ======================================
+    public static String INVALID_FORECAST_INTERVAL = "Forecast interval must be a positive integer";
+    public static String NULL_FORECAST_INTERVAL = "Forecast interval should be set";
+    public static String INVALID_FORECASTER_NAME =
+        "Valid characters for forecaster name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
+
+    // ======================================
+    // Resource constraints
+    // ======================================
+    public static final String DISABLED_ERR_MSG = "Forecast functionality is disabled. To enable update plugins.forecast.enabled to true";
+
+    // ======================================
+    // RESTful API
+    // ======================================
+    public static String FAIL_TO_CREATE_FORECASTER = "Fail to create forecaster";
+    public static String FAIL_TO_UPDATE_FORECASTER = "Fail to update forecaster";
+    public static String FAIL_TO_FIND_FORECASTER_MSG = "Can't find forecaster with id: ";
+    public static final String FORECASTER_ID_MISSING_MSG = "Forecaster ID is missing";
+    public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
+
+    // ======================================
+    // Security
+    // ======================================
+    public static String NO_PERMISSION_TO_ACCESS_FORECASTER = "User does not have permissions to access forecaster: ";
+    public static String FAIL_TO_GET_USER_INFO = "Unable to get user information from forecaster ";
+
+    // ======================================
+    // Used for custom forecast result index
+    // ======================================
+    public static String CAN_NOT_FIND_RESULT_INDEX = "Can't find result index ";
+    public static String INVALID_RESULT_INDEX_PREFIX = "Result index must start with " + CUSTOM_RESULT_INDEX_PREFIX;
+    public static String INVALID_CHAR_IN_RESULT_INDEX_NAME =
+        "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";
+
+    // ======================================
+    // Task
+    // ======================================
+    public static String FORECASTER_IS_RUNNING = "Forecaster is already running";
+
+    // ======================================
+    // transport
+    // ======================================
+    public static final String FORECAST_ID_MISSING_MSG = "forecaster ID is missing";
+}

--- a/src/main/java/org/opensearch/forecast/constant/ForecastCommonMessages.java
+++ b/src/main/java/org/opensearch/forecast/constant/ForecastCommonMessages.java
@@ -30,9 +30,9 @@ public class ForecastCommonMessages {
     // ======================================
     // RESTful API
     // ======================================
-    public static String FAIL_TO_CREATE_FORECASTER = "Fail to create forecaster";
-    public static String FAIL_TO_UPDATE_FORECASTER = "Fail to update forecaster";
-    public static String FAIL_TO_FIND_FORECASTER_MSG = "Can't find forecaster with id: ";
+    public static String FAIL_TO_CREATE_FORECASTER = "Failed to create forecaster";
+    public static String FAIL_TO_UPDATE_FORECASTER = "Failed to update forecaster";
+    public static String FAIL_TO_FIND_FORECASTER_MSG = "Can not find forecaster with id: ";
     public static final String FORECASTER_ID_MISSING_MSG = "Forecaster ID is missing";
     public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
 

--- a/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
@@ -27,11 +27,13 @@ public class CommonMessages {
         return String.format(Locale.ROOT, CommonMessages.TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT, limit);
     }
 
-    public static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT = "We can have only %d categorical field/s.";
+    public static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT =
+        "Currently we only support up to %d categorical field/s in order to bound system resource consumption.";
+
     public static String CAN_NOT_FIND_RESULT_INDEX = "Can't find result index ";
     public static String INVALID_CHAR_IN_RESULT_INDEX_NAME =
         "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";
-    public static String FAIL_TO_VALIDATE = "fail to validate";
+    public static String FAIL_TO_VALIDATE = "failed to validate";
     public static String INVALID_TIMESTAMP = "Timestamp field: (%s) must be of type date";
     public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping";
     public static String INVALID_NAME = "Valid characters for name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
@@ -50,14 +52,14 @@ public class CommonMessages {
     // ======================================
     // Index message
     // ======================================
-    public static final String CREATE_INDEX_NOT_ACKNOWLEDGED = "Create index %S not acknowledged";
+    public static final String CREATE_INDEX_NOT_ACKNOWLEDGED = "Create index %S not acknowledged by OpenSearch core";
     public static final String SUCCESS_SAVING_RESULT_MSG = "Result saved successfully.";
     public static final String CANNOT_SAVE_RESULT_ERR_MSG = "Cannot save results due to write block.";
 
     // ======================================
     // Resource constraints
     // ======================================
-    public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
+    public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is open due to excessive memory consumption.";
 
     // ======================================
     // Transport

--- a/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.constant;
+
+import java.util.Locale;
+
+public class CommonMessages {
+    // ======================================
+    // Validation message
+    // ======================================
+    public static String NEGATIVE_TIME_CONFIGURATION = "should be non-negative";
+    public static String INVALID_RESULT_INDEX_MAPPING = "Result index mapping is not correct for index: ";
+    public static String EMPTY_NAME = "name should be set";
+    public static String NULL_TIME_FIELD = "Time field should be set";
+    public static String EMPTY_INDICES = "Indices should be set";
+
+    public static String getTooManyCategoricalFieldErr(int limit) {
+        return String.format(Locale.ROOT, CommonMessages.TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT, limit);
+    }
+
+    public static final String TOO_MANY_CATEGORICAL_FIELD_ERR_MSG_FORMAT = "We can have only %d categorical field/s.";
+    public static String CAN_NOT_FIND_RESULT_INDEX = "Can't find result index ";
+    public static String INVALID_CHAR_IN_RESULT_INDEX_NAME =
+        "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";
+    public static String FAIL_TO_VALIDATE = "fail to validate";
+    public static String INVALID_TIMESTAMP = "Timestamp field: (%s) must be of type date";
+    public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping";
+    public static String INVALID_NAME = "Valid characters for name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
+    // change this error message to make it compatible with old version's integration(nexus) test
+    public static String FAIL_TO_FIND_CONFIG_MSG = "Can't find config with id: ";
+    public static final String CAN_NOT_CHANGE_CATEGORY_FIELD = "Can't change category field";
+    public static final String CAN_NOT_CHANGE_CUSTOM_RESULT_INDEX = "Can't change custom result index";
+    public static final String CATEGORICAL_FIELD_TYPE_ERR_MSG = "A categorical field must be of type keyword or ip.";
+    // Modifying message for FEATURE below may break the parseADValidationException method of ValidateAnomalyDetectorTransportAction
+    public static final String FEATURE_INVALID_MSG_PREFIX = "Feature has an invalid query";
+    public static final String FEATURE_WITH_EMPTY_DATA_MSG = FEATURE_INVALID_MSG_PREFIX + " returning empty aggregated data: ";
+    public static final String FEATURE_WITH_INVALID_QUERY_MSG = FEATURE_INVALID_MSG_PREFIX + " causing a runtime exception: ";
+    public static final String UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG =
+        "Feature has an unknown exception caught while executing the feature query: ";
+
+    // ======================================
+    // Index message
+    // ======================================
+    public static final String CREATE_INDEX_NOT_ACKNOWLEDGED = "Create index %S not acknowledged";
+    public static final String SUCCESS_SAVING_RESULT_MSG = "Result saved successfully.";
+    public static final String CANNOT_SAVE_RESULT_ERR_MSG = "Cannot save results due to write block.";
+
+    // ======================================
+    // Resource constraints
+    // ======================================
+    public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
+
+    // ======================================
+    // Transport
+    // ======================================
+    public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
+
+    // ======================================
+    // transport/restful client
+    // ======================================
+    public static final String WAIT_ERR_MSG = "Exception in waiting for result";
+    public static final String ALL_FEATURES_DISABLED_ERR_MSG =
+        "Having trouble querying data because all of your features have been disabled.";
+    // We need this invalid query tag to show proper error message on frontend
+    // refer to AD Dashboard code: https://tinyurl.com/8b5n8hat
+    public static final String INVALID_SEARCH_QUERY_MSG = "Invalid search query.";
+    public static final String NO_REQUESTS_ADDED_ERR = "no requests added";
+
+    // ======================================
+    // rate limiting worker
+    // ======================================
+    public static final String BUG_RESPONSE = "We might have bugs.";
+    public static final String MEMORY_LIMIT_EXCEEDED_ERR_MSG = "AD models memory usage exceeds our limit.";
+
+}

--- a/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
@@ -59,7 +59,8 @@ public class CommonMessages {
     // ======================================
     // Resource constraints
     // ======================================
-    public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is open due to excessive memory consumption.";
+    public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG =
+        "The total OpenSearch memory usage exceeds our threshold, opening the AD memory circuit.";
 
     // ======================================
     // Transport

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -41,7 +41,6 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
@@ -64,6 +63,7 @@ import org.opensearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.transport.RemoteTransportException;
 
@@ -200,7 +200,7 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
             assertTrue("Should not reach here", false);
             inProgressLatch.countDown();
         }, exception -> {
-            assertTrue(exception.getMessage().contains(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG));
+            assertTrue(exception.getMessage().contains(CommonMessages.FAIL_TO_FIND_CONFIG_MSG));
             inProgressLatch.countDown();
         }), stateNError);
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
@@ -571,7 +571,7 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
             assertTrue("Should not reach here ", false);
             inProgressLatch.countDown();
         }, exception -> {
-            assertTrue(exception.getMessage().contains(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG));
+            assertTrue(exception.getMessage().contains(CommonMessages.FAIL_TO_FIND_CONFIG_MSG));
             inProgressLatch.countDown();
         }), stateInitProgress);
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));

--- a/src/test/java/org/opensearch/ad/EntityProfileRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/EntityProfileRunnerTests.java
@@ -32,8 +32,8 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorJob;
 import org.opensearch.ad.model.Entity;
@@ -304,7 +304,7 @@ public class EntityProfileRunnerTests extends AbstractADTest {
             assertTrue("Should not reach here", false);
             inProgressLatch.countDown();
         }, exception -> {
-            assertTrue(exception.getMessage().contains(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
+            assertTrue(exception.getMessage().contains(ADCommonMessages.EMPTY_PROFILES_COLLECT));
             inProgressLatch.countDown();
         }));
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));

--- a/src/test/java/org/opensearch/ad/TestHelpers.java
+++ b/src/test/java/org/opensearch/ad/TestHelpers.java
@@ -57,8 +57,8 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.feature.Features;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
@@ -1504,7 +1504,7 @@ public class TestHelpers {
         DetectorValidationIssue issue = new DetectorValidationIssue(
             ValidationAspect.MODEL,
             DetectorValidationIssueType.DETECTION_INTERVAL,
-            CommonErrorMessages.DETECTOR_INTERVAL_REC + intervalRec,
+            ADCommonMessages.DETECTOR_INTERVAL_REC + intervalRec,
             null,
             new IntervalTimeConfiguration(intervalRec, ChronoUnit.MINUTES)
         );

--- a/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/DetectionResultEvalutationIT.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.opensearch.ad.TestHelpers;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
@@ -118,7 +118,7 @@ public class DetectionResultEvalutationIT extends AbstractSyntheticDataTest {
         Map<String, Map<String, String>> messageMap = (Map<String, Map<String, String>>) XContentMapValues
             .extractValue("model", responseMap);
         assertEquals(
-            CommonErrorMessages.DETECTOR_INTERVAL_REC + recDetectorIntervalMinutes,
+            ADCommonMessages.DETECTOR_INTERVAL_REC + recDetectorIntervalMinutes,
             messageMap.get("detection_interval").get("message")
         );
     }
@@ -158,7 +158,7 @@ public class DetectionResultEvalutationIT extends AbstractSyntheticDataTest {
         Map<String, Map<String, String>> messageMap = (Map<String, Map<String, String>>) XContentMapValues
             .extractValue("model", responseMap);
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.WINDOW_DELAY_REC, expectedWindowDelayMinutes, expectedWindowDelayMinutes),
+            String.format(Locale.ROOT, ADCommonMessages.WINDOW_DELAY_REC, expectedWindowDelayMinutes, expectedWindowDelayMinutes),
             messageMap.get("window_delay").get("message")
         );
     }

--- a/src/test/java/org/opensearch/ad/mock/transport/MockForwardADTaskRequest_1_0.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockForwardADTaskRequest_1_0.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -60,12 +60,12 @@ public class MockForwardADTaskRequest_1_0 extends ActionRequest {
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (detector == null) {
-            validationException = addValidationError(CommonErrorMessages.DETECTOR_MISSING, validationException);
+            validationException = addValidationError(ADCommonMessages.DETECTOR_MISSING, validationException);
         } else if (detector.getDetectorId() == null) {
-            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_ID_MISSING_MSG, validationException);
         }
         if (adTaskAction == null) {
-            validationException = addValidationError(CommonErrorMessages.AD_TASK_ACTION_MISSING, validationException);
+            validationException = addValidationError(ADCommonMessages.AD_TASK_ACTION_MISSING, validationException);
         }
         return validationException;
     }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -11,11 +11,10 @@
 
 package org.opensearch.ad.model;
 
+import static org.opensearch.ad.constant.ADCommonMessages.INVALID_RESULT_INDEX_PREFIX;
 import static org.opensearch.ad.constant.ADCommonName.CUSTOM_RESULT_INDEX_PREFIX;
-import static org.opensearch.ad.constant.CommonErrorMessages.INVALID_CHAR_IN_RESULT_INDEX_NAME;
-import static org.opensearch.ad.constant.CommonErrorMessages.INVALID_RESULT_INDEX_NAME_SIZE;
-import static org.opensearch.ad.constant.CommonErrorMessages.INVALID_RESULT_INDEX_PREFIX;
 import static org.opensearch.ad.model.AnomalyDetector.MAX_RESULT_INDEX_NAME_SIZE;
+import static org.opensearch.timeseries.constant.CommonMessages.INVALID_CHAR_IN_RESULT_INDEX_NAME;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -26,8 +25,8 @@ import java.util.concurrent.TimeUnit;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.common.exception.ADValidationException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContent;
@@ -261,7 +260,7 @@ public class AnomalyDetectorTests extends AbstractADTest {
             () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
         );
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIME_CONFIGURATION_UNITS, ChronoUnit.MILLIS),
+            String.format(Locale.ROOT, ADCommonMessages.INVALID_TIME_CONFIGURATION_UNITS, ChronoUnit.MILLIS),
             exception.getMessage()
         );
     }
@@ -280,7 +279,7 @@ public class AnomalyDetectorTests extends AbstractADTest {
             () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
         );
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIME_CONFIGURATION_UNITS, ChronoUnit.MILLIS),
+            String.format(Locale.ROOT, ADCommonMessages.INVALID_TIME_CONFIGURATION_UNITS, ChronoUnit.MILLIS),
             exception.getMessage()
         );
     }
@@ -631,7 +630,7 @@ public class AnomalyDetectorTests extends AbstractADTest {
         resultIndexNameBuilder.append("a");
 
         errorMessage = AnomalyDetector.validateResultIndex(resultIndexNameBuilder.toString());
-        assertEquals(INVALID_RESULT_INDEX_NAME_SIZE, errorMessage);
+        assertEquals(AnomalyDetector.INVALID_RESULT_INDEX_NAME_SIZE, errorMessage);
 
         errorMessage = AnomalyDetector.validateResultIndex(CUSTOM_RESULT_INDEX_PREFIX + "abc#");
         assertEquals(INVALID_CHAR_IN_RESULT_INDEX_NAME, errorMessage);

--- a/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/DetectorProfileTests.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.xcontent.XContentParser;
@@ -99,7 +99,7 @@ public class DetectorProfileTests extends OpenSearchTestCase {
         assertEquals("total_entities", DetectorProfileName.getName(ADCommonName.TOTAL_ENTITIES).getName());
         assertEquals("active_entities", DetectorProfileName.getName(ADCommonName.ACTIVE_ENTITIES).getName());
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> DetectorProfileName.getName("abc"));
-        assertEquals(exception.getMessage(), CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
+        assertEquals(exception.getMessage(), ADCommonMessages.UNSUPPORTED_PROFILE_TYPE);
     }
 
     public void testDetectorProfileSet() throws IllegalArgumentException {

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -12,9 +12,9 @@
 package org.opensearch.ad.rest;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
 import static org.opensearch.ad.rest.handler.AbstractAnomalyDetectorActionHandler.DUPLICATE_DETECTOR_MSG;
 import static org.opensearch.ad.rest.handler.AbstractAnomalyDetectorActionHandler.NO_DOCS_IN_USER_INDEX_MSG;
+import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -34,8 +34,8 @@ import org.junit.Assert;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.AnomalyDetectorRestTestCase;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.ad.model.AnomalyDetectorJob;
@@ -53,6 +53,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 
 import com.google.common.collect.ImmutableList;
@@ -178,7 +179,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
         Response response = TestHelpers
@@ -229,7 +230,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.CAN_NOT_CHANGE_CATEGORY_FIELD));
+        assertThat(ex.getMessage(), containsString(CommonMessages.CAN_NOT_CHANGE_CATEGORY_FIELD));
     }
 
     public void testGetAnomalyDetector() throws Exception {
@@ -238,7 +239,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, false);
 
         Exception ex = expectThrows(ResponseException.class, () -> getAnomalyDetector(detector.getDetectorId(), client()));
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -288,7 +289,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -454,7 +455,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -476,7 +477,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             ResponseException.class,
             () -> TestHelpers.makeRequest(client(), "GET", AnomalyDetectorPlugin.LEGACY_AD_BASE + "/stats", ImmutableMap.of(), "", null)
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -509,7 +510,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -646,7 +647,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -691,7 +692,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
         Response response = TestHelpers
@@ -859,7 +860,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
         Response startAdJobResponse = TestHelpers
@@ -909,7 +910,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                FAIL_TO_FIND_DETECTOR_MSG,
+                FAIL_TO_FIND_CONFIG_MSG,
                 () -> TestHelpers
                     .makeRequest(
                         client(),
@@ -950,7 +951,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     null
                 )
         );
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -1011,7 +1012,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                FAIL_TO_FIND_DETECTOR_MSG,
+                FAIL_TO_FIND_CONFIG_MSG,
                 () -> TestHelpers
                     .makeRequest(
                         client(),
@@ -1109,7 +1110,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, false);
 
         Exception ex = expectThrows(ResponseException.class, () -> getDetectorProfile(detector.getDetectorId()));
-        assertThat(ex.getMessage(), containsString(CommonErrorMessages.DISABLED_ERR_MSG));
+        assertThat(ex.getMessage(), containsString(ADCommonMessages.DISABLED_ERR_MSG));
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, true);
 
@@ -1291,7 +1292,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         Map<String, Map<String, String>> messageMap = (Map<String, Map<String, String>>) XContentMapValues
             .extractValue("detector", responseMap);
         assertEquals("Validation response returned", RestStatus.OK, TestHelpers.restStatus(resp));
-        assertEquals("time field missing", CommonErrorMessages.NULL_TIME_FIELD, messageMap.get("time_field").get("message"));
+        assertEquals("time field missing", CommonMessages.NULL_TIME_FIELD, messageMap.get("time_field").get("message"));
     }
 
     public void testValidateAnomalyDetectorWithIncorrectShingleSize() throws Exception {
@@ -1350,7 +1351,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                CommonErrorMessages.NOT_EXISTENT_VALIDATION_TYPE,
+                ADCommonMessages.NOT_EXISTENT_VALIDATION_TYPE,
                 () -> TestHelpers
                     .makeRequest(
                         client(),
@@ -1420,7 +1421,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Map<String, String>> messageMap = (Map<String, Map<String, String>>) XContentMapValues
             .extractValue("detector", responseMap);
-        assertEquals("invalid detector Name", CommonErrorMessages.INVALID_DETECTOR_NAME, messageMap.get("name").get("message"));
+        assertEquals("invalid detector Name", CommonMessages.INVALID_NAME, messageMap.get("name").get("message"));
     }
 
     public void testValidateAnomalyDetectorWithFeatureQueryReturningNoData() throws Exception {
@@ -1441,7 +1442,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             .extractValue("detector", responseMap);
         assertEquals(
             "empty data",
-            CommonErrorMessages.FEATURE_WITH_EMPTY_DATA_MSG + "f-empty",
+            CommonMessages.FEATURE_WITH_EMPTY_DATA_MSG + "f-empty",
             messageMap.get("feature_attributes").get("message")
         );
     }
@@ -1464,7 +1465,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             .extractValue("detector", responseMap);
         assertEquals(
             "runtime exception",
-            CommonErrorMessages.FEATURE_WITH_INVALID_QUERY_MSG + "non-numeric-feature",
+            CommonMessages.FEATURE_WITH_INVALID_QUERY_MSG + "non-numeric-feature",
             messageMap.get("feature_attributes").get("message")
         );
     }
@@ -1550,7 +1551,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                 searchTopAnomalyResults(detector.getDetectorId() + "-invalid", false, "{\"start_time_ms\":1, \"end_time_ms\":2}", client());
             }
         );
-        assertTrue(invalidDetectorIdException.getMessage().contains("Can't find detector with id"));
+        assertTrue(invalidDetectorIdException.getMessage().contains("Can't find config with id"));
 
         // Invalid order field
         Exception invalidOrderException = expectThrows(IOException.class, () -> {

--- a/src/test/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandlerTests.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.action.DocWriteResponse.Result.CREATED;
-import static org.opensearch.ad.constant.CommonErrorMessages.CAN_NOT_FIND_LATEST_TASK;
+import static org.opensearch.ad.constant.ADCommonMessages.CAN_NOT_FIND_LATEST_TASK;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,8 +39,8 @@ import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.mock.model.MockSimpleLog;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -342,7 +342,7 @@ public class IndexAnomalyDetectorJobActionHandlerTests extends OpenSearchTestCas
             Object[] args = invocation.getArguments();
             ActionListener<AnomalyResultResponse> listener = (ActionListener<AnomalyResultResponse>) args[2];
 
-            listener.onFailure(new InternalFailure(detectorId, CommonErrorMessages.NO_MODEL_ERR_MSG));
+            listener.onFailure(new InternalFailure(detectorId, ADCommonMessages.NO_MODEL_ERR_MSG));
 
             return null;
         }).when(client).execute(any(AnomalyResultAction.class), any(), any());

--- a/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskCacheManagerTests.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ad.MemoryTracker.Origin.HISTORICAL_SINGLE_ENTITY_DETECTOR;
-import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
+import static org.opensearch.ad.constant.ADCommonMessages.DETECTOR_IS_RUNNING;
 import static org.opensearch.ad.task.ADTaskCacheManager.TASK_RETRY_LIMIT;
 
 import java.io.IOException;

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -38,7 +38,6 @@ import static org.opensearch.ad.TestHelpers.randomIntervalTimeConfiguration;
 import static org.opensearch.ad.TestHelpers.randomUser;
 import static org.opensearch.ad.constant.ADCommonName.ANOMALY_RESULT_INDEX_ALIAS;
 import static org.opensearch.ad.constant.ADCommonName.DETECTION_STATE_INDEX;
-import static org.opensearch.ad.constant.CommonErrorMessages.CREATE_INDEX_NOT_ACKNOWLEDGED;
 import static org.opensearch.ad.model.Entity.createSingleAttributeEntity;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.DELETE_AD_RESULT_WHEN_DELETE_DETECTOR;
@@ -47,6 +46,7 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.timeseries.constant.CommonMessages.CREATE_INDEX_NOT_ACKNOWLEDGED;
 
 import java.io.IOException;
 import java.time.Instant;

--- a/src/test/java/org/opensearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
@@ -143,7 +143,7 @@ public class ADBatchAnomalyResultTransportActionTests extends HistoricalAnalysis
                 ImmutableList.of(NotSerializableExceptionWrapper.class, EndRunException.class),
                 () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(10000)
             );
-            assertTrue(exception.getMessage(), exception.getMessage().contains("AD plugin is disabled"));
+            assertTrue(exception.getMessage(), exception.getMessage().contains("AD functionality is disabled"));
             updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, false));
         } finally {
             // guarantee reset back to default

--- a/src/test/java/org/opensearch/ad/transport/ADCancelTaskTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADCancelTaskTests.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.ADUnitTestCase;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.task.ADTaskCancellationState;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -48,7 +48,7 @@ public class ADCancelTaskTests extends ADUnitTestCase {
     public void testInvalidADCancelTaskRequest() {
         ADCancelTaskRequest request = new ADCancelTaskRequest(null, null, null, randomDiscoveryNode());
         ActionRequestValidationException validationException = request.validate();
-        assertTrue(validationException.getMessage().contains(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertTrue(validationException.getMessage().contains(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testSerializeResponse() throws IOException {

--- a/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADTaskProfileTests.java
@@ -23,7 +23,7 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.TestHelpers;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.ADTaskProfile;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -63,7 +63,7 @@ public class ADTaskProfileTests extends OpenSearchSingleNodeTestCase {
         DiscoveryNode node = new DiscoveryNode(UUIDs.randomBase64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
         ADTaskProfileRequest request = new ADTaskProfileRequest(null, node);
         ActionRequestValidationException validationException = request.validate();
-        assertTrue(validationException.getMessage().contains(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertTrue(validationException.getMessage().contains(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testADTaskProfileNodeResponse() throws IOException {

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -12,8 +12,7 @@
 package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.TestHelpers.HISTORICAL_ANALYSIS_FINISHED_FAILED_STATS;
-import static org.opensearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
-import static org.opensearch.ad.constant.CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG;
+import static org.opensearch.ad.constant.ADCommonMessages.DETECTOR_IS_RUNNING;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
@@ -22,6 +21,7 @@ import static org.opensearch.ad.util.RestHandlerUtils.START_JOB;
 import static org.opensearch.ad.util.RestHandlerUtils.STOP_JOB;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -112,7 +112,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalAnalysisIn
             OpenSearchStatusException.class,
             () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
         );
-        assertTrue(exception.getMessage().contains(FAIL_TO_FIND_DETECTOR_MSG));
+        assertTrue(exception.getMessage().contains(FAIL_TO_FIND_CONFIG_MSG));
     }
 
     public void testValidHistoricalAnalysis() throws IOException, InterruptedException {

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -76,8 +76,8 @@ import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.common.exception.ResourceNotFoundException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.SinglePointFeatures;
 import org.opensearch.ad.ml.ModelManager;
@@ -114,6 +114,7 @@ import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.transport.NodeNotConnectedException;
@@ -522,7 +523,7 @@ public class AnomalyResultTests extends AbstractADTest {
             .getTRcfResult(any(String.class), any(String.class), any(double[].class), any(ActionListener.class));
 
         when(stateManager.fetchExceptionAndClear(any(String.class)))
-            .thenReturn(Optional.of(new LimitExceededException(adID, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG)));
+            .thenReturn(Optional.of(new LimitExceededException(adID, CommonMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG)));
 
         // These constructors register handler in transport service
         new RCFResultTransportAction(
@@ -565,7 +566,7 @@ public class AnomalyResultTests extends AbstractADTest {
     public void testInsufficientCapacityExceptionDuringRestoringModel() {
 
         ModelManager rcfManager = mock(ModelManager.class);
-        doThrow(new NotSerializableExceptionWrapper(new LimitExceededException(adID, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG)))
+        doThrow(new NotSerializableExceptionWrapper(new LimitExceededException(adID, CommonMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG)))
             .when(rcfManager)
             .getTRcfResult(any(String.class), any(String.class), any(double[].class), any(ActionListener.class));
 
@@ -1073,22 +1074,22 @@ public class AnomalyResultTests extends AbstractADTest {
 
     public void testEmptyID() {
         ActionRequestValidationException e = new AnomalyResultRequest("", 100, 200).validate();
-        assertThat(e.validationErrors(), hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testZeroStartTime() {
         ActionRequestValidationException e = new AnomalyResultRequest(adID, 0, 200).validate();
-        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonMessages.INVALID_TIMESTAMP_ERR_MSG)));
     }
 
     public void testNegativeEndTime() {
         ActionRequestValidationException e = new AnomalyResultRequest(adID, 0, -200).validate();
-        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonMessages.INVALID_TIMESTAMP_ERR_MSG)));
     }
 
     public void testNegativeTime() {
         ActionRequestValidationException e = new AnomalyResultRequest(adID, 10, -200).validate();
-        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonMessages.INVALID_TIMESTAMP_ERR_MSG)));
     }
 
     // no exception should be thrown
@@ -1600,7 +1601,7 @@ public class AnomalyResultTests extends AbstractADTest {
     public void testAllFeaturesDisabled() throws IOException {
         doAnswer(invocation -> {
             ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
-            listener.onFailure(new EndRunException(adID, CommonErrorMessages.ALL_FEATURES_DISABLED_ERR_MSG, true));
+            listener.onFailure(new EndRunException(adID, CommonMessages.ALL_FEATURES_DISABLED_ERR_MSG, true));
             return null;
         }).when(stateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
 
@@ -1627,7 +1628,7 @@ public class AnomalyResultTests extends AbstractADTest {
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
         action.doExecute(null, request, listener);
 
-        assertException(listener, EndRunException.class, CommonErrorMessages.ALL_FEATURES_DISABLED_ERR_MSG);
+        assertException(listener, EndRunException.class, CommonMessages.ALL_FEATURES_DISABLED_ERR_MSG);
     }
 
     @SuppressWarnings("unchecked")
@@ -1713,7 +1714,7 @@ public class AnomalyResultTests extends AbstractADTest {
                     .of(
                         new EndRunException(
                             adID,
-                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            CommonMessages.INVALID_SEARCH_QUERY_MSG,
                             new NoSuchElementException("No value present"),
                             false
                         )
@@ -1742,7 +1743,7 @@ public class AnomalyResultTests extends AbstractADTest {
         );
 
         action.doExecute(null, request, listener);
-        assertException(listener, EndRunException.class, CommonErrorMessages.INVALID_SEARCH_QUERY_MSG);
+        assertException(listener, EndRunException.class, CommonMessages.INVALID_SEARCH_QUERY_MSG);
         verify(featureQuery, times(1)).getColdStartData(any(AnomalyDetector.class), any(ActionListener.class));
     }
 
@@ -1757,7 +1758,7 @@ public class AnomalyResultTests extends AbstractADTest {
                     .of(
                         new EndRunException(
                             adID,
-                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            CommonMessages.INVALID_SEARCH_QUERY_MSG,
                             new NoSuchElementException("No value present"),
                             true
                         )
@@ -1786,7 +1787,7 @@ public class AnomalyResultTests extends AbstractADTest {
         );
 
         action.doExecute(null, request, listener);
-        assertException(listener, EndRunException.class, CommonErrorMessages.INVALID_SEARCH_QUERY_MSG);
+        assertException(listener, EndRunException.class, CommonMessages.INVALID_SEARCH_QUERY_MSG);
         verify(featureQuery, never()).getColdStartData(any(AnomalyDetector.class), any(ActionListener.class));
     }
 

--- a/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
@@ -32,7 +32,7 @@ import org.opensearch.ad.NodeStateManager;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
@@ -135,6 +135,6 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
 
     public void testEmptyDetectorID() {
         ActionRequestValidationException e = new DeleteModelRequest().validate();
-        assertThat(e.validationErrors(), Matchers.hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), Matchers.hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/DeleteTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteTests.java
@@ -43,8 +43,8 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
@@ -150,12 +150,12 @@ public class DeleteTests extends AbstractADTest {
 
     public void testEmptyIDDeleteModel() {
         ActionRequestValidationException e = new DeleteModelRequest("").validate();
-        assertThat(e.validationErrors(), Matchers.hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), Matchers.hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testEmptyIDStopDetector() {
         ActionRequestValidationException e = new StopDetectorRequest().validate();
-        assertThat(e.validationErrors(), hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testValidIDStopDetector() {

--- a/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
@@ -38,8 +38,8 @@ import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.AnomalyDetectionException;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.model.Entity;
 import org.opensearch.ad.model.EntityProfileName;
 import org.opensearch.ad.model.ModelProfile;
@@ -379,6 +379,6 @@ public class EntityProfileTests extends AbstractADTest {
         assertEquals("state", EntityProfileName.getName(ADCommonName.STATE).getName());
         assertEquals("models", EntityProfileName.getName(ADCommonName.MODELS).getName());
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> EntityProfileName.getName("abc"));
-        assertEquals(exception.getMessage(), CommonErrorMessages.UNSUPPORTED_PROFILE_TYPE);
+        assertEquals(exception.getMessage(), ADCommonMessages.UNSUPPORTED_PROFILE_TYPE);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
@@ -59,8 +59,8 @@ import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.common.exception.LimitExceededException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.constant.CommonValue;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.ml.CheckpointDao;
@@ -85,6 +85,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.transport.TransportService;
@@ -335,19 +336,19 @@ public class EntityResultTransportActionTests extends AbstractADTest {
     public void testEmptyId() {
         request = new EntityResultRequest("", entities, start, end);
         ActionRequestValidationException e = request.validate();
-        assertThat(e.validationErrors(), hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testReverseTime() {
         request = new EntityResultRequest(detectorId, entities, end, start);
         ActionRequestValidationException e = request.validate();
-        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonMessages.INVALID_TIMESTAMP_ERR_MSG)));
     }
 
     public void testNegativeTime() {
         request = new EntityResultRequest(detectorId, entities, start, -end);
         ActionRequestValidationException e = request.validate();
-        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonMessages.INVALID_TIMESTAMP_ERR_MSG)));
     }
 
     public void testJsonResponse() throws IOException, JsonPathNotFoundException {

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskTests.java
@@ -20,7 +20,7 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.ad.AnomalyDetectorPlugin;
 import org.opensearch.ad.TestHelpers;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.ADTaskAction;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -86,7 +86,7 @@ public class ForwardADTaskTests extends OpenSearchSingleNodeTestCase {
         );
 
         ActionRequestValidationException exception = request.validate();
-        assertTrue(exception.getMessage().contains(CommonErrorMessages.DETECTOR_MISSING));
+        assertTrue(exception.getMessage().contains(ADCommonMessages.DETECTOR_MISSING));
     }
 
     private void testForwardADTaskRequest(ForwardADTaskRequest request) throws IOException {

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
@@ -42,7 +42,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.NodeStateManager;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.model.Entity;
@@ -57,6 +57,7 @@ import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -147,7 +148,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);
-        assertException(future, OpenSearchStatusException.class, CommonErrorMessages.EMPTY_PROFILES_COLLECT);
+        assertException(future, OpenSearchStatusException.class, ADCommonMessages.EMPTY_PROFILES_COLLECT);
     }
 
     @SuppressWarnings("unchecked")
@@ -172,7 +173,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);
-        assertException(future, OpenSearchStatusException.class, CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG);
+        assertException(future, OpenSearchStatusException.class, CommonMessages.FAIL_TO_FIND_CONFIG_MSG);
     }
 
     public void testGetTransportActionWithReturnTask() {

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -79,7 +79,6 @@ import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.EndRunException;
 import org.opensearch.ad.common.exception.InternalFailure;
 import org.opensearch.ad.common.exception.LimitExceededException;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.CompositeRetriever;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
@@ -122,6 +121,7 @@ import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.transport.Transport;
@@ -334,7 +334,7 @@ public class MultiEntityResultTests extends AbstractADTest {
                     .of(
                         new EndRunException(
                             detectorId,
-                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            CommonMessages.INVALID_SEARCH_QUERY_MSG,
                             new NoSuchElementException("No value present"),
                             false
                         )
@@ -342,7 +342,7 @@ public class MultiEntityResultTests extends AbstractADTest {
             );
         PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
         action.doExecute(null, request, listener);
-        assertException(listener, EndRunException.class, CommonErrorMessages.INVALID_SEARCH_QUERY_MSG);
+        assertException(listener, EndRunException.class, CommonMessages.INVALID_SEARCH_QUERY_MSG);
     }
 
     // a handler that forwards response or exception received from network
@@ -507,7 +507,7 @@ public class MultiEntityResultTests extends AbstractADTest {
         action.doExecute(null, request, listener2);
         Exception e = expectThrows(EndRunException.class, () -> listener2.actionGet(10000L));
         // wrapped INVALID_SEARCH_QUERY_MSG around SearchPhaseExecutionException by convertedQueryFailureException
-        assertThat("actual message: " + e.getMessage(), e.getMessage(), containsString(CommonErrorMessages.INVALID_SEARCH_QUERY_MSG));
+        assertThat("actual message: " + e.getMessage(), e.getMessage(), containsString(CommonMessages.INVALID_SEARCH_QUERY_MSG));
         assertThat("actual message: " + e.getMessage(), e.getMessage(), containsString(allShardsFailedMsg));
         // not end now
         assertTrue(!((EndRunException) e).isEndNow());
@@ -805,7 +805,7 @@ public class MultiEntityResultTests extends AbstractADTest {
 
         listener = new PlainActionFuture<>();
         action.doExecute(null, request, listener);
-        assertException(listener, LimitExceededException.class, CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG);
+        assertException(listener, LimitExceededException.class, CommonMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG);
     }
 
     public void testNotAck() throws InterruptedException, IOException {
@@ -1226,7 +1226,7 @@ public class MultiEntityResultTests extends AbstractADTest {
                 .of(
                     new EndRunException(
                         detectorId,
-                        CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                        CommonMessages.INVALID_SEARCH_QUERY_MSG,
                         new NoSuchElementException("No value present"),
                         true
                     )
@@ -1239,7 +1239,7 @@ public class MultiEntityResultTests extends AbstractADTest {
                     .of(
                         new EndRunException(
                             detectorId,
-                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            CommonMessages.INVALID_SEARCH_QUERY_MSG,
                             new NoSuchElementException("No value present"),
                             true
                         )
@@ -1270,7 +1270,7 @@ public class MultiEntityResultTests extends AbstractADTest {
                     .of(
                         new EndRunException(
                             detectorId,
-                            CommonErrorMessages.INVALID_SEARCH_QUERY_MSG,
+                            CommonMessages.INVALID_SEARCH_QUERY_MSG,
                             new NoSuchElementException("No value present"),
                             false
                         )

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -49,7 +49,6 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.ad.AnomalyDetectorRunner;
 import org.opensearch.ad.TestHelpers;
 import org.opensearch.ad.breaker.ADCircuitBreakerService;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.Features;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
@@ -75,6 +74,7 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.transport.TransportService;
 
@@ -424,7 +424,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
             @Override
             public void onFailure(Exception e) {
                 Assert.assertTrue("actual class: " + e.getClass(), e instanceof OpenSearchStatusException);
-                Assert.assertTrue(e.getMessage().contains(CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
+                Assert.assertTrue(e.getMessage().contains(CommonMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
                 inProgressLatch.countDown();
             }
         };

--- a/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
@@ -42,8 +42,8 @@ import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.common.exception.LimitExceededException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.ml.ThresholdingResult;
 import org.opensearch.ad.stats.ADStat;
@@ -243,7 +243,7 @@ public class RCFResultTests extends OpenSearchTestCase {
 
     public void testEmptyID() {
         ActionRequestValidationException e = new RCFResultRequest(null, "123-rcf-1", new double[] { 0 }).validate();
-        assertThat(e.validationErrors(), Matchers.hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), Matchers.hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testFeatureIsNull() {

--- a/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
@@ -28,8 +28,8 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.ml.ThresholdingResult;
 import org.opensearch.common.Strings;
@@ -124,12 +124,12 @@ public class ThresholdResultTests extends OpenSearchTestCase {
 
     public void testEmptyDetectorID() {
         ActionRequestValidationException e = new ThresholdResultRequest(null, "123-threshold", 2).validate();
-        assertThat(e.validationErrors(), Matchers.hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), Matchers.hasItem(ADCommonMessages.AD_ID_MISSING_MSG));
     }
 
     public void testEmptyModelID() {
         ActionRequestValidationException e = new ThresholdResultRequest("123", "", 2).validate();
-        assertThat(e.validationErrors(), Matchers.hasItem(CommonErrorMessages.MODEL_ID_MISSING_MSG));
+        assertThat(e.validationErrors(), Matchers.hasItem(ADCommonMessages.MODEL_ID_MISSING_MSG));
     }
 
     public void testSerialzationRequest() throws IOException {

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorResponseTests.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.opensearch.ad.AbstractADTest;
 import org.opensearch.ad.TestHelpers;
-import org.opensearch.ad.constant.CommonErrorMessages;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.DetectorValidationIssue;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
@@ -84,7 +84,7 @@ public class ValidateAnomalyDetectorResponseTests extends AbstractADTest {
         String validationResponse = TestHelpers.xContentBuilderToString(response.toXContent(TestHelpers.builder()));
         assertEquals(
             "{\"model\":{\"detection_interval\":{\"message\":\""
-                + CommonErrorMessages.DETECTOR_INTERVAL_REC
+                + ADCommonMessages.DETECTOR_INTERVAL_REC
                 + intervalRec
                 + "\",\"suggested_value\":{\"period\":{\"interval\":5,\"unit\":\"Minutes\"}}}}}",
             validationResponse

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -20,8 +20,8 @@ import java.util.Locale;
 import org.junit.Test;
 import org.opensearch.ad.ADIntegTestCase;
 import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorValidationIssueType;
@@ -30,6 +30,7 @@ import org.opensearch.ad.model.ValidationAspect;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.timeseries.constant.CommonMessages;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
@@ -70,7 +71,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertNotNull(response.getIssue());
         assertEquals(DetectorValidationIssueType.INDICES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.INDEX_NOT_FOUND));
+        assertTrue(response.getIssue().getMessage().contains(ADCommonMessages.INDEX_NOT_FOUND));
     }
 
     @Test
@@ -110,9 +111,9 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertNotNull(response.getIssue());
         assertEquals(DetectorValidationIssueType.FEATURE_ATTRIBUTES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.FEATURE_WITH_EMPTY_DATA_MSG));
+        assertTrue(response.getIssue().getMessage().contains(CommonMessages.FEATURE_WITH_EMPTY_DATA_MSG));
         assertTrue(response.getIssue().getSubIssues().containsKey(maxFeature.getName()));
-        assertTrue(CommonErrorMessages.FEATURE_WITH_EMPTY_DATA_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName())));
+        assertTrue(CommonMessages.FEATURE_WITH_EMPTY_DATA_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName())));
     }
 
     @Test
@@ -199,11 +200,9 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertNotNull(response.getIssue());
         assertEquals(DetectorValidationIssueType.FEATURE_ATTRIBUTES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.FEATURE_WITH_INVALID_QUERY_MSG));
+        assertTrue(response.getIssue().getMessage().contains(CommonMessages.FEATURE_WITH_INVALID_QUERY_MSG));
         assertTrue(response.getIssue().getSubIssues().containsKey(maxFeature.getName()));
-        assertTrue(
-            CommonErrorMessages.FEATURE_WITH_INVALID_QUERY_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName()))
-        );
+        assertTrue(CommonMessages.FEATURE_WITH_INVALID_QUERY_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName())));
     }
 
     @Test
@@ -228,7 +227,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertNotNull(response.getIssue());
         assertEquals(DetectorValidationIssueType.FEATURE_ATTRIBUTES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG));
+        assertTrue(response.getIssue().getMessage().contains(CommonMessages.UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG));
         assertTrue(response.getIssue().getSubIssues().containsKey(nameField));
     }
 
@@ -252,11 +251,9 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertEquals(response.getIssue().getSubIssues().keySet().size(), 2);
         assertEquals(DetectorValidationIssueType.FEATURE_ATTRIBUTES, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.FEATURE_WITH_INVALID_QUERY_MSG));
+        assertTrue(response.getIssue().getMessage().contains(CommonMessages.FEATURE_WITH_INVALID_QUERY_MSG));
         assertTrue(response.getIssue().getSubIssues().containsKey(maxFeature.getName()));
-        assertTrue(
-            CommonErrorMessages.FEATURE_WITH_INVALID_QUERY_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName()))
-        );
+        assertTrue(CommonMessages.FEATURE_WITH_INVALID_QUERY_MSG.contains(response.getIssue().getSubIssues().get(maxFeature.getName())));
     }
 
     @Test
@@ -322,7 +319,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
         assertEquals(DetectorValidationIssueType.RESULT_INDEX, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertTrue(response.getIssue().getMessage().contains(CommonErrorMessages.INVALID_RESULT_INDEX_MAPPING));
+        assertTrue(response.getIssue().getMessage().contains(CommonMessages.INVALID_RESULT_INDEX_MAPPING));
     }
 
     private void testValidateAnomalyDetectorWithCustomResultIndex(boolean resultIndexCreated) throws IOException {
@@ -385,7 +382,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         ValidateAnomalyDetectorResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
         assertEquals(DetectorValidationIssueType.NAME, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertEquals(CommonErrorMessages.INVALID_DETECTOR_NAME, response.getIssue().getMessage());
+        assertEquals(CommonMessages.INVALID_NAME, response.getIssue().getMessage());
     }
 
     @Test
@@ -440,7 +437,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertEquals(DetectorValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.NON_EXISTENT_TIMESTAMP, anomalyDetector.getTimeField()),
+            String.format(Locale.ROOT, CommonMessages.NON_EXISTENT_TIMESTAMP, anomalyDetector.getTimeField()),
             response.getIssue().getMessage()
         );
     }
@@ -461,7 +458,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertEquals(DetectorValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
         assertEquals(
-            String.format(Locale.ROOT, CommonErrorMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()),
+            String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()),
             response.getIssue().getMessage()
         );
     }


### PR DESCRIPTION
### Description
In this pull request, I have refactored the code related to shared log or error messages in both AD and forecasting modules to CommonMessages. Additionally, the previously used CommonErrorMessages has been renamed to ADCommonMessages. For the Forecasting module, I have introduced new names in ForecastCommonMessages.

Testing done:
* gradle build

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/866

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
