### PR TITLE
[Extensions] Improves performance by replacing cluster state calls for index existence with exists()/aliasExists() API calls

### DIFF
--- a/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java
@@ -67,6 +67,7 @@ import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.DiscoveryNodeFilterer;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.CreateIndexResponse;
+import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.client.indices.PutMappingRequest;
 import org.opensearch.client.indices.rollover.RolloverRequest;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -305,12 +306,56 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     }
 
     /**
+     * Determine if index exists
+     *
+     * @param indexName the name of the index
+     * @return true if index exists
+     */
+    public boolean indexExists(String indexName) {
+        GetIndexRequest getindexRequest = new GetIndexRequest(indexName);
+
+        CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
+        sdkRestClient.indices().exists(getindexRequest, ActionListener.wrap(response -> { existsFuture.complete(response); }, exception -> {
+            existsFuture.completeExceptionally(exception);
+        }));
+
+        Boolean existsResponse = existsFuture
+            .orTimeout(AnomalyDetectorSettings.REQUEST_TIMEOUT.get(environmentSettings).getMillis(), TimeUnit.MILLISECONDS)
+            .join();
+
+        return existsResponse.booleanValue();
+    }
+
+    /**
+     * Determine if alias exists
+     *
+     * @param aliasName the name of the alias
+     * @return true if alias exists
+     */
+    public boolean aliasExists(String aliasName) {
+        GetAliasesRequest getAliasRequest = new GetAliasesRequest(aliasName);
+
+        CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
+        sdkRestClient
+            .indices()
+            .existsAlias(getAliasRequest, ActionListener.wrap(response -> { existsFuture.complete(response); }, exception -> {
+                existsFuture.completeExceptionally(exception);
+            }));
+
+        Boolean existsResponse = existsFuture
+            .orTimeout(AnomalyDetectorSettings.REQUEST_TIMEOUT.get(environmentSettings).getMillis(), TimeUnit.MILLISECONDS)
+            .join();
+
+        return existsResponse.booleanValue();
+    }
+
+    /**
      * Anomaly detector index exist or not.
      *
      * @return true if anomaly detector index exists
      */
     public boolean doesAnomalyDetectorIndexExist() {
-        return sdkClusterService.state().getRoutingTable().hasIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX);
+        return indexExists(AnomalyDetector.ANOMALY_DETECTORS_INDEX);
     }
 
     /**
@@ -319,7 +364,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return true if anomaly detector job index exists
      */
     public boolean doesAnomalyDetectorJobIndexExist() {
-        return sdkClusterService.state().getRoutingTable().hasIndex(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX);
+        return indexExists(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX);
     }
 
     /**
@@ -328,11 +373,11 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return true if anomaly result index exists
      */
     public boolean doesDefaultAnomalyResultIndexExist() {
-        return sdkClusterService.state().metadata().hasAlias(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        return aliasExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
     }
 
     public boolean doesIndexExist(String indexName) {
-        return sdkClusterService.state().metadata().hasIndex(indexName);
+        return indexExists(indexName);
     }
 
     public <T> void initCustomResultIndexAndExecute(String resultIndex, AnomalyDetectorFunction function, ActionListener<T> listener) {
@@ -471,7 +516,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return true if anomaly state index exists
      */
     public boolean doesDetectorStateIndexExist() {
-        return sdkClusterService.state().getRoutingTable().hasIndex(CommonName.DETECTION_STATE_INDEX);
+        return indexExists(CommonName.DETECTION_STATE_INDEX);
     }
 
     /**
@@ -480,27 +525,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return true if checkpoint index exists
      */
     public boolean doesCheckpointIndexExist() {
-        return sdkClusterService.state().getRoutingTable().hasIndex(CommonName.CHECKPOINT_INDEX_NAME);
-    }
-
-    /**
-     * Index exists or not
-     * @param sdkClusterService Cluster service
-     * @param name Index name
-     * @return true if the index exists
-     */
-    public static boolean doesIndexExists(SDKClusterService sdkClusterService, String name) {
-        return sdkClusterService.state().getRoutingTable().hasIndex(name);
-    }
-
-    /**
-     * Alias exists or not
-     * @param sdkClusterService Cluster service
-     * @param alias Alias name
-     * @return true if the alias exists
-     */
-    public static boolean doesAliasExists(SDKClusterService sdkClusterService, String alias) {
-        return sdkClusterService.state().metadata().hasAlias(alias);
+        return indexExists(CommonName.CHECKPOINT_INDEX_NAME);
     }
 
     private ActionListener<CreateIndexResponse> markMappingUpToDate(ADIndex index, ActionListener<CreateIndexResponse> followingListener) {
@@ -979,9 +1004,9 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
     private void shouldUpdateIndex(ADIndex index, ActionListener<Boolean> thenDo) {
         boolean exists = false;
         if (index.isAlias()) {
-            exists = AnomalyDetectionIndices.doesAliasExists(sdkClusterService, index.getIndexName());
+            exists = aliasExists(index.getIndexName());
         } else {
-            exists = AnomalyDetectionIndices.doesIndexExists(sdkClusterService, index.getIndexName());
+            exists = indexExists(index.getIndexName());
         }
         if (false == exists) {
             thenDo.onResponse(Boolean.FALSE);

--- a/src/main/java/org/opensearch/ad/rest/handler/AnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AnomalyDetectorActionHandler.java
@@ -15,6 +15,8 @@ import static org.opensearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_IN
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,7 +25,10 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.ad.model.AnomalyDetectorJob;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.RestHandlerUtils;
+import org.opensearch.client.indices.GetIndexRequest;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestStatus;
@@ -57,7 +62,7 @@ public class AnomalyDetectorActionHandler {
         AnomalyDetectorFunction function,
         NamedXContentRegistry xContentRegistry
     ) {
-        if (sdkClusterService.state().metadata().indices().containsKey(ANOMALY_DETECTOR_JOB_INDEX)) {
+        if (anomalyDetectorJobIndexExists(client)) {
             GetRequest request = new GetRequest(ANOMALY_DETECTOR_JOB_INDEX).id(detectorId);
             client
                 .get(
@@ -101,5 +106,20 @@ public class AnomalyDetectorActionHandler {
             }
         }
         function.execute();
+    }
+
+    private boolean anomalyDetectorJobIndexExists(SDKRestClient sdkRestClient) {
+        GetIndexRequest getindexRequest = new GetIndexRequest(ANOMALY_DETECTOR_JOB_INDEX);
+
+        CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
+        sdkRestClient.indices().exists(getindexRequest, ActionListener.wrap(response -> { existsFuture.complete(response); }, exception -> {
+            existsFuture.completeExceptionally(exception);
+        }));
+
+        Boolean existsResponse = existsFuture
+            .orTimeout(AnomalyDetectorSettings.REQUEST_TIMEOUT.get(Settings.EMPTY).getMillis(), TimeUnit.MILLISECONDS)
+            .join();
+
+        return existsResponse.booleanValue();
     }
 }

--- a/src/test/java/org/opensearch/ad/indices/InitAnomalyDetectionIndicesTests.java
+++ b/src/test/java/org/opensearch/ad/indices/InitAnomalyDetectionIndicesTests.java
@@ -15,7 +15,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -100,16 +99,14 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
         clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().build()).build();
         when(clusterService.state()).thenReturn(clusterState);
 
-        adIndices = spy(
-            new AnomalyDetectionIndices(
-                client,
-                sdkJavaAsyncClient,
-                clusterService,
-                threadPool,
-                settings,
-                nodeFilter,
-                AnomalyDetectorSettings.MAX_UPDATE_RETRY_TIMES
-            )
+        adIndices = new AnomalyDetectionIndices(
+            client,
+            sdkJavaAsyncClient,
+            clusterService,
+            threadPool,
+            settings,
+            nodeFilter,
+            AnomalyDetectorSettings.MAX_UPDATE_RETRY_TIMES
         );
 
     }


### PR DESCRIPTION
### Description
Companion SDK PR : https://github.com/opensearch-project/opensearch-sdk-java/pull/802 (SDK PR must be merged first)

Replaces the following cluster state calls to check if an index/alias exists with the `SDKIndicesClient` `exist()` and `existsAlias()` methods :
- `state().getRoutingTable().hasIndex(indexName)`
- `state().metadata().hasIndex(indexName)`
- `state().metadata().indices().containsKey(indexName)`
- `state().metadata().hasAlias(alias)` 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/674

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
