### PR TITLE
[Extensions] Retrieve transport service from SDKTransportService rather than ExtensionsRunner

### DIFF
--- a/src/main/java/org/opensearch/ad/rest/RestAnomalyDetectorJobAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestAnomalyDetectorJobAction.java
@@ -191,7 +191,7 @@ public class RestAnomalyDetectorJobAction extends BaseExtensionRestHandler {
             requestBody.field(GetJobDetailsRequest.JOB_TYPE, AnomalyDetectorExtension.AD_JOB_TYPE);
             requestBody.field(GetJobDetailsRequest.JOB_PARAMETER_ACTION, ADJobParameterAction.class.getName());
             requestBody.field(GetJobDetailsRequest.JOB_RUNNER_ACTION, ADJobRunnerAction.class.getName());
-            requestBody.field(GetJobDetailsRequest.EXTENSION_UNIQUE_ID, extensionsRunner.getUniqueId());
+            requestBody.field(GetJobDetailsRequest.EXTENSION_UNIQUE_ID, extensionsRunner.getSdkTransportService().getUniqueId());
             requestBody.endObject();
 
             Request registerJobDetailsRequest = new Request(

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -68,7 +68,7 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
         super(extensionsRunner);
         this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
         this.environmentSettings = extensionsRunner.getEnvironmentSettings();
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.sdkRestClient = sdkRestClient;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/ADBatchAnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADBatchAnomalyResultTransportAction.java
@@ -35,7 +35,7 @@ public class ADBatchAnomalyResultTransportAction extends TransportAction<ADBatch
         ADBatchTaskRunner adBatchTaskRunner
     ) {
         super(ADBatchAnomalyResultAction.NAME, actionFilters, taskManager);
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.adBatchTaskRunner = adBatchTaskRunner;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -66,7 +66,7 @@ public class AnomalyDetectorJobTransportAction extends TransportAction<AnomalyDe
         ADTaskManager adTaskManager
     ) {
         super(AnomalyDetectorJobAction.NAME, actionFilters, taskManager);
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.client = client;
         this.clusterService = clusterService;
         this.settings = extensionsRunner.getEnvironmentSettings();

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -164,7 +164,7 @@ public class AnomalyResultTransportAction extends TransportAction<ActionRequest,
     ) {
         super(AnomalyResultAction.NAME, actionFilters, taskManager);
         this.extensionsRunner = extensionsRunner;
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.settings = extensionsRunner.getEnvironmentSettings();
         this.sdkRestClient = sdkRestClient;
         this.stateManager = manager;

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -80,7 +80,7 @@ public class DeleteAnomalyDetectorTransportAction extends TransportAction<Delete
         ADTaskManager adTaskManager
     ) {
         super(DeleteAnomalyDetectorAction.NAME, actionFilters, taskManager);
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.client = client;
         this.clusterService = clusterService;
         this.xContentRegistry = xContentRegistry;

--- a/src/main/java/org/opensearch/ad/transport/ForwardADTaskTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ForwardADTaskTransportAction.java
@@ -71,7 +71,7 @@ public class ForwardADTaskTransportAction extends TransportAction<ForwardADTaskR
     ) {
         super(ForwardADTaskAction.NAME, actionFilters, taskManager);
         this.adTaskManager = adTaskManager;
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.adTaskCacheManager = adTaskCacheManager;
         this.featureManager = featureManager;
         this.stateManager = stateManager;

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -127,7 +127,7 @@ public class GetAnomalyDetectorTransportAction extends TransportAction<GetAnomal
         this.nodeFilter = nodeFilter;
         filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.adTaskManager = adTaskManager;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -78,7 +78,7 @@ public class IndexAnomalyDetectorTransportAction extends TransportAction<IndexAn
     ) {
         super(IndexAnomalyDetectorAction.NAME, actionFilters, taskManager);
         this.client = restClient;
-        this.transportService = extensionsRunner.getExtensionTransportService();
+        this.transportService = extensionsRunner.getSdkTransportService().getTransportService();
         this.clusterService = sdkClusterService;
         this.anomalyDetectionIndices = anomalyDetectionIndices;
         this.xContentRegistry = namedXContentRegistry;

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskTransportActionTests.java
@@ -71,7 +71,7 @@ public class ForwardADTaskTransportActionTests extends ADUnitTestCase {
         adTaskCacheManager = mock(ADTaskCacheManager.class);
         featureManager = mock(FeatureManager.class);
         stateManager = mock(NodeStateManager.class);
-        when(extensionsRunner.getExtensionTransportService()).thenReturn(transportService);
+        when(extensionsRunner.getSdkTransportService().getTransportService()).thenReturn(transportService);
         forwardADTaskTransportAction = new ForwardADTaskTransportAction(
             extensionsRunner,
             taskManager,

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskTransportActionTests.java
@@ -40,6 +40,7 @@ import org.opensearch.ad.model.ADTaskType;
 import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.sdk.ExtensionsRunner;
+import org.opensearch.sdk.SDKTransportService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.transport.TransportService;
@@ -50,6 +51,7 @@ public class ForwardADTaskTransportActionTests extends ADUnitTestCase {
     private ExtensionsRunner extensionsRunner;
     private TaskManager taskManager;
     private ActionFilters actionFilters;
+    private SDKTransportService sdkTransportService;
     private TransportService transportService;
     private ADTaskManager adTaskManager;
     private ADTaskCacheManager adTaskCacheManager;
@@ -66,12 +68,14 @@ public class ForwardADTaskTransportActionTests extends ADUnitTestCase {
         extensionsRunner = mock(ExtensionsRunner.class);
         taskManager = mock(TaskManager.class);
         actionFilters = mock(ActionFilters.class);
+        sdkTransportService = mock(SDKTransportService.class);
         transportService = mock(TransportService.class);
         adTaskManager = mock(ADTaskManager.class);
         adTaskCacheManager = mock(ADTaskCacheManager.class);
         featureManager = mock(FeatureManager.class);
         stateManager = mock(NodeStateManager.class);
-        when(extensionsRunner.getSdkTransportService().getTransportService()).thenReturn(transportService);
+        when(extensionsRunner.getSdkTransportService()).thenReturn(sdkTransportService);
+        when(sdkTransportService.getTransportService()).thenReturn(transportService);
         forwardADTaskTransportAction = new ForwardADTaskTransportAction(
             extensionsRunner,
             taskManager,

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -52,9 +52,11 @@ import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.sdk.SDKNamedXContentRegistry;
+import org.opensearch.sdk.SDKTransportService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -93,6 +95,11 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
         SDKNamedXContentRegistry sdkNamedXContentRegistry = mock(SDKNamedXContentRegistry.class);
         when(mockRunner.getNamedXContentRegistry()).thenReturn(sdkNamedXContentRegistry);
         when(sdkNamedXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
+        SDKTransportService mockSdkTransportService = mock(SDKTransportService.class);
+        TransportService mockTransportService = mock(TransportService.class);
+        when(mockRunner.getSdkTransportService()).thenReturn(mockSdkTransportService);
+        when(mockSdkTransportService.getTransportService()).thenReturn(mockTransportService);
 
         action = new GetAnomalyDetectorTransportAction(
             mockRunner,

--- a/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
@@ -56,11 +56,13 @@ import org.opensearch.sdk.SDKClient.SDKRestClient;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.sdk.SDKClusterService.SDKClusterSettings;
 import org.opensearch.sdk.SDKNamedXContentRegistry;
+import org.opensearch.sdk.SDKTransportService;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -121,6 +123,11 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
 
         this.mockSdkXContentRegistry = mock(SDKNamedXContentRegistry.class);
         when(mockSdkXContentRegistry.getRegistry()).thenReturn(xContentRegistry());
+
+        SDKTransportService mockSdkTransportService = mock(SDKTransportService.class);
+        TransportService mockTransportService = mock(TransportService.class);
+        when(mockRunner.getSdkTransportService()).thenReturn(mockSdkTransportService);
+        when(mockSdkTransportService.getTransportService()).thenReturn(mockTransportService);
 
         action = new IndexAnomalyDetectorTransportAction(
             mockRunner,


### PR DESCRIPTION
### Description
Coming from changes in https://github.com/opensearch-project/opensearch-sdk-java/pull/768

Retrieves transport service from SDKTransportService rather than directly from the extensionsRunner

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
