### PR TITLE
[Extensions] Improves performance by replacing cluster state calls to retrieve cluster name

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
@@ -25,6 +25,9 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.task.ADTaskCancellationState;
 import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -35,17 +38,20 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
     private final Logger logger = LogManager.getLogger(ADCancelTaskTransportAction.class);
     private ADTaskManager adTaskManager;
     private SDKClusterService clusterService;
+    private Settings settings;
 
     @Inject
     public ADCancelTaskTransportAction(
         TaskManager taskManager,
         ActionFilters actionFilters,
         ADTaskManager adTaskManager,
-        SDKClusterService clusterService
+        SDKClusterService clusterService,
+        ExtensionsRunner extensionsRunner
     ) {
         super(ADCancelTaskAction.NAME, actionFilters, taskManager);
         this.adTaskManager = adTaskManager;
         this.clusterService = clusterService;
+        this.settings = extensionsRunner.getEnvironmentSettings();
     }
 
     protected ADCancelTaskResponse newResponse(
@@ -53,7 +59,7 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
         List<ADCancelTaskNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADCancelTaskResponse(clusterService.state().getClusterName(), responses, failures);
+        return new ADCancelTaskResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
@@ -26,7 +26,6 @@ import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.task.ADTaskCancellationState;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.ClusterName;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
@@ -38,7 +37,7 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
     private final Logger logger = LogManager.getLogger(ADCancelTaskTransportAction.class);
     private ADTaskManager adTaskManager;
     private SDKClusterService clusterService;
-    private Settings settings;
+    private ExtensionsRunner extensionsRunner;
 
     @Inject
     public ADCancelTaskTransportAction(
@@ -51,7 +50,7 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
         super(ADCancelTaskAction.NAME, actionFilters, taskManager);
         this.adTaskManager = adTaskManager;
         this.clusterService = clusterService;
-        this.settings = extensionsRunner.getEnvironmentSettings();
+        this.extensionsRunner = extensionsRunner;
     }
 
     protected ADCancelTaskResponse newResponse(
@@ -59,7 +58,11 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
         List<ADCancelTaskNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADCancelTaskResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
+        return new ADCancelTaskResponse(
+            new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")),
+            responses,
+            failures
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADCancelTaskTransportAction.java
@@ -25,8 +25,6 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.task.ADTaskCancellationState;
 import org.opensearch.ad.task.ADTaskManager;
-import org.opensearch.cluster.ClusterName;
-import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -37,20 +35,17 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
     private final Logger logger = LogManager.getLogger(ADCancelTaskTransportAction.class);
     private ADTaskManager adTaskManager;
     private SDKClusterService clusterService;
-    private ExtensionsRunner extensionsRunner;
 
     @Inject
     public ADCancelTaskTransportAction(
         TaskManager taskManager,
         ActionFilters actionFilters,
         ADTaskManager adTaskManager,
-        SDKClusterService clusterService,
-        ExtensionsRunner extensionsRunner
+        SDKClusterService clusterService
     ) {
         super(ADCancelTaskAction.NAME, actionFilters, taskManager);
         this.adTaskManager = adTaskManager;
         this.clusterService = clusterService;
-        this.extensionsRunner = extensionsRunner;
     }
 
     protected ADCancelTaskResponse newResponse(
@@ -58,11 +53,7 @@ public class ADCancelTaskTransportAction extends TransportAction<ADCancelTaskReq
         List<ADCancelTaskNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADCancelTaskResponse(
-            new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")),
-            responses,
-            failures
-        );
+        return new ADCancelTaskResponse(clusterService.getClusterName(), responses, failures);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/ADStatsNodesTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADStatsNodesTransportAction.java
@@ -27,7 +27,6 @@ import org.opensearch.ad.stats.InternalStatNames;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
@@ -48,7 +47,7 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
     private final ADTaskManager adTaskManager;
 
     private final SDKClusterService sdkClusterService;
-    private Settings settings;
+    private ExtensionsRunner extensionsRunner;
 
     /**
      * Constructor
@@ -76,7 +75,7 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
         this.jvmService = jvmService;
         this.adTaskManager = adTaskManager;
         this.sdkClusterService = sdkClusterService;
-        this.settings = extensionsRunner.getEnvironmentSettings();
+        this.extensionsRunner = extensionsRunner;
     }
 
     protected ADStatsNodesResponse newResponse(
@@ -84,7 +83,11 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
         List<ADStatsNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADStatsNodesResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
+        return new ADStatsNodesResponse(
+            new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")),
+            responses,
+            failures
+        );
     }
 
     protected ADStatsNodeRequest newNodeRequest(ADStatsRequest request) {

--- a/src/main/java/org/opensearch/ad/transport/ADStatsNodesTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADStatsNodesTransportAction.java
@@ -25,10 +25,8 @@ import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.stats.InternalStatNames;
 import org.opensearch.ad.task.ADTaskManager;
-import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.monitor.jvm.JvmService;
-import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -47,7 +45,6 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
     private final ADTaskManager adTaskManager;
 
     private final SDKClusterService sdkClusterService;
-    private ExtensionsRunner extensionsRunner;
 
     /**
      * Constructor
@@ -58,7 +55,6 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
      * @param jvmService ES JVM Service
      * @param adTaskManager AD task manager
      * @param taskManager Task manager
-     * @param extensionsRunner extensions runner
      */
     @Inject
     public ADStatsNodesTransportAction(
@@ -67,15 +63,13 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
         ADStats adStats,
         JvmService jvmService,
         ADTaskManager adTaskManager,
-        TaskManager taskManager,
-        ExtensionsRunner extensionsRunner
+        TaskManager taskManager
     ) {
         super(ADStatsNodesAction.NAME, actionFilters, taskManager);
         this.adStats = adStats;
         this.jvmService = jvmService;
         this.adTaskManager = adTaskManager;
         this.sdkClusterService = sdkClusterService;
-        this.extensionsRunner = extensionsRunner;
     }
 
     protected ADStatsNodesResponse newResponse(
@@ -83,11 +77,7 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
         List<ADStatsNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADStatsNodesResponse(
-            new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")),
-            responses,
-            failures
-        );
+        return new ADStatsNodesResponse(sdkClusterService.getClusterName(), responses, failures);
     }
 
     protected ADStatsNodeRequest newNodeRequest(ADStatsRequest request) {

--- a/src/main/java/org/opensearch/ad/transport/ADStatsNodesTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADStatsNodesTransportAction.java
@@ -25,8 +25,11 @@ import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.stats.InternalStatNames;
 import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.monitor.jvm.JvmService;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -45,6 +48,7 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
     private final ADTaskManager adTaskManager;
 
     private final SDKClusterService sdkClusterService;
+    private Settings settings;
 
     /**
      * Constructor
@@ -55,6 +59,7 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
      * @param jvmService ES JVM Service
      * @param adTaskManager AD task manager
      * @param taskManager Task manager
+     * @param extensionsRunner extensions runner
      */
     @Inject
     public ADStatsNodesTransportAction(
@@ -63,13 +68,15 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
         ADStats adStats,
         JvmService jvmService,
         ADTaskManager adTaskManager,
-        TaskManager taskManager
+        TaskManager taskManager,
+        ExtensionsRunner extensionsRunner
     ) {
         super(ADStatsNodesAction.NAME, actionFilters, taskManager);
         this.adStats = adStats;
         this.jvmService = jvmService;
         this.adTaskManager = adTaskManager;
         this.sdkClusterService = sdkClusterService;
+        this.settings = extensionsRunner.getEnvironmentSettings();
     }
 
     protected ADStatsNodesResponse newResponse(
@@ -77,7 +84,7 @@ public class ADStatsNodesTransportAction extends TransportAction<ADStatsRequest,
         List<ADStatsNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADStatsNodesResponse(sdkClusterService.state().getClusterName(), responses, failures);
+        return new ADStatsNodesResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
     }
 
     protected ADStatsNodeRequest newNodeRequest(ADStatsRequest request) {

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
@@ -22,7 +22,10 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.model.ADTaskProfile;
 import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -41,6 +44,7 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
     // private HashRing hashRing;
 
     private final SDKClusterService sdkClusterService;
+    private Settings settings;
 
     @Inject
     public ADTaskProfileTransportAction(
@@ -49,13 +53,15 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
         ADTaskManager adTaskManager,
         /* MultiNode support https://github.com/opensearch-project/opensearch-sdk-java/issues/200 */
         // HashRing hashRing,
-        TaskManager taskManager
+        TaskManager taskManager,
+        ExtensionsRunner extensionsRunner
     ) {
         super(ADTaskProfileAction.NAME, actionFilters, taskManager);
         this.adTaskManager = adTaskManager;
         /* MultiNode support https://github.com/opensearch-project/opensearch-sdk-java/issues/200 */
         // this.hashRing = hashRing;
         this.sdkClusterService = sdkClusterService;
+        this.settings = extensionsRunner.getEnvironmentSettings();
     }
 
     protected ADTaskProfileResponse newResponse(
@@ -63,7 +69,7 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
         List<ADTaskProfileNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADTaskProfileResponse(sdkClusterService.state().getClusterName(), responses, failures);
+        return new ADTaskProfileResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
     }
 
     protected ADTaskProfileNodeRequest newNodeRequest(ADTaskProfileRequest request) {

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
@@ -22,9 +22,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.ad.model.ADTaskProfile;
 import org.opensearch.ad.task.ADTaskManager;
-import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -43,7 +41,6 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
     // private HashRing hashRing;
 
     private final SDKClusterService sdkClusterService;
-    private ExtensionsRunner extensionsRunner;
 
     @Inject
     public ADTaskProfileTransportAction(
@@ -52,15 +49,13 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
         ADTaskManager adTaskManager,
         /* MultiNode support https://github.com/opensearch-project/opensearch-sdk-java/issues/200 */
         // HashRing hashRing,
-        TaskManager taskManager,
-        ExtensionsRunner extensionsRunner
+        TaskManager taskManager
     ) {
         super(ADTaskProfileAction.NAME, actionFilters, taskManager);
         this.adTaskManager = adTaskManager;
         /* MultiNode support https://github.com/opensearch-project/opensearch-sdk-java/issues/200 */
         // this.hashRing = hashRing;
         this.sdkClusterService = sdkClusterService;
-        this.extensionsRunner = extensionsRunner;
     }
 
     protected ADTaskProfileResponse newResponse(
@@ -68,11 +63,7 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
         List<ADTaskProfileNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADTaskProfileResponse(
-            new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")),
-            responses,
-            failures
-        );
+        return new ADTaskProfileResponse(sdkClusterService.getClusterName(), responses, failures);
     }
 
     protected ADTaskProfileNodeRequest newNodeRequest(ADTaskProfileRequest request) {

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileTransportAction.java
@@ -24,7 +24,6 @@ import org.opensearch.ad.model.ADTaskProfile;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
@@ -44,7 +43,7 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
     // private HashRing hashRing;
 
     private final SDKClusterService sdkClusterService;
-    private Settings settings;
+    private ExtensionsRunner extensionsRunner;
 
     @Inject
     public ADTaskProfileTransportAction(
@@ -61,7 +60,7 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
         /* MultiNode support https://github.com/opensearch-project/opensearch-sdk-java/issues/200 */
         // this.hashRing = hashRing;
         this.sdkClusterService = sdkClusterService;
-        this.settings = extensionsRunner.getEnvironmentSettings();
+        this.extensionsRunner = extensionsRunner;
     }
 
     protected ADTaskProfileResponse newResponse(
@@ -69,7 +68,11 @@ public class ADTaskProfileTransportAction extends TransportAction<ADTaskProfileR
         List<ADTaskProfileNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new ADTaskProfileResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
+        return new ADTaskProfileResponse(
+            new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")),
+            responses,
+            failures
+        );
     }
 
     protected ADTaskProfileNodeRequest newNodeRequest(ADTaskProfileRequest request) {

--- a/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
@@ -26,8 +26,6 @@ import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.task.ADTaskCacheManager;
-import org.opensearch.cluster.ClusterName;
-import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -44,7 +42,6 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
     private ADTaskCacheManager adTaskCacheManager;
     private EntityColdStarter coldStarter;
     private SDKClusterService clusterService;
-    private ExtensionsRunner extensionsRunner;
 
     @Inject
     public DeleteModelTransportAction(
@@ -57,8 +54,7 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         FeatureManager featureManager,
         CacheProvider cache,
         ADTaskCacheManager adTaskCacheManager,
-        EntityColdStarter coldStarter,
-        ExtensionsRunner extensionsRunner
+        EntityColdStarter coldStarter
     ) {
         super(DeleteModelAction.NAME, actionFilters, taskManager);
         this.clusterService = clusterService;
@@ -68,7 +64,6 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         this.cache = cache;
         this.adTaskCacheManager = adTaskCacheManager;
         this.coldStarter = coldStarter;
-        this.extensionsRunner = extensionsRunner;
     }
 
     @Override
@@ -111,6 +106,6 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         List<DeleteModelNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new DeleteModelResponse(new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")), responses, failures);
+        return new DeleteModelResponse(clusterService.getClusterName(), responses, failures);
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
@@ -27,7 +27,6 @@ import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.cluster.ClusterName;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
@@ -45,7 +44,7 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
     private ADTaskCacheManager adTaskCacheManager;
     private EntityColdStarter coldStarter;
     private SDKClusterService clusterService;
-    private Settings settings;
+    private ExtensionsRunner extensionsRunner;
 
     @Inject
     public DeleteModelTransportAction(
@@ -69,7 +68,7 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         this.cache = cache;
         this.adTaskCacheManager = adTaskCacheManager;
         this.coldStarter = coldStarter;
-        this.settings = extensionsRunner.getEnvironmentSettings();
+        this.extensionsRunner = extensionsRunner;
     }
 
     @Override
@@ -112,6 +111,6 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         List<DeleteModelNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new DeleteModelResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
+        return new DeleteModelResponse(new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")), responses, failures);
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteModelTransportAction.java
@@ -26,6 +26,9 @@ import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.task.ADTaskCacheManager;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -42,6 +45,7 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
     private ADTaskCacheManager adTaskCacheManager;
     private EntityColdStarter coldStarter;
     private SDKClusterService clusterService;
+    private Settings settings;
 
     @Inject
     public DeleteModelTransportAction(
@@ -54,7 +58,8 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         FeatureManager featureManager,
         CacheProvider cache,
         ADTaskCacheManager adTaskCacheManager,
-        EntityColdStarter coldStarter
+        EntityColdStarter coldStarter,
+        ExtensionsRunner extensionsRunner
     ) {
         super(DeleteModelAction.NAME, actionFilters, taskManager);
         this.clusterService = clusterService;
@@ -64,6 +69,7 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         this.cache = cache;
         this.adTaskCacheManager = adTaskCacheManager;
         this.coldStarter = coldStarter;
+        this.settings = extensionsRunner.getEnvironmentSettings();
     }
 
     @Override
@@ -106,6 +112,6 @@ public class DeleteModelTransportAction extends TransportAction<DeleteModelReque
         List<DeleteModelNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        return new DeleteModelResponse(clusterService.state().getClusterName(), responses, failures);
+        return new DeleteModelResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/ProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ProfileTransportAction.java
@@ -29,7 +29,6 @@ import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.ModelProfile;
-import org.opensearch.cluster.ClusterName;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
@@ -48,7 +47,6 @@ public class ProfileTransportAction extends TransportAction<ProfileRequest, Prof
     private SDKClusterService sdkClusterService;
     // the number of models to return. Defaults to 10.
     private volatile int numModelsToReturn;
-    private ExtensionsRunner extensionsRunner;
 
     /**
      * Constructor
@@ -72,7 +70,6 @@ public class ProfileTransportAction extends TransportAction<ProfileRequest, Prof
         CacheProvider cacheProvider
     ) {
         super(ProfileAction.NAME, actionFilters, taskManager);
-        this.extensionsRunner = extensionsRunner;
         this.modelManager = modelManager;
         this.featureManager = featureManager;
         this.cacheProvider = cacheProvider;
@@ -82,7 +79,7 @@ public class ProfileTransportAction extends TransportAction<ProfileRequest, Prof
     }
 
     private ProfileResponse newResponse(ProfileRequest request, List<ProfileNodeResponse> responses, List<FailedNodeException> failures) {
-        return new ProfileResponse(new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")), responses, failures);
+        return new ProfileResponse(sdkClusterService.getClusterName(), responses, failures);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/ProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ProfileTransportAction.java
@@ -30,7 +30,6 @@ import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.ModelProfile;
 import org.opensearch.cluster.ClusterName;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
@@ -49,7 +48,7 @@ public class ProfileTransportAction extends TransportAction<ProfileRequest, Prof
     private SDKClusterService sdkClusterService;
     // the number of models to return. Defaults to 10.
     private volatile int numModelsToReturn;
-    private Settings settings;
+    private ExtensionsRunner extensionsRunner;
 
     /**
      * Constructor
@@ -73,17 +72,17 @@ public class ProfileTransportAction extends TransportAction<ProfileRequest, Prof
         CacheProvider cacheProvider
     ) {
         super(ProfileAction.NAME, actionFilters, taskManager);
+        this.extensionsRunner = extensionsRunner;
         this.modelManager = modelManager;
         this.featureManager = featureManager;
         this.cacheProvider = cacheProvider;
         this.sdkClusterService = sdkClusterService;
-        this.settings = extensionsRunner.getEnvironmentSettings();
-        this.numModelsToReturn = MAX_MODEL_SIZE_PER_NODE.get(settings);
+        this.numModelsToReturn = MAX_MODEL_SIZE_PER_NODE.get(extensionsRunner.getEnvironmentSettings());
         this.sdkClusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_MODEL_SIZE_PER_NODE, it -> this.numModelsToReturn = it);
     }
 
     private ProfileResponse newResponse(ProfileRequest request, List<ProfileNodeResponse> responses, List<FailedNodeException> failures) {
-        return new ProfileResponse(new ClusterName(settings.get("cluster.name")), responses, failures);
+        return new ProfileResponse(new ClusterName(extensionsRunner.getEnvironmentSettings().get("cluster.name")), responses, failures);
     }
 
     @Override

--- a/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
@@ -44,12 +44,10 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.extensions.DiscoveryExtensionNode;
-import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -70,7 +68,9 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
         ThreadPool threadPool = mock(ThreadPool.class);
 
         SDKClusterService clusterService = mock(SDKClusterService.class);
+        ClusterName clusterName = mock(ClusterName.class);
         ClusterState clusterState = mock(ClusterState.class);
+        when(clusterService.getClusterName()).thenReturn(clusterName);
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.getClusterName()).thenReturn(new ClusterName("clustername"));
         localNodeID = "foo";
@@ -95,9 +95,6 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
         when(cacheProvider.get()).thenReturn(entityCache);
         ADTaskCacheManager adTaskCacheManager = mock(ADTaskCacheManager.class);
         EntityColdStarter coldStarter = mock(EntityColdStarter.class);
-        ExtensionsRunner extensionsRunner = mock(ExtensionsRunner.class);
-        Settings settings = Settings.builder().put("cluster.name", "clusterName").build();
-        when(extensionsRunner.getEnvironmentSettings()).thenReturn(settings);
 
         action = new DeleteModelTransportAction(
             threadPool,
@@ -109,8 +106,7 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
             featureManager,
             cacheProvider,
             adTaskCacheManager,
-            coldStarter,
-            extensionsRunner
+            coldStarter
         );
     }
 

--- a/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
@@ -44,10 +44,12 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.extensions.DiscoveryExtensionNode;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKClusterService;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -93,6 +95,9 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
         when(cacheProvider.get()).thenReturn(entityCache);
         ADTaskCacheManager adTaskCacheManager = mock(ADTaskCacheManager.class);
         EntityColdStarter coldStarter = mock(EntityColdStarter.class);
+        ExtensionsRunner extensionsRunner = mock(ExtensionsRunner.class);
+        Settings settings = Settings.builder().put("cluster.name", "clusterName").build();
+        when(extensionsRunner.getEnvironmentSettings()).thenReturn(settings);
 
         action = new DeleteModelTransportAction(
             threadPool,
@@ -104,7 +109,8 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
             featureManager,
             cacheProvider,
             adTaskCacheManager,
-            coldStarter
+            coldStarter,
+            extensionsRunner
         );
     }
 


### PR DESCRIPTION
### Description
SDK Companion PR : https://github.com/opensearch-project/opensearch-sdk-java/pull/818 (SDK PR must be merged first)

Retrieves cluster name from the SDKClusterService rather than from the cluster state
See comment [here](https://github.com/opensearch-project/opensearch-sdk-java/issues/674#issuecomment-1581621293) for more details

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/674

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
