### PR TITLE
Updated Maintainers and CODE_OWNERS list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @jmazanec15 @jngz-es @kaituo @saratvemulapalli @ohltyler @vamshin @VijayanB @ylwu-amzn @amitgalitz @sudiptoguha @jackiehanyang @sean-zheng-amazon
+* @jmazanec15 @jngz-es @kaituo @saratvemulapalli @ohltyler @vamshin @VijayanB @ylwu-amzn @amitgalitz @sudiptoguha @jackiehanyang @sean-zheng-amazon @dbwiddis @owaiskazi19 @joshpalis
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sudipto Guha            | [sudiptoguha](https://github.com/sudiptoguha)            | Amazon      |
 | Jackie Han              | [jackiehanyang](https://github.com/jackiehanyang)        | Amazon      |
 | Sean Zheng              | [sean-zheng-amazon](https://github.com/sean-zheng-amazon)| Amazon      |
+| Dan Widdis              | [dbwiddis](https://github.com/dbwiddis)                  | Amazon      |
+| Owais Kazi              | [owaiskazi19](https://github.com/owaiskazi19)            | Amazon      |
+| Josh Palis              | [joshpalis](https://github.com/joshpalis)                | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Update outdated MAINTAINERS and OWNERS list

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
