### PR TITLE
Enforce DOCUMENT Replication for AD Indices and Adjust Primary Shards

### DIFF
--- a/src/main/java/org/opensearch/forecast/indices/ForecastIndexManagement.java
+++ b/src/main/java/org/opensearch/forecast/indices/ForecastIndexManagement.java
@@ -204,8 +204,8 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
         } catch (IOException e) {
             throw new EndRunException("", "Cannot find checkpoint mapping file", true);
         }
-        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
-        // found).
+        // forecast indices need RAW (e.g., we want users to be able to consume forecast results as soon as
+        // possible and send out an alert if a threshold is breached).
         Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
         CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_CHECKPOINT_INDEX_NAME, replicationSettings)
             .mapping(mapping, XContentType.JSON);

--- a/src/main/java/org/opensearch/forecast/indices/ForecastIndexManagement.java
+++ b/src/main/java/org/opensearch/forecast/indices/ForecastIndexManagement.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.forecast.indices;
 
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.forecast.constant.ForecastCommonName.DUMMY_FORECAST_RESULT_ID;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_CHECKPOINT_INDEX_MAPPING_FILE;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_MAX_PRIMARY_SHARDS;
@@ -19,6 +20,7 @@ import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_RESULT_
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_RESULT_HISTORY_RETENTION_PERIOD;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_RESULT_HISTORY_ROLLOVER_PERIOD;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_STATE_INDEX_MAPPING_FILE;
+import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
 
 import java.io.IOException;
 import java.util.EnumMap;
@@ -61,7 +63,7 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
      * @param settings       OS cluster setting
      * @param nodeFilter     Used to filter eligible nodes to host forecast indices
      * @param maxUpdateRunningTimes max number of retries to update index mapping and setting
-     * @throws IOException
+     * @throws IOException when failing to get mapping file
      */
     public ForecastIndexManagement(
         Client client,
@@ -177,7 +179,8 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
     @Override
     public void initStateIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_STATE_INDEX)
+            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+            CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_STATE_INDEX, replicationSettings)
                 .mapping(getStateMappings(), XContentType.JSON)
                 .settings(settings);
             adminClient.indices().create(request, markMappingUpToDate(ForecastIndex.STATE, actionListener));
@@ -201,7 +204,10 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
         } catch (IOException e) {
             throw new EndRunException("", "Cannot find checkpoint mapping file", true);
         }
-        CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_CHECKPOINT_INDEX_NAME)
+        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
+        // found).
+        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+        CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_CHECKPOINT_INDEX_NAME, replicationSettings)
             .mapping(mapping, XContentType.JSON);
         choosePrimaryShards(request, true);
         adminClient.indices().create(request, markMappingUpToDate(ForecastIndex.CHECKPOINT, actionListener));

--- a/src/main/java/org/opensearch/forecast/settings/ForecastSettings.java
+++ b/src/main/java/org/opensearch/forecast/settings/ForecastSettings.java
@@ -111,7 +111,7 @@ public final class ForecastSettings {
 
     // max number of primary shards of a forecast index
     public static final Setting<Integer> FORECAST_MAX_PRIMARY_SHARDS = Setting
-        .intSetting("plugins.forecast.max_primary_shards", 10, 0, 200, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .intSetting("plugins.forecast.max_primary_shards", 20, 0, 200, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     // ======================================
     // Security

--- a/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
+++ b/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.timeseries.indices;
 
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
 import static org.opensearch.timeseries.constant.CommonMessages.CAN_NOT_FIND_RESULT_INDEX;
 
 import java.io.IOException;
@@ -426,7 +428,10 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
      * @throws IOException IOException from {@link IndexManagement#getConfigMappings}
      */
     public void initConfigIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
-        CreateIndexRequest request = new CreateIndexRequest(CommonName.CONFIG_INDEX)
+        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
+        // found).
+        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+        CreateIndexRequest request = new CreateIndexRequest(CommonName.CONFIG_INDEX, replicationSettings)
             .mapping(getConfigMappings(), XContentType.JSON)
             .settings(settings);
         adminClient.indices().create(request, actionListener);
@@ -477,7 +482,11 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
      */
     public void initJobIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            CreateIndexRequest request = new CreateIndexRequest(CommonName.JOB_INDEX).mapping(getJobMappings(), XContentType.JSON);
+            // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if
+            // anomalies found).
+            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+            CreateIndexRequest request = new CreateIndexRequest(CommonName.JOB_INDEX, replicationSettings)
+                .mapping(getJobMappings(), XContentType.JSON);
             request
                 .settings(
                     Settings
@@ -928,7 +937,10 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
 
         CreateIndexRequest createRequest = rollOverRequest.getCreateIndexRequest();
 
-        createRequest.index(rolloverIndexPattern).mapping(resultMapping, XContentType.JSON);
+        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
+        // found).
+        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+        createRequest.index(rolloverIndexPattern).settings(replicationSettings).mapping(resultMapping, XContentType.JSON);
 
         choosePrimaryShards(createRequest, true);
 
@@ -953,7 +965,10 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
         IndexType resultIndex,
         ActionListener<CreateIndexResponse> actionListener
     ) {
-        CreateIndexRequest request = new CreateIndexRequest(resultIndexName).mapping(resultMapping, XContentType.JSON);
+        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
+        // found).
+        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
+        CreateIndexRequest request = new CreateIndexRequest(resultIndexName, replicationSettings).mapping(resultMapping, XContentType.JSON);
         if (alias != null) {
             request.alias(new Alias(alias));
         }

--- a/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
+++ b/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
@@ -428,8 +428,8 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
      * @throws IOException IOException from {@link IndexManagement#getConfigMappings}
      */
     public void initConfigIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
-        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
-        // found).
+        // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as possible
+        // and send out an alert if anomalies found).
         Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
         CreateIndexRequest request = new CreateIndexRequest(CommonName.CONFIG_INDEX, replicationSettings)
             .mapping(getConfigMappings(), XContentType.JSON)
@@ -482,8 +482,8 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
      */
     public void initJobIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if
-            // anomalies found).
+            // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as
+            // possible and send out an alert if anomalies found).
             Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
             CreateIndexRequest request = new CreateIndexRequest(CommonName.JOB_INDEX, replicationSettings)
                 .mapping(getJobMappings(), XContentType.JSON);
@@ -937,8 +937,8 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
 
         CreateIndexRequest createRequest = rollOverRequest.getCreateIndexRequest();
 
-        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
-        // found).
+        // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as possible
+        // and send out an alert if anomalies found).
         Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
         createRequest.index(rolloverIndexPattern).settings(replicationSettings).mapping(resultMapping, XContentType.JSON);
 
@@ -965,8 +965,8 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
         IndexType resultIndex,
         ActionListener<CreateIndexResponse> actionListener
     ) {
-        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
-        // found).
+        // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as possible
+        // and send out an alert if anomalies found).
         Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
         CreateIndexRequest request = new CreateIndexRequest(resultIndexName, replicationSettings).mapping(resultMapping, XContentType.JSON);
         if (alias != null) {


### PR DESCRIPTION
### Description
In this PR, we temporarily enforce DOCUMENT replication for AD indices. This change is necessary due to the current limitation of SegRep, which doesn't support Get/MultiGet by ID. This measure will be in place until SegRep adds support for these operations.

This adjustment aligns with the modification made in the referenced PR: https://github.com/opensearch-project/job-scheduler/pull/417

Additionally, this PR increases the number of primary shards for forecasting indices from 10 to 20, recognizing the higher write intensity of these indices. For instance, when the horizon is 24, we are expected to save 25 documents: 24 for each forecast and 1 for the actual value. In contrast, for AD, we save one document per actual value.

Testing done:
1. gradle build passed

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/936

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
