### PR TITLE
Fix build with latest OpenSearch (for real this time)

### DIFF
--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -29,7 +29,6 @@ import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
-import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -327,7 +326,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             .endObject()
             .endObject();
         Request request = new Request("PUT", "_cluster/settings");
-        request.setJsonEntity(Strings.toString(builder));
+        request.setJsonEntity(builder.toString());
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
         Thread.sleep(2000); // sleep some time to resolve flaky test

--- a/src/test/java/org/opensearch/ad/e2e/AbstractSyntheticDataTest.java
+++ b/src/test/java/org/opensearch/ad/e2e/AbstractSyntheticDataTest.java
@@ -66,7 +66,7 @@ public class AbstractSyntheticDataTest extends ODFERestTestCase {
         settingCommand.endObject();
         settingCommand.endObject();
         Request request = new Request("PUT", "/_cluster/settings");
-        request.setJsonEntity(org.opensearch.common.Strings.toString(settingCommand));
+        request.setJsonEntity(settingCommand.toString());
 
         adminClient().performRequest(request);
     }

--- a/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/EntityProfileTests.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.constant.ADCommonName;
-import org.opensearch.common.Strings;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
@@ -38,7 +37,7 @@ public class EntityProfileTests extends AbstractTimeSeriesTest {
 
         XContentBuilder builder = jsonBuilder();
         profile1.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         assertEquals("INIT", JsonDeserializer.getTextValue(json, ADCommonName.STATE));
 
@@ -46,7 +45,7 @@ public class EntityProfileTests extends AbstractTimeSeriesTest {
 
         builder = jsonBuilder();
         profile2.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        json = Strings.toString(builder);
+        json = builder.toString();
 
         assertTrue(false == JsonDeserializer.hasChildNode(json, ADCommonName.STATE));
     }
@@ -56,7 +55,7 @@ public class EntityProfileTests extends AbstractTimeSeriesTest {
 
         XContentBuilder builder = jsonBuilder();
         profile1.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         assertEquals("INIT", JsonDeserializer.getTextValue(json, ADCommonName.STATE));
 
@@ -64,7 +63,7 @@ public class EntityProfileTests extends AbstractTimeSeriesTest {
 
         builder = jsonBuilder();
         profile2.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        json = Strings.toString(builder);
+        json = builder.toString();
 
         assertTrue(false == JsonDeserializer.hasChildNode(json, ADCommonName.STATE));
     }

--- a/src/test/java/org/opensearch/ad/model/ModelProfileTests.java
+++ b/src/test/java/org/opensearch/ad/model/ModelProfileTests.java
@@ -15,7 +15,6 @@ import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
 
-import org.opensearch.common.Strings;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
@@ -33,14 +32,14 @@ public class ModelProfileTests extends AbstractTimeSeriesTest {
             0
         );
         XContentBuilder builder = getBuilder(profile1);
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertTrue(JsonDeserializer.hasChildNode(json, CommonName.ENTITY_KEY));
         assertFalse(JsonDeserializer.hasChildNode(json, CommonName.MODEL_SIZE_IN_BYTES));
 
         ModelProfile profile2 = new ModelProfile(randomAlphaOfLength(5), null, 1);
 
         builder = getBuilder(profile2);
-        json = Strings.toString(builder);
+        json = builder.toString();
 
         assertFalse(JsonDeserializer.hasChildNode(json, CommonName.ENTITY_KEY));
         assertTrue(JsonDeserializer.hasChildNode(json, CommonName.MODEL_SIZE_IN_BYTES));

--- a/src/test/java/org/opensearch/ad/transport/ADStatsTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADStatsTests.java
@@ -38,7 +38,6 @@ import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.transport.TransportAddress;
@@ -117,7 +116,7 @@ public class ADStatsTests extends OpenSearchTestCase {
         // Test toXContent
         XContentBuilder builder = jsonBuilder();
         adStatsNodeResponse.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject();
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         for (Map.Entry<String, Object> stat : stats.entrySet()) {
             assertEquals("toXContent does not work", JsonDeserializer.getTextValue(json, stat.getKey()), stat.getValue());
@@ -164,7 +163,7 @@ public class ADStatsTests extends OpenSearchTestCase {
         // Test toXContent
         XContentBuilder builder = jsonBuilder();
         adStatsNodeResponse.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject();
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         for (Map.Entry<String, Object> stat : stats.entrySet()) {
             if (stat.getKey().equals(ModelState.LAST_CHECKPOINT_TIME_KEY) || stat.getKey().equals(ModelState.LAST_USED_TIME_KEY)) {
@@ -236,7 +235,7 @@ public class ADStatsTests extends OpenSearchTestCase {
         // Test toXContent
         XContentBuilder builder = jsonBuilder();
         adStatsNodesResponse.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject();
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         logger.info("JSON: " + json);
 
@@ -260,7 +259,7 @@ public class ADStatsTests extends OpenSearchTestCase {
         ADStatsNodesResponse readRequest = new ADStatsNodesResponse(streamInput);
 
         builder = jsonBuilder();
-        String readJson = Strings.toString(readRequest.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject());
+        String readJson = readRequest.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject().toString();
         assertEquals("Serialization fails", readJson, json);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -90,7 +90,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -1016,7 +1015,7 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
         XContentBuilder builder = jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         Function<JsonElement, FeatureData> function = (s) -> {
             try {
                 String featureId = JsonDeserializer.getTextValue(s, FeatureData.FEATURE_ID_FIELD);
@@ -1065,7 +1064,7 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
         XContentBuilder builder = jsonBuilder();
         request.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getTextValue(json, ADCommonName.ID_JSON_KEY), request.getAdID());
         assertEquals(JsonDeserializer.getLongValue(json, CommonName.START_JSON_KEY), request.getStart());
         assertEquals(JsonDeserializer.getLongValue(json, CommonName.END_JSON_KEY), request.getEnd());

--- a/src/test/java/org/opensearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/CronTransportActionTests.java
@@ -33,7 +33,6 @@ import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -113,7 +112,7 @@ public class CronTransportActionTests extends AbstractTimeSeriesTest {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         Function<JsonElement, String> function = (s) -> {
             try {
                 return JsonDeserializer.getTextValue(s, CronNodeResponse.NODE_ID);

--- a/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteModelTransportActionTests.java
@@ -38,7 +38,6 @@ import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -118,7 +117,7 @@ public class DeleteModelTransportActionTests extends AbstractTimeSeriesTest {
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         Function<JsonElement, String> function = (s) -> {
             try {
                 return JsonDeserializer.getTextValue(s, CronNodeResponse.NODE_ID);

--- a/src/test/java/org/opensearch/ad/transport/DeleteTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteTests.java
@@ -47,7 +47,6 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -185,7 +184,7 @@ public class DeleteTests extends AbstractTimeSeriesTest {
         XContentBuilder builder = jsonBuilder();
         request.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getTextValue(json, ADCommonName.ID_JSON_KEY), requestSupplier.get());
     }
 

--- a/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
@@ -74,7 +74,6 @@ import org.opensearch.ad.stats.ADStat;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.stats.suppliers.CounterSupplier;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -357,7 +356,7 @@ public class EntityResultTransportActionTests extends AbstractTimeSeriesTest {
         XContentBuilder builder = jsonBuilder();
         request.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getTextValue(json, ADCommonName.ID_JSON_KEY), detectorId);
         assertEquals(JsonDeserializer.getLongValue(json, CommonName.START_JSON_KEY), start);
         assertEquals(JsonDeserializer.getLongValue(json, CommonName.END_JSON_KEY), end);

--- a/src/test/java/org/opensearch/ad/transport/ProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ProfileTests.java
@@ -35,7 +35,6 @@ import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.ModelProfileOnNode;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.transport.TransportAddress;
@@ -153,7 +152,7 @@ public class ProfileTests extends OpenSearchTestCase {
         // Test toXContent
         XContentBuilder builder = jsonBuilder();
         profileNodeResponse.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject();
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         for (Map.Entry<String, Long> profile : modelSizeMap1.entrySet()) {
             assertEquals(
@@ -229,7 +228,7 @@ public class ProfileTests extends OpenSearchTestCase {
         // Test toXContent
         XContentBuilder builder = jsonBuilder();
         profileResponse.toXContent(builder.startObject(), ToXContent.EMPTY_PARAMS).endObject();
-        String json = Strings.toString(builder);
+        String json = builder.toString();
 
         logger.info("JSON: " + json);
 

--- a/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
@@ -49,7 +49,6 @@ import org.opensearch.ad.stats.ADStat;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.stats.suppliers.CounterSupplier;
 import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -233,7 +232,7 @@ public class RCFResultTests extends OpenSearchTestCase {
         XContentBuilder builder = jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getDoubleValue(json, RCFResultResponse.RCF_SCORE_JSON_KEY), response.getRCFScore(), 0.001);
         assertEquals(JsonDeserializer.getDoubleValue(json, RCFResultResponse.FOREST_SIZE_JSON_KEY), response.getForestSize(), 0.001);
         assertTrue(
@@ -267,7 +266,7 @@ public class RCFResultTests extends OpenSearchTestCase {
         XContentBuilder builder = jsonBuilder();
         request.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getTextValue(json, ADCommonName.ID_JSON_KEY), request.getAdID());
         assertArrayEquals(JsonDeserializer.getDoubleArrayValue(json, ADCommonName.FEATURE_JSON_KEY), request.getFeatures(), 0.001);
     }

--- a/src/test/java/org/opensearch/ad/transport/StopDetectorActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/StopDetectorActionTests.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.ActionResponse;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -94,7 +93,7 @@ public class StopDetectorActionTests extends OpenSearchIntegTestCase {
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
         stopDetectorResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertNotNull(builder);
-        String jsonStr = Strings.toString(builder);
+        String jsonStr = builder.toString();
         assertEquals("{\"success\":true}", jsonStr);
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
@@ -32,7 +32,6 @@ import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.ml.ThresholdingResult;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -117,7 +116,7 @@ public class ThresholdResultTests extends OpenSearchTestCase {
         XContentBuilder builder = jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getDoubleValue(json, ADCommonName.ANOMALY_GRADE_JSON_KEY), response.getAnomalyGrade(), 0.001);
         assertEquals(JsonDeserializer.getDoubleValue(json, ADCommonName.CONFIDENCE_JSON_KEY), response.getConfidence(), 0.001);
     }
@@ -148,7 +147,7 @@ public class ThresholdResultTests extends OpenSearchTestCase {
         XContentBuilder builder = jsonBuilder();
         request.toXContent(builder, ToXContent.EMPTY_PARAMS);
 
-        String json = Strings.toString(builder);
+        String json = builder.toString();
         assertEquals(JsonDeserializer.getTextValue(json, ADCommonName.ID_JSON_KEY), request.getAdID());
         assertEquals(JsonDeserializer.getDoubleValue(json, ADCommonName.RCF_SCORE_JSON_KEY), request.getRCFScore(), 0.001);
     }


### PR DESCRIPTION
This is a follow-up to #971, where commit 2839bc2c6f470639b68901086c80cb2152d96558 only fixed _some_ but not _all_ of the build errors (it allowed `./gradlew run` to pass but `./gradlew build` was failing).

Fix the build errors when we run `./gradlew build`.
