### PR TITLE
[Backport 2.x] Defaults anomaly grade to 0 if negative

### DIFF
--- a/src/main/java/org/opensearch/ad/model/AnomalyResult.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyResult.java
@@ -426,7 +426,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             detectorId,
             taskId,
             rcfScore,
-            grade,
+            Math.max(0, grade),
             confidence,
             featureData,
             dataStartTime,


### PR DESCRIPTION
### Description
Manual Backport of https://github.com/opensearch-project/anomaly-detection/pull/976 (without the import changes since these were already handled by #974 )


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
