### PR TITLE
Refactoring task cache manager for forecasting

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorJobRunner.java
@@ -112,7 +112,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
 
     public void setSettings(Settings settings) {
         this.settings = settings;
-        this.maxRetryForEndRunException = AnomalyDetectorSettings.MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings);
+        this.maxRetryForEndRunException = AnomalyDetectorSettings.AD_MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings);
     }
 
     public void setAdTaskManager(ADTaskManager adTaskManager) {

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorProfileRunner.java
@@ -39,7 +39,6 @@ import org.opensearch.ad.model.DetectorProfileName;
 import org.opensearch.ad.model.DetectorState;
 import org.opensearch.ad.model.InitProgressProfile;
 import org.opensearch.ad.settings.ADNumericSetting;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.ad.transport.ProfileAction;
 import org.opensearch.ad.transport.ProfileRequest;
@@ -70,6 +69,7 @@ import org.opensearch.timeseries.common.exception.ResourceNotFoundException;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
 import org.opensearch.timeseries.model.Job;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.DiscoveryNodeFilterer;
 import org.opensearch.timeseries.util.ExceptionUtil;
 import org.opensearch.timeseries.util.MultiResponsesDelegateActionListener;
@@ -105,7 +105,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
         }
         this.transportService = transportService;
         this.adTaskManager = adTaskManager;
-        this.maxTotalEntitiesToTrack = AnomalyDetectorSettings.MAX_TOTAL_ENTITIES_TO_TRACK;
+        this.maxTotalEntitiesToTrack = TimeSeriesSettings.MAX_TOTAL_ENTITIES_TO_TRACK;
     }
 
     public void profile(String detectorId, ActionListener<DetectorProfile> listener, Set<DetectorProfileName> profilesToCollect) {

--- a/src/main/java/org/opensearch/ad/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ModelManager.java
@@ -33,17 +33,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ad.DetectorModelSize;
-import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.model.AnomalyDetector;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.util.DateUtils;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.timeseries.MemoryTracker;
 import org.opensearch.timeseries.common.exception.ResourceNotFoundException;
 import org.opensearch.timeseries.ml.SingleStreamModelIdMapper;
 import org.opensearch.timeseries.model.Entity;
@@ -624,7 +623,7 @@ public class ModelManager implements DetectorModelSize {
             .parallelExecutionEnabled(false)
             .compact(true)
             .precision(Precision.FLOAT_32)
-            .boundingBoxCacheFraction(AnomalyDetectorSettings.BATCH_BOUNDING_BOX_CACHE_RATIO)
+            .boundingBoxCacheFraction(TimeSeriesSettings.BATCH_BOUNDING_BOX_CACHE_RATIO)
             .shingleSize(shingleSize)
             .anomalyRate(1 - this.thresholdMinPvalue)
             .transformMethod(TransformMethod.NORMALIZE)

--- a/src/main/java/org/opensearch/ad/ml/TRCFMemoryAwareConcurrentHashmap.java
+++ b/src/main/java/org/opensearch/ad/ml/TRCFMemoryAwareConcurrentHashmap.java
@@ -13,8 +13,8 @@ package org.opensearch.ad.ml;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.opensearch.ad.MemoryTracker;
-import org.opensearch.ad.MemoryTracker.Origin;
+import org.opensearch.timeseries.MemoryTracker;
+import org.opensearch.timeseries.MemoryTracker.Origin;
 
 import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
 
@@ -37,7 +37,7 @@ public class TRCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, Mo
         ModelState<ThresholdedRandomCutForest> deletedModelState = super.remove(key);
         if (deletedModelState != null && deletedModelState.getModel() != null) {
             long memoryToRelease = memoryTracker.estimateTRCFModelSize(deletedModelState.getModel());
-            memoryTracker.releaseMemory(memoryToRelease, true, Origin.SINGLE_ENTITY_DETECTOR);
+            memoryTracker.releaseMemory(memoryToRelease, true, Origin.REAL_TIME_DETECTOR);
         }
         return deletedModelState;
     }
@@ -47,7 +47,7 @@ public class TRCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, Mo
         ModelState<ThresholdedRandomCutForest> previousAssociatedState = super.put(key, value);
         if (value != null && value.getModel() != null) {
             long memoryToConsume = memoryTracker.estimateTRCFModelSize(value.getModel());
-            memoryTracker.consumeMemory(memoryToConsume, true, Origin.SINGLE_ENTITY_DETECTOR);
+            memoryTracker.consumeMemory(memoryToConsume, true, Origin.REAL_TIME_DETECTOR);
         }
         return previousAssociatedState;
     }

--- a/src/main/java/org/opensearch/ad/ratelimit/BatchWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/BatchWorker.java
@@ -19,7 +19,6 @@ import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.ThreadedActionListener;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -27,6 +26,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 
 /**
  *
@@ -46,7 +46,7 @@ public abstract class BatchWorker<RequestType extends QueuedRequest, BatchReques
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorker.java
@@ -23,13 +23,13 @@ import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 
 public class CheckpointMaintainWorker extends ScheduledWorker<CheckpointMaintainRequest, CheckpointWriteRequest> {
     private static final Logger LOG = LogManager.getLogger(CheckpointMaintainWorker.class);
@@ -43,7 +43,7 @@ public class CheckpointMaintainWorker extends ScheduledWorker<CheckpointMaintain
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
@@ -32,7 +32,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.get.MultiGetItemResponse;
 import org.opensearch.action.get.MultiGetRequest;
 import org.opensearch.action.get.MultiGetResponse;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.indices.ADIndex;
@@ -53,6 +52,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.EndRunException;
 import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.model.Config;
@@ -91,7 +91,7 @@ public class CheckpointReadWorker extends BatchWorker<EntityFeatureRequest, Mult
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
@@ -30,7 +30,6 @@ import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.ml.CheckpointDao;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelState;
@@ -43,6 +42,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.util.ExceptionUtil;
 
@@ -60,7 +60,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
@@ -12,7 +12,7 @@
 package org.opensearch.ad.ratelimit;
 
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -20,13 +20,13 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 
 /**
  * A queue slowly releasing low-priority requests to CheckpointReadQueue
@@ -52,7 +52,7 @@ public class ColdEntityWorker extends ScheduledWorker<EntityFeatureRequest, Enti
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,
@@ -87,12 +87,12 @@ public class ColdEntityWorker extends ScheduledWorker<EntityFeatureRequest, Enti
         this.batchSize = AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE, it -> this.batchSize = it);
 
-        this.expectedExecutionTimeInMilliSecsPerRequest = AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS
+        this.expectedExecutionTimeInMilliSecsPerRequest = AnomalyDetectorSettings.AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS
             .get(settings);
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(
-                EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
+                AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
                 it -> this.expectedExecutionTimeInMilliSecsPerRequest = it
             );
     }

--- a/src/main/java/org/opensearch/ad/ratelimit/ConcurrentWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ConcurrentWorker.java
@@ -19,13 +19,13 @@ import java.util.concurrent.Semaphore;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 
 /**
  * A queue to run concurrent requests (either batch or single request).
@@ -74,7 +74,7 @@ public abstract class ConcurrentWorker<RequestType extends QueuedRequest> extend
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartWorker.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.ratelimit;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_CONCURRENCY;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_ENTITY_COLD_START_QUEUE_CONCURRENCY;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -23,7 +23,6 @@ import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.EntityModel;
@@ -37,6 +36,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.util.ExceptionUtil;
 
 /**
@@ -61,7 +61,7 @@ public class EntityColdStartWorker extends SingleRequestWorker<EntityRequest> {
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,
@@ -90,7 +90,7 @@ public class EntityColdStartWorker extends SingleRequestWorker<EntityRequest> {
             mediumSegmentPruneRatio,
             lowSegmentPruneRatio,
             maintenanceFreqConstant,
-            ENTITY_COLD_START_QUEUE_CONCURRENCY,
+            AD_ENTITY_COLD_START_QUEUE_CONCURRENCY,
             executionTtl,
             stateTtl,
             nodeStateManager

--- a/src/main/java/org/opensearch/ad/ratelimit/RateLimitedRequestWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/RateLimitedRequestWorker.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -44,6 +43,7 @@ import org.opensearch.timeseries.ExpiringState;
 import org.opensearch.timeseries.MaintenanceState;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.TimeSeriesException;
 
 /**
@@ -175,7 +175,7 @@ public abstract class RateLimitedRequestWorker<RequestType extends QueuedRequest
     protected final ConcurrentSkipListMap<String, RequestQueue> requestQueues;
     private String lastSelectedRequestQueueId;
     protected Random random;
-    private ADCircuitBreakerService adCircuitBreakerService;
+    private CircuitBreakerService adCircuitBreakerService;
     protected ThreadPool threadPool;
     protected Instant cooldownStart;
     protected int coolDownMinutes;
@@ -194,7 +194,7 @@ public abstract class RateLimitedRequestWorker<RequestType extends QueuedRequest
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.transport.ADResultBulkRequest;
@@ -44,6 +43,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.util.ExceptionUtil;
 
@@ -60,7 +60,7 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ScheduledWorker.java
@@ -18,7 +18,6 @@ import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -26,6 +25,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 
 public abstract class ScheduledWorker<RequestType extends QueuedRequest, TransformedRequestType extends QueuedRequest> extends
     RateLimitedRequestWorker<RequestType> {
@@ -45,7 +45,7 @@ public abstract class ScheduledWorker<RequestType extends QueuedRequest, Transfo
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/ratelimit/SingleRequestWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/SingleRequestWorker.java
@@ -19,13 +19,13 @@ import java.util.concurrent.BlockingQueue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 
 public abstract class SingleRequestWorker<RequestType extends QueuedRequest> extends ConcurrentWorker<RequestType> {
     private static final Logger LOG = LogManager.getLogger(SingleRequestWorker.class);
@@ -37,7 +37,7 @@ public abstract class SingleRequestWorker<RequestType extends QueuedRequest> ext
         Setting<Float> maxHeapPercentForQueueSetting,
         ClusterService clusterService,
         Random random,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ThreadPool threadPool,
         Settings settings,
         float maxQueuedTaskRatio,

--- a/src/main/java/org/opensearch/ad/rest/AbstractAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/AbstractAnomalyDetectorAction.java
@@ -11,12 +11,12 @@
 
 package org.opensearch.ad.rest;
 
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_REQUEST_TIMEOUT;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.DETECTION_INTERVAL;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.DETECTION_WINDOW_DELAY;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -36,8 +36,8 @@ public abstract class AbstractAnomalyDetectorAction extends BaseRestHandler {
         this.requestTimeout = AD_REQUEST_TIMEOUT.get(settings);
         this.detectionInterval = DETECTION_INTERVAL.get(settings);
         this.detectionWindowDelay = DETECTION_WINDOW_DELAY.get(settings);
-        this.maxSingleEntityDetectors = MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings);
-        this.maxMultiEntityDetectors = MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings);
+        this.maxSingleEntityDetectors = AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings);
+        this.maxMultiEntityDetectors = AD_MAX_HC_ANOMALY_DETECTORS.get(settings);
         this.maxAnomalyFeatures = MAX_ANOMALY_FEATURES.get(settings);
         // TODO: will add more cluster setting consumer later
         // TODO: inject ClusterSettings only if clusterService is only used to get ClusterSettings
@@ -46,10 +46,8 @@ public abstract class AbstractAnomalyDetectorAction extends BaseRestHandler {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DETECTION_WINDOW_DELAY, it -> detectionWindowDelay = it);
         clusterService
             .getClusterSettings()
-            .addSettingsUpdateConsumer(MAX_SINGLE_ENTITY_ANOMALY_DETECTORS, it -> maxSingleEntityDetectors = it);
-        clusterService
-            .getClusterSettings()
-            .addSettingsUpdateConsumer(MAX_MULTI_ENTITY_ANOMALY_DETECTORS, it -> maxMultiEntityDetectors = it);
+            .addSettingsUpdateConsumer(AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS, it -> maxSingleEntityDetectors = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_MAX_HC_ANOMALY_DETECTORS, it -> maxMultiEntityDetectors = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
     }
 }

--- a/src/main/java/org/opensearch/ad/settings/LegacyOpenDistroAnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/LegacyOpenDistroAnomalyDetectorSettings.java
@@ -170,7 +170,7 @@ public class LegacyOpenDistroAnomalyDetectorSettings {
             Setting.Property.Deprecated
         );
 
-    public static final Setting<Boolean> FILTER_BY_BACKEND_ROLES = Setting
+    public static final Setting<Boolean> AD_FILTER_BY_BACKEND_ROLES = Setting
         .boolSetting(
             "opendistro.anomaly_detection.filter_by_backend_roles",
             false,

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
@@ -14,7 +14,7 @@ package org.opensearch.ad.stats.suppliers;
 import static org.opensearch.ad.ml.ModelState.LAST_CHECKPOINT_TIME_KEY;
 import static org.opensearch.ad.ml.ModelState.LAST_USED_TIME_KEY;
 import static org.opensearch.ad.ml.ModelState.MODEL_TYPE_KEY;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_MODEL_SIZE_PER_NODE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,8 +68,8 @@ public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>>
     public ModelsOnNodeSupplier(ModelManager modelManager, CacheProvider cache, Settings settings, ClusterService clusterService) {
         this.modelManager = modelManager;
         this.cache = cache;
-        this.numModelsToReturn = MAX_MODEL_SIZE_PER_NODE.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_MODEL_SIZE_PER_NODE, it -> this.numModelsToReturn = it);
+        this.numModelsToReturn = AD_MAX_MODEL_SIZE_PER_NODE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_MAX_MODEL_SIZE_PER_NODE, it -> this.numModelsToReturn = it);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskCache.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskCache.java
@@ -11,10 +11,10 @@
 
 package org.opensearch.ad.task;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_MIN_SAMPLES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_TREES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.TIME_DECAY;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.NUM_MIN_SAMPLES;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.NUM_SAMPLES_PER_TREE;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.NUM_TREES;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.TIME_DECAY;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -26,8 +26,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.AnomalyDetector;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.timeseries.model.Entity;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.config.TransformMethod;
@@ -78,9 +78,9 @@ public class ADBatchTaskCache {
             .parallelExecutionEnabled(false)
             .compact(true)
             .precision(Precision.FLOAT_32)
-            .boundingBoxCacheFraction(AnomalyDetectorSettings.BATCH_BOUNDING_BOX_CACHE_RATIO)
+            .boundingBoxCacheFraction(TimeSeriesSettings.BATCH_BOUNDING_BOX_CACHE_RATIO)
             .shingleSize(shingleSize)
-            .anomalyRate(1 - AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE)
+            .anomalyRate(1 - TimeSeriesSettings.THRESHOLD_MIN_PVALUE)
             .transformMethod(TransformMethod.NORMALIZE)
             .alertOnce(true)
             .autoAdjust(true)

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.ad.task;
 
-import static org.opensearch.ad.breaker.MemoryCircuitBreaker.DEFAULT_JVM_HEAP_USAGE_THRESHOLD;
 import static org.opensearch.ad.constant.ADCommonMessages.NO_ELIGIBLE_NODE_TO_RUN_DETECTOR;
 import static org.opensearch.ad.model.ADTask.CURRENT_PIECE_FIELD;
 import static org.opensearch.ad.model.ADTask.EXECUTION_END_TIME_FIELD;
@@ -25,9 +24,10 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_RUNNING_ENTITIES_PER_DETECTOR_FOR_HISTORICAL_ANALYSIS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_TOP_ENTITIES_FOR_HISTORICAL_ANALYSIS;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_TOP_ENTITIES_LIMIT_FOR_HISTORICAL_ANALYSIS;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_MIN_SAMPLES;
 import static org.opensearch.ad.stats.InternalStatNames.JVM_HEAP_USAGE;
 import static org.opensearch.timeseries.TimeSeriesAnalyticsPlugin.AD_BATCH_TASK_THREAD_POOL_NAME;
+import static org.opensearch.timeseries.breaker.MemoryCircuitBreaker.DEFAULT_JVM_HEAP_USAGE_THRESHOLD;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.NUM_MIN_SAMPLES;
 import static org.opensearch.timeseries.stats.StatNames.AD_EXECUTING_BATCH_TASK_COUNT;
 import static org.opensearch.timeseries.util.ParseUtils.isNullOrEmpty;
 
@@ -49,7 +49,6 @@ import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ThreadedActionListener;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.PriorityTracker;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.constant.ADCommonMessages;
@@ -92,6 +91,7 @@ import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.EndRunException;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.common.exception.ResourceNotFoundException;
@@ -129,7 +129,7 @@ public class ADBatchTaskRunner {
     private final ADStats adStats;
     private final ClusterService clusterService;
     private final FeatureManager featureManager;
-    private final ADCircuitBreakerService adCircuitBreakerService;
+    private final CircuitBreakerService adCircuitBreakerService;
     private final ADTaskManager adTaskManager;
     private final AnomalyResultBulkIndexHandler anomalyResultBulkIndexHandler;
     private final ADIndexManagement anomalyDetectionIndices;
@@ -155,7 +155,7 @@ public class ADBatchTaskRunner {
         ClusterService clusterService,
         Client client,
         SecurityClientUtil clientUtil,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         FeatureManager featureManager,
         ADTaskManager adTaskManager,
         ADIndexManagement anomalyDetectionIndices,

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -13,8 +13,8 @@ package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_START_DETECTOR;
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_STOP_DETECTOR;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_REQUEST_TIMEOUT;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
 import static org.opensearch.timeseries.util.ParseUtils.resolveUserAndExecute;
 import static org.opensearch.timeseries.util.RestHandlerUtils.wrapRestActionListener;
@@ -75,8 +75,8 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         this.anomalyDetectionIndices = anomalyDetectionIndices;
         this.xContentRegistry = xContentRegistry;
         this.adTaskManager = adTaskManager;
-        filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        filterByEnabled = AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.recorder = recorder;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyResultTransportAction.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.PAGE_SIZE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_PAGE_SIZE;
 import static org.opensearch.timeseries.constant.CommonMessages.INVALID_SEARCH_QUERY_MSG;
 
 import java.net.ConnectException;
@@ -42,7 +42,6 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.constant.ADCommonName;
@@ -79,6 +78,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.ClientException;
 import org.opensearch.timeseries.common.exception.EndRunException;
 import org.opensearch.timeseries.common.exception.InternalFailure;
@@ -92,6 +92,7 @@ import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.FeatureData;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.timeseries.util.ExceptionUtil;
 import org.opensearch.timeseries.util.ParseUtils;
@@ -124,7 +125,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ADStats adStats;
-    private final ADCircuitBreakerService adCircuitBreakerService;
+    private final CircuitBreakerService adCircuitBreakerService;
     private final ThreadPool threadPool;
     private final Client client;
     private final SecurityClientUtil clientUtil;
@@ -157,7 +158,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         HashRing hashRing,
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         ADStats adStats,
         ThreadPool threadPool,
         NamedXContentRegistry xContentRegistry,
@@ -184,13 +185,13 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         this.threadPool = threadPool;
         this.hcDetectors = new HashSet<>();
         this.xContentRegistry = xContentRegistry;
-        this.intervalRatioForRequest = AnomalyDetectorSettings.INTERVAL_RATIO_FOR_REQUESTS;
+        this.intervalRatioForRequest = TimeSeriesSettings.INTERVAL_RATIO_FOR_REQUESTS;
 
-        this.maxEntitiesPerInterval = MAX_ENTITIES_PER_QUERY.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ENTITIES_PER_QUERY, it -> maxEntitiesPerInterval = it);
+        this.maxEntitiesPerInterval = AD_MAX_ENTITIES_PER_QUERY.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_MAX_ENTITIES_PER_QUERY, it -> maxEntitiesPerInterval = it);
 
-        this.pageSize = PAGE_SIZE.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(PAGE_SIZE, it -> pageSize = it);
+        this.pageSize = AD_PAGE_SIZE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_PAGE_SIZE, it -> pageSize = it);
         this.adTaskManager = adTaskManager;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_DELETE_DETECTOR;
 import static org.opensearch.ad.model.ADTaskType.HISTORICAL_DETECTOR_TASK_TYPES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
 import static org.opensearch.timeseries.util.ParseUtils.resolveUserAndExecute;
@@ -80,8 +80,8 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
         this.clusterService = clusterService;
         this.xContentRegistry = xContentRegistry;
         this.adTaskManager = adTaskManager;
-        filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        filterByEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/DeleteAnomalyResultsTransportAction.java
@@ -12,7 +12,7 @@
 package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_DELETE_AD_RESULT;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
 import static org.opensearch.timeseries.util.RestHandlerUtils.wrapRestActionListener;
@@ -50,8 +50,8 @@ public class DeleteAnomalyResultsTransportAction extends HandledTransportAction<
     ) {
         super(DeleteAnomalyResultsAction.NAME, transportService, actionFilters, DeleteByQueryRequest::new);
         this.client = client;
-        filterEnabled = FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterEnabled = it);
+        filterEnabled = AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterEnabled = it);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.indices.ADIndex;
@@ -52,6 +51,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.EndRunException;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.constant.CommonMessages;
@@ -85,7 +85,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
 
     private static final Logger LOG = LogManager.getLogger(EntityResultTransportAction.class);
     private ModelManager modelManager;
-    private ADCircuitBreakerService adCircuitBreakerService;
+    private CircuitBreakerService adCircuitBreakerService;
     private CacheProvider cache;
     private final NodeStateManager stateManager;
     private ADIndexManagement indexUtil;
@@ -101,7 +101,7 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         ActionFilters actionFilters,
         TransportService transportService,
         ModelManager manager,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         CacheProvider entityCache,
         NodeStateManager stateManager,
         ADIndexManagement indexUtil,

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_GET_DETECTOR;
 import static org.opensearch.ad.model.ADTaskType.ALL_DETECTOR_TASK_TYPES;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.timeseries.constant.CommonMessages.FAIL_TO_FIND_CONFIG_MSG;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
@@ -67,6 +67,7 @@ import org.opensearch.timeseries.Name;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.Job;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.DiscoveryNodeFilterer;
 import org.opensearch.timeseries.util.RestHandlerUtils;
 import org.opensearch.timeseries.util.SecurityClientUtil;
@@ -123,8 +124,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
 
         this.xContentRegistry = xContentRegistry;
         this.nodeFilter = nodeFilter;
-        filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        filterByEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.transportService = transportService;
         this.adTaskManager = adTaskManager;
     }
@@ -169,7 +170,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                         client,
                         clientUtil,
                         xContentRegistry,
-                        AnomalyDetectorSettings.NUM_MIN_SAMPLES
+                        TimeSeriesSettings.NUM_MIN_SAMPLES
                     );
                     profileRunner
                         .profile(
@@ -209,7 +210,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                         clientUtil,
                         xContentRegistry,
                         nodeFilter,
-                        AnomalyDetectorSettings.NUM_MIN_SAMPLES,
+                        TimeSeriesSettings.NUM_MIN_SAMPLES,
                         transportService,
                         adTaskManager
                     );

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_CREATE_DETECTOR;
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_UPDATE_DETECTOR;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.timeseries.util.ParseUtils.getConfig;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
@@ -86,8 +86,8 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         this.xContentRegistry = xContentRegistry;
         this.adTaskManager = adTaskManager;
         this.searchFeatureDao = searchFeatureDao;
-        filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        filterByEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.settings = settings;
     }
 

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -12,7 +12,7 @@
 package org.opensearch.ad.transport;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_PREVIEW_DETECTOR;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_CONCURRENT_PREVIEW;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -34,7 +34,6 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.ad.AnomalyDetectorRunner;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyResult;
@@ -51,6 +50,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.tasks.Task;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.ClientException;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.common.exception.TimeSeriesException;
@@ -68,7 +68,7 @@ public class PreviewAnomalyDetectorTransportAction extends
     private final NamedXContentRegistry xContentRegistry;
     private volatile Integer maxAnomalyFeatures;
     private volatile Boolean filterByEnabled;
-    private final ADCircuitBreakerService adCircuitBreakerService;
+    private final CircuitBreakerService adCircuitBreakerService;
     private Semaphore lock;
 
     @Inject
@@ -80,7 +80,7 @@ public class PreviewAnomalyDetectorTransportAction extends
         Client client,
         AnomalyDetectorRunner anomalyDetectorRunner,
         NamedXContentRegistry xContentRegistry,
-        ADCircuitBreakerService adCircuitBreakerService
+        CircuitBreakerService adCircuitBreakerService
     ) {
         super(PreviewAnomalyDetectorAction.NAME, transportService, actionFilters, PreviewAnomalyDetectorRequest::new);
         this.clusterService = clusterService;
@@ -89,8 +89,8 @@ public class PreviewAnomalyDetectorTransportAction extends
         this.xContentRegistry = xContentRegistry;
         maxAnomalyFeatures = MAX_ANOMALY_FEATURES.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
-        filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        filterByEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.adCircuitBreakerService = adCircuitBreakerService;
         this.lock = new Semaphore(MAX_CONCURRENT_PREVIEW.get(settings), true);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_CONCURRENT_PREVIEW, it -> { lock = new Semaphore(it); });

--- a/src/main/java/org/opensearch/ad/transport/ProfileTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ProfileTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_MODEL_SIZE_PER_NODE;
 
 import java.io.IOException;
 import java.util.List;
@@ -83,8 +83,8 @@ public class ProfileTransportAction extends TransportNodesAction<ProfileRequest,
         this.modelManager = modelManager;
         this.featureManager = featureManager;
         this.cacheProvider = cacheProvider;
-        this.numModelsToReturn = MAX_MODEL_SIZE_PER_NODE.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_MODEL_SIZE_PER_NODE, it -> this.numModelsToReturn = it);
+        this.numModelsToReturn = AD_MAX_MODEL_SIZE_PER_NODE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_MAX_MODEL_SIZE_PER_NODE, it -> this.numModelsToReturn = it);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/RCFResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/RCFResultTransportAction.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.Version;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.stats.ADStats;
@@ -28,6 +27,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.tasks.Task;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.stats.StatNames;
@@ -37,7 +37,7 @@ public class RCFResultTransportAction extends HandledTransportAction<RCFResultRe
 
     private static final Logger LOG = LogManager.getLogger(RCFResultTransportAction.class);
     private ModelManager manager;
-    private ADCircuitBreakerService adCircuitBreakerService;
+    private CircuitBreakerService adCircuitBreakerService;
     private HashRing hashRing;
     private ADStats adStats;
 
@@ -46,7 +46,7 @@ public class RCFResultTransportAction extends HandledTransportAction<RCFResultRe
         ActionFilters actionFilters,
         TransportService transportService,
         ModelManager manager,
-        ADCircuitBreakerService adCircuitBreakerService,
+        CircuitBreakerService adCircuitBreakerService,
         HashRing hashRing,
         ADStats adStats
     ) {

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.ad.transport;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.util.ParseUtils.checkFilterByBackendRoles;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
 
@@ -86,8 +86,8 @@ public class ValidateAnomalyDetectorTransportAction extends
         this.clusterService = clusterService;
         this.xContentRegistry = xContentRegistry;
         this.anomalyDetectionIndices = anomalyDetectionIndices;
-        this.filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        this.filterByEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.searchFeatureDao = searchFeatureDao;
         this.clock = Clock.systemUTC();
         this.settings = settings;

--- a/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
+++ b/src/main/java/org/opensearch/ad/transport/handler/ADSearchHandler.java
@@ -12,7 +12,7 @@
 package org.opensearch.ad.transport.handler;
 
 import static org.opensearch.ad.constant.ADCommonMessages.FAIL_TO_SEARCH;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.util.ParseUtils.addUserBackendRolesFilter;
 import static org.opensearch.timeseries.util.ParseUtils.getUserContext;
 import static org.opensearch.timeseries.util.ParseUtils.isAdmin;
@@ -40,8 +40,8 @@ public class ADSearchHandler {
 
     public ADSearchHandler(Settings settings, ClusterService clusterService, Client client) {
         this.client = client;
-        filterEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterEnabled = it);
+        filterEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterEnabled = it);
     }
 
     /**

--- a/src/main/java/org/opensearch/timeseries/MemoryTracker.java
+++ b/src/main/java/org/opensearch/timeseries/MemoryTracker.java
@@ -27,6 +27,15 @@ import org.opensearch.timeseries.common.exception.LimitExceededException;
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
 
+/**
+ * Responsible for tracking and managing the memory consumption related to OpenSearch time series analysis.
+ * It offers functionalities to:
+ * - Track the total memory consumption and consumption per specific origin.
+ * - Monitor reserved memory bytes.
+ * - Decide if memory can be allocated based on the current usage and the heap limit.
+ * - Estimate the memory size for a ThresholdedRandomCutForest model based on various parameters.
+ *
+ */
 public class MemoryTracker {
     private static final Logger LOG = LogManager.getLogger(MemoryTracker.class);
 
@@ -304,11 +313,21 @@ public class MemoryTracker {
     }
 
     /**
-     * This function derives from the old code: https://tinyurl.com/2eaabja6
+     * Determines if hosting is allowed based on the estimated size of a given ThresholdedRandomCutForest and
+     * the available memory resources.
      *
-     * @param configId Config Id
-     * @param trcf Thresholded random cut forest model
-     * @return true if there is enough memory; otherwise throw LimitExceededException.
+     * <p>This method synchronizes access to ensure that checks and operations related to resource availability
+     * are thread-safe.
+     *
+     * @param configId      The identifier for the configuration being checked. Used in error messages.
+     * @param trcf          The ThresholdedRandomCutForest to estimate the size for.
+     * @return              True if the system can allocate the required bytes to host the trcf.
+     * @throws LimitExceededException If the required memory for the trcf exceeds the available memory.
+     *
+     * <p>Usage example:
+     * <pre>{@code
+     * boolean canHost = isHostingAllowed("config123", myTRCF);
+     * }</pre>
      */
     public synchronized boolean isHostingAllowed(String configId, ThresholdedRandomCutForest trcf) {
         long requiredBytes = estimateTRCFModelSize(trcf);

--- a/src/main/java/org/opensearch/timeseries/MemoryTracker.java
+++ b/src/main/java/org/opensearch/timeseries/MemoryTracker.java
@@ -9,9 +9,9 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad;
+package org.opensearch.timeseries;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE;
 
 import java.util.EnumMap;
 import java.util.Locale;
@@ -19,55 +19,48 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.monitor.jvm.JvmService;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
 
-/**
- * Class to track AD memory usage.
- *
- */
 public class MemoryTracker {
     private static final Logger LOG = LogManager.getLogger(MemoryTracker.class);
 
     public enum Origin {
-        SINGLE_ENTITY_DETECTOR,
-        HC_DETECTOR,
+        REAL_TIME_DETECTOR,
         HISTORICAL_SINGLE_ENTITY_DETECTOR,
+        REAL_TIME_FORECASTER
     }
 
     // memory tracker for total consumption of bytes
-    private long totalMemoryBytes;
-    private final Map<Origin, Long> totalMemoryBytesByOrigin;
+    protected long totalMemoryBytes;
+    protected final Map<Origin, Long> totalMemoryBytesByOrigin;
     // reserved for models. Cannot be deleted at will.
-    private long reservedMemoryBytes;
-    private final Map<Origin, Long> reservedMemoryBytesByOrigin;
-    private long heapSize;
-    private long heapLimitBytes;
-    private long desiredModelSize;
+    protected long reservedMemoryBytes;
+    protected final Map<Origin, Long> reservedMemoryBytesByOrigin;
+    protected long heapSize;
+    protected long heapLimitBytes;
     // we observe threshold model uses a fixed size array and the size is the same
-    private int thresholdModelBytes;
-    private ADCircuitBreakerService adCircuitBreakerService;
+    protected int thresholdModelBytes;
+    protected CircuitBreakerService timeSeriesCircuitBreakerService;
 
     /**
      * Constructor
      *
      * @param jvmService Service providing jvm info
      * @param modelMaxSizePercentage Percentage of heap for the max size of a model
-     * @param modelDesiredSizePercentage percentage of heap for the desired size of a model
      * @param clusterService Cluster service object
-     * @param adCircuitBreakerService Memory circuit breaker
+     * @param timeSeriesCircuitBreakerService Memory circuit breaker
      */
     public MemoryTracker(
         JvmService jvmService,
         double modelMaxSizePercentage,
-        double modelDesiredSizePercentage,
         ClusterService clusterService,
-        ADCircuitBreakerService adCircuitBreakerService
+        CircuitBreakerService timeSeriesCircuitBreakerService
     ) {
         this.totalMemoryBytes = 0;
         this.totalMemoryBytesByOrigin = new EnumMap<Origin, Long>(Origin.class);
@@ -75,40 +68,14 @@ public class MemoryTracker {
         this.reservedMemoryBytesByOrigin = new EnumMap<Origin, Long>(Origin.class);
         this.heapSize = jvmService.info().getMem().getHeapMax().getBytes();
         this.heapLimitBytes = (long) (heapSize * modelMaxSizePercentage);
-        this.desiredModelSize = (long) (heapSize * modelDesiredSizePercentage);
         if (clusterService != null) {
             clusterService
                 .getClusterSettings()
-                .addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> this.heapLimitBytes = (long) (heapSize * it));
+                .addSettingsUpdateConsumer(AD_MODEL_MAX_SIZE_PERCENTAGE, it -> this.heapLimitBytes = (long) (heapSize * it));
         }
 
         this.thresholdModelBytes = 180_000;
-        this.adCircuitBreakerService = adCircuitBreakerService;
-    }
-
-    /**
-     * This function derives from the old code: https://tinyurl.com/2eaabja6
-     *
-     * @param detectorId Detector Id
-     * @param trcf Thresholded random cut forest model
-     * @return true if there is enough memory; otherwise throw LimitExceededException.
-     */
-    public synchronized boolean isHostingAllowed(String detectorId, ThresholdedRandomCutForest trcf) {
-        long requiredBytes = estimateTRCFModelSize(trcf);
-        if (canAllocateReserved(requiredBytes)) {
-            return true;
-        } else {
-            throw new LimitExceededException(
-                detectorId,
-                String
-                    .format(
-                        Locale.ROOT,
-                        "Exceeded memory limit. New size is %d bytes and max limit is %d bytes",
-                        reservedMemoryBytes + requiredBytes,
-                        heapLimitBytes
-                    )
-            );
-        }
+        this.timeSeriesCircuitBreakerService = timeSeriesCircuitBreakerService;
     }
 
     /**
@@ -117,7 +84,7 @@ public class MemoryTracker {
      * true when circuit breaker is closed and there is enough reserved memory.
      */
     public synchronized boolean canAllocateReserved(long requiredBytes) {
-        return (false == adCircuitBreakerService.isOpen() && reservedMemoryBytes + requiredBytes <= heapLimitBytes);
+        return (false == timeSeriesCircuitBreakerService.isOpen() && reservedMemoryBytes + requiredBytes <= heapLimitBytes);
     }
 
     /**
@@ -126,7 +93,7 @@ public class MemoryTracker {
      * true when circuit breaker is closed and there is enough overall memory.
      */
     public synchronized boolean canAllocate(long bytes) {
-        return false == adCircuitBreakerService.isOpen() && totalMemoryBytes + bytes <= heapLimitBytes;
+        return false == timeSeriesCircuitBreakerService.isOpen() && totalMemoryBytes + bytes <= heapLimitBytes;
     }
 
     public synchronized void consumeMemory(long memoryToConsume, boolean reserved, Origin origin) {
@@ -157,23 +124,6 @@ public class MemoryTracker {
         if (originTotalMemoryBytes != null) {
             mapToUpdate.put(origin, originTotalMemoryBytes - memoryToConsume);
         }
-    }
-
-    /**
-     * Gets the estimated size of an entity's model.
-     *
-     * @param trcf ThresholdedRandomCutForest object
-     * @return estimated model size in bytes
-     */
-    public long estimateTRCFModelSize(ThresholdedRandomCutForest trcf) {
-        RandomCutForest forest = trcf.getForest();
-        return estimateTRCFModelSize(
-            forest.getDimensions(),
-            forest.getNumberOfTrees(),
-            forest.getBoundingBoxCacheFraction(),
-            forest.getShingleSize(),
-            forest.isInternalShinglingEnabled()
-        );
     }
 
     /**
@@ -306,14 +256,6 @@ public class MemoryTracker {
         return heapLimitBytes;
     }
 
-    /**
-     *
-     * @return Desired model partition size in bytes
-     */
-    public long getDesiredModelSize() {
-        return desiredModelSize;
-    }
-
     public long getTotalMemoryBytes() {
         return totalMemoryBytes;
     }
@@ -359,5 +301,47 @@ public class MemoryTracker {
 
     public int getThresholdModelBytes() {
         return thresholdModelBytes;
+    }
+
+    /**
+     * This function derives from the old code: https://tinyurl.com/2eaabja6
+     *
+     * @param configId Config Id
+     * @param trcf Thresholded random cut forest model
+     * @return true if there is enough memory; otherwise throw LimitExceededException.
+     */
+    public synchronized boolean isHostingAllowed(String configId, ThresholdedRandomCutForest trcf) {
+        long requiredBytes = estimateTRCFModelSize(trcf);
+        if (canAllocateReserved(requiredBytes)) {
+            return true;
+        } else {
+            throw new LimitExceededException(
+                configId,
+                String
+                    .format(
+                        Locale.ROOT,
+                        "Exceeded memory limit. New size is %d bytes and max limit is %d bytes",
+                        reservedMemoryBytes + requiredBytes,
+                        heapLimitBytes
+                    )
+            );
+        }
+    }
+
+    /**
+     * Gets the estimated size of an entity's model.
+     *
+     * @param trcf ThresholdedRandomCutForest object
+     * @return estimated model size in bytes
+     */
+    public long estimateTRCFModelSize(ThresholdedRandomCutForest trcf) {
+        RandomCutForest forest = trcf.getForest();
+        return estimateTRCFModelSize(
+            forest.getDimensions(),
+            forest.getNumberOfTrees(),
+            forest.getBoundingBoxCacheFraction(),
+            forest.getShingleSize(),
+            forest.isInternalShinglingEnabled()
+        );
     }
 }

--- a/src/main/java/org/opensearch/timeseries/breaker/BreakerName.java
+++ b/src/main/java/org/opensearch/timeseries/breaker/BreakerName.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad.breaker;
+package org.opensearch.timeseries.breaker;
 
 public enum BreakerName {
 

--- a/src/main/java/org/opensearch/timeseries/breaker/CircuitBreaker.java
+++ b/src/main/java/org/opensearch/timeseries/breaker/CircuitBreaker.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad.breaker;
+package org.opensearch.timeseries.breaker;
 
 /**
  * An interface for circuit breaker.

--- a/src/main/java/org/opensearch/timeseries/breaker/CircuitBreakerService.java
+++ b/src/main/java/org/opensearch/timeseries/breaker/CircuitBreakerService.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad.breaker;
+package org.opensearch.timeseries.breaker;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -20,23 +20,23 @@ import org.opensearch.ad.settings.ADEnabledSetting;
 import org.opensearch.monitor.jvm.JvmService;
 
 /**
- * Class {@code ADCircuitBreakerService} provide storing, retrieving circuit breakers functions.
+ * Class {@code CircuitBreakerService} provide storing, retrieving circuit breakers functions.
  *
  * This service registers internal system breakers and provide API for users to register their own breakers.
  */
-public class ADCircuitBreakerService {
+public class CircuitBreakerService {
 
     private final ConcurrentMap<String, CircuitBreaker> breakers = new ConcurrentHashMap<>();
     private final JvmService jvmService;
 
-    private static final Logger logger = LogManager.getLogger(ADCircuitBreakerService.class);
+    private static final Logger logger = LogManager.getLogger(CircuitBreakerService.class);
 
     /**
      * Constructor.
      *
      * @param jvmService jvm info
      */
-    public ADCircuitBreakerService(JvmService jvmService) {
+    public CircuitBreakerService(JvmService jvmService) {
         this.jvmService = jvmService;
     }
 
@@ -67,7 +67,7 @@ public class ADCircuitBreakerService {
      *
      * @return ADCircuitBreakerService
      */
-    public ADCircuitBreakerService init() {
+    public CircuitBreakerService init() {
         // Register memory circuit breaker
         registerBreaker(BreakerName.MEM.getName(), new MemoryCircuitBreaker(this.jvmService));
         logger.info("Registered memory breaker.");

--- a/src/main/java/org/opensearch/timeseries/breaker/MemoryCircuitBreaker.java
+++ b/src/main/java/org/opensearch/timeseries/breaker/MemoryCircuitBreaker.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad.breaker;
+package org.opensearch.timeseries.breaker;
 
 import org.opensearch.monitor.jvm.JvmService;
 

--- a/src/main/java/org/opensearch/timeseries/breaker/ThresholdCircuitBreaker.java
+++ b/src/main/java/org/opensearch/timeseries/breaker/ThresholdCircuitBreaker.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad.breaker;
+package org.opensearch.timeseries.breaker;
 
 /**
  * An abstract class for all breakers with threshold.

--- a/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
@@ -12,8 +12,8 @@
 package org.opensearch.timeseries.feature;
 
 import static org.apache.commons.math3.linear.MatrixUtils.createRealMatrix;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_PAGE_SIZE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.PAGE_SIZE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.PREVIEW_TIMEOUT_IN_MILLIS;
 import static org.opensearch.timeseries.util.ParseUtils.batchFeatureQuery;
 
@@ -120,7 +120,7 @@ public class SearchFeatureDao extends AbstractRetriever {
 
         if (clusterService != null) {
             clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ENTITIES_FOR_PREVIEW, it -> this.maxEntitiesForPreview = it);
-            clusterService.getClusterSettings().addSettingsUpdateConsumer(PAGE_SIZE, it -> this.pageSize = it);
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_PAGE_SIZE, it -> this.pageSize = it);
         }
         this.minimumDocCountForPreview = minimumDocCount;
         this.previewTimeoutInMilliseconds = previewTimeoutInMilliseconds;
@@ -158,7 +158,7 @@ public class SearchFeatureDao extends AbstractRetriever {
             minimumDocCount,
             Clock.systemUTC(),
             MAX_ENTITIES_FOR_PREVIEW.get(settings),
-            PAGE_SIZE.get(settings),
+            AD_PAGE_SIZE.get(settings),
             PREVIEW_TIMEOUT_IN_MILLIS
         );
     }

--- a/src/main/java/org/opensearch/timeseries/model/Job.java
+++ b/src/main/java/org/opensearch/timeseries/model/Job.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.timeseries.model;
 
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.DEFAULT_AD_JOB_LOC_DURATION_SECONDS;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.DEFAULT_JOB_LOC_DURATION_SECONDS;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -175,7 +175,7 @@ public class Job implements Writeable, ToXContentObject, ScheduledJobParameter {
         Instant enabledTime = null;
         Instant disabledTime = null;
         Instant lastUpdateTime = null;
-        Long lockDurationSeconds = DEFAULT_AD_JOB_LOC_DURATION_SECONDS;
+        Long lockDurationSeconds = DEFAULT_JOB_LOC_DURATION_SECONDS;
         User user = null;
         String resultIndex = null;
 

--- a/src/main/java/org/opensearch/timeseries/settings/TimeSeriesSettings.java
+++ b/src/main/java/org/opensearch/timeseries/settings/TimeSeriesSettings.java
@@ -197,4 +197,16 @@ public class TimeSeriesSettings {
     // JOB
     // ======================================
     public static final long DEFAULT_JOB_LOC_DURATION_SECONDS = 60;
+
+    // ======================================
+    // stats/profile API setting
+    // ======================================
+    // profile API needs to report total entities. We can use cardinality aggregation for a single-category field.
+    // But we cannot do that for multi-category fields as it requires scripting to generate run time fields,
+    // which is expensive. We work around the problem by using a composite query to find the first 10_000 buckets.
+    // Generally, traversing all buckets/combinations can't be done without visiting all matches, which is costly
+    // for data with many entities. Given that it is often enough to have a lower bound of the number of entities,
+    // such as "there are at least 10000 entities", the default is set to 10,000. That is, requests will count the
+    // total entities up to 10,000.
+    public static final int MAX_TOTAL_ENTITIES_TO_TRACK = 10_000;
 }

--- a/src/main/java/org/opensearch/timeseries/task/RealtimeTaskCache.java
+++ b/src/main/java/org/opensearch/timeseries/task/RealtimeTaskCache.java
@@ -14,12 +14,12 @@ package org.opensearch.timeseries.task;
 import java.time.Instant;
 
 /**
- * AD realtime task cache which will hold these data
+ * realtime task cache which will hold these data
  * 1. task state
  * 2. init progress
  * 3. error
  * 4. last job run time
- * 5. detector interval
+ * 5. analysis interval
  */
 public class RealtimeTaskCache {
 

--- a/src/main/java/org/opensearch/timeseries/task/RealtimeTaskCache.java
+++ b/src/main/java/org/opensearch/timeseries/task/RealtimeTaskCache.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.ad.task;
+package org.opensearch.timeseries.task;
 
 import java.time.Instant;
 
@@ -21,7 +21,7 @@ import java.time.Instant;
  * 4. last job run time
  * 5. detector interval
  */
-public class ADRealtimeTaskCache {
+public class RealtimeTaskCache {
 
     // task state
     private String state;
@@ -42,7 +42,7 @@ public class ADRealtimeTaskCache {
     // To avoid repeated query when there is no data, record whether we have done that or not.
     private boolean queriedResultIndex;
 
-    public ADRealtimeTaskCache(String state, Float initProgress, String error, long detectorIntervalInMillis) {
+    public RealtimeTaskCache(String state, Float initProgress, String error, long detectorIntervalInMillis) {
         this.state = state;
         this.initProgress = initProgress;
         this.error = error;

--- a/src/main/java/org/opensearch/timeseries/task/TaskCacheManager.java
+++ b/src/main/java/org/opensearch/timeseries/task/TaskCacheManager.java
@@ -62,7 +62,7 @@ public class TaskCacheManager {
     }
 
     /**
-     * Add deleted task's id to deleted detector tasks queue.
+     * Add deleted task's id to deleted tasks queue.
      * @param taskId task id
      */
     public void addDeletedTask(String taskId) {
@@ -73,14 +73,14 @@ public class TaskCacheManager {
 
     /**
      * Check if deleted task queue has items.
-     * @return true if has deleted detector task in cache
+     * @return true if has deleted task in cache
      */
     public boolean hasDeletedTask() {
         return !deletedTasks.isEmpty();
     }
 
     /**
-     * Poll one deleted forecaster task.
+     * Poll one deleted task.
      * @return task id
      */
     public String pollDeletedTask() {

--- a/src/main/java/org/opensearch/timeseries/task/TaskCacheManager.java
+++ b/src/main/java/org/opensearch/timeseries/task/TaskCacheManager.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.timeseries.task;
+
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.MAX_CACHED_DELETED_TASKS;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.timeseries.model.TaskState;
+
+public class TaskCacheManager {
+    private final Logger logger = LogManager.getLogger(TaskCacheManager.class);
+    /**
+     * This field is to cache all realtime tasks on coordinating node.
+     * <p>Node: coordinating node</p>
+     * <p>Key is config id</p>
+     */
+    private Map<String, RealtimeTaskCache> realtimeTaskCaches;
+
+    /**
+     * This field is to cache all deleted config level tasks on coordinating node.
+     * Will try to clean up child task and result later.
+     * <p>Node: coordinating node</p>
+     * Check {@link ForecastTaskManager#cleanChildTasksAndResultsOfDeletedTask()}
+     */
+    private Queue<String> deletedTasks;
+
+    protected volatile Integer maxCachedDeletedTask;
+    /**
+     * This field is to cache deleted detector IDs. Hourly cron will poll this queue
+     * and clean AD results. Check ADTaskManager#cleanResultOfDeletedConfig()
+     * <p>Node: any data node servers delete detector request</p>
+     */
+    protected Queue<String> deletedConfigs;
+
+    public TaskCacheManager(Settings settings, ClusterService clusterService) {
+        this.realtimeTaskCaches = new ConcurrentHashMap<>();
+        this.deletedTasks = new ConcurrentLinkedQueue<>();
+        this.maxCachedDeletedTask = MAX_CACHED_DELETED_TASKS.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_CACHED_DELETED_TASKS, it -> maxCachedDeletedTask = it);
+        this.deletedConfigs = new ConcurrentLinkedQueue<>();
+    }
+
+    public RealtimeTaskCache getRealtimeTaskCache(String configId) {
+        return realtimeTaskCaches.get(configId);
+    }
+
+    public void initRealtimeTaskCache(String configId, long configIntervalInMillis) {
+        realtimeTaskCaches.put(configId, new RealtimeTaskCache(null, null, null, configIntervalInMillis));
+        logger.debug("Realtime task cache inited");
+    }
+
+    /**
+     * Add deleted task's id to deleted detector tasks queue.
+     * @param taskId task id
+     */
+    public void addDeletedTask(String taskId) {
+        if (deletedTasks.size() < maxCachedDeletedTask) {
+            deletedTasks.add(taskId);
+        }
+    }
+
+    /**
+     * Check if deleted task queue has items.
+     * @return true if has deleted detector task in cache
+     */
+    public boolean hasDeletedTask() {
+        return !deletedTasks.isEmpty();
+    }
+
+    /**
+     * Poll one deleted forecaster task.
+     * @return task id
+     */
+    public String pollDeletedTask() {
+        return this.deletedTasks.poll();
+    }
+
+    /**
+     * Clear realtime task cache.
+     */
+    public void clearRealtimeTaskCache() {
+        realtimeTaskCaches.clear();
+    }
+
+    /**
+     * Check if realtime task field value change needed or not by comparing with cache.
+     * 1. If new field value is null, will consider changed needed to this field.
+     * 2. will consider the real time task change needed if
+     * 1) init progress is larger or the old init progress is null, or
+     * 2) if the state is different, and it is not changing from running to init.
+     *  for other fields, as long as field values changed, will consider the realtime
+     *  task change needed. We did this so that the init progress or state won't go backwards.
+     * 3. If realtime task cache not found, will consider the realtime task change needed.
+     *
+     * @param detectorId detector id
+     * @param newState new task state
+     * @param newInitProgress new init progress
+     * @param newError new error
+     * @return true if realtime task change needed.
+     */
+    public boolean isRealtimeTaskChangeNeeded(String detectorId, String newState, Float newInitProgress, String newError) {
+        if (realtimeTaskCaches.containsKey(detectorId)) {
+            RealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(detectorId);
+            boolean stateChangeNeeded = false;
+            String oldState = realtimeTaskCache.getState();
+            if (newState != null
+                && !newState.equals(oldState)
+                && !(TaskState.INIT.name().equals(newState) && TaskState.RUNNING.name().equals(oldState))) {
+                stateChangeNeeded = true;
+            }
+            boolean initProgressChangeNeeded = false;
+            Float existingProgress = realtimeTaskCache.getInitProgress();
+            if (newInitProgress != null
+                && !newInitProgress.equals(existingProgress)
+                && (existingProgress == null || newInitProgress > existingProgress)) {
+                initProgressChangeNeeded = true;
+            }
+            boolean errorChanged = false;
+            if (newError != null && !newError.equals(realtimeTaskCache.getError())) {
+                errorChanged = true;
+            }
+            if (stateChangeNeeded || initProgressChangeNeeded || errorChanged) {
+                return true;
+            }
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Update realtime task cache with new field values. If realtime task cache exist, update it
+     * directly if task is not done; if task is done, remove the detector's realtime task cache.
+     *
+     * If realtime task cache doesn't exist, will do nothing. Next realtime job run will re-init
+     * realtime task cache when it finds task cache not inited yet.
+     * Check ADTaskManager#initCacheWithCleanupIfRequired(String, AnomalyDetector, TransportService, ActionListener),
+     * ADTaskManager#updateLatestRealtimeTaskOnCoordinatingNode(String, String, Long, Long, String, ActionListener)
+     *
+     * @param detectorId detector id
+     * @param newState new task state
+     * @param newInitProgress new init progress
+     * @param newError new error
+     */
+    public void updateRealtimeTaskCache(String detectorId, String newState, Float newInitProgress, String newError) {
+        RealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(detectorId);
+        if (realtimeTaskCache != null) {
+            if (newState != null) {
+                realtimeTaskCache.setState(newState);
+            }
+            if (newInitProgress != null) {
+                realtimeTaskCache.setInitProgress(newInitProgress);
+            }
+            if (newError != null) {
+                realtimeTaskCache.setError(newError);
+            }
+            if (newState != null && !TaskState.NOT_ENDED_STATES.contains(newState)) {
+                // If task is done, will remove its realtime task cache.
+                logger.info("Realtime task done with state {}, remove RT task cache for detector ", newState, detectorId);
+                removeRealtimeTaskCache(detectorId);
+            }
+        } else {
+            logger.debug("Realtime task cache is not inited yet for detector {}", detectorId);
+        }
+    }
+
+    public void refreshRealtimeJobRunTime(String detectorId) {
+        RealtimeTaskCache taskCache = realtimeTaskCaches.get(detectorId);
+        if (taskCache != null) {
+            taskCache.setLastJobRunTime(Instant.now().toEpochMilli());
+        }
+    }
+
+    /**
+     * Get detector IDs from realtime task cache.
+     * @return array of detector id
+     */
+    public String[] getDetectorIdsInRealtimeTaskCache() {
+        return realtimeTaskCaches.keySet().toArray(new String[0]);
+    }
+
+    /**
+     * Remove detector's realtime task from cache.
+     * @param detectorId detector id
+     */
+    public void removeRealtimeTaskCache(String detectorId) {
+        if (realtimeTaskCaches.containsKey(detectorId)) {
+            logger.info("Delete realtime cache for detector {}", detectorId);
+            realtimeTaskCaches.remove(detectorId);
+        }
+    }
+
+    /**
+     * We query result index to check if there are any result generated for detector to tell whether it passed initialization of not.
+     * To avoid repeated query when there is no data, record whether we have done that or not.
+     * @param id detector id
+     */
+    public void markResultIndexQueried(String id) {
+        RealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(id);
+        // we initialize a real time cache at the beginning of AnomalyResultTransportAction if it
+        // cannot be found. If the cache is empty, we will return early and wait it for it to be
+        // initialized.
+        if (realtimeTaskCache != null) {
+            realtimeTaskCache.setQueriedResultIndex(true);
+        }
+    }
+
+    /**
+     * We query result index to check if there are any result generated for detector to tell whether it passed initialization of not.
+     *
+     * @param id detector id
+     * @return whether we have queried result index or not.
+     */
+    public boolean hasQueriedResultIndex(String id) {
+        RealtimeTaskCache realtimeTaskCache = realtimeTaskCaches.get(id);
+        if (realtimeTaskCache != null) {
+            return realtimeTaskCache.hasQueriedResultIndex();
+        }
+        return false;
+    }
+
+    /**
+     * Add deleted config's id to deleted config queue.
+     * @param configId config id
+     */
+    public void addDeletedConfig(String configId) {
+        if (deletedConfigs.size() < maxCachedDeletedTask) {
+            deletedConfigs.add(configId);
+        }
+    }
+
+    /**
+     * Poll one deleted config.
+     * @return config id
+     */
+    public String pollDeletedConfig() {
+        return this.deletedConfigs.poll();
+    }
+}

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.NUM_MIN_SAMPLES;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.opensearch.timeseries.settings.TimeSeriesSettings.NUM_MIN_SAMPLES;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -84,6 +84,7 @@ import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
 import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.MemoryTracker;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.common.exception.EndRunException;
@@ -92,6 +93,7 @@ import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.model.FeatureData;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
 import org.opensearch.timeseries.model.Job;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.ClientUtil;
 import org.opensearch.timeseries.util.DiscoveryNodeFilterer;
 
@@ -553,7 +555,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractTimeSeriesTest {
             Collections.singletonList(new FeatureData("123", "abc", 0d)),
             randomAlphaOfLength(4),
             // not fully initialized
-            Long.valueOf(AnomalyDetectorSettings.NUM_MIN_SAMPLES - 1),
+            Long.valueOf(TimeSeriesSettings.NUM_MIN_SAMPLES - 1),
             randomLong(),
             // not an HC detector
             false,
@@ -716,7 +718,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractTimeSeriesTest {
         Settings settings = Settings
             .builder()
             .put(AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE.getKey(), 2)
-            .put(AnomalyDetectorSettings.MAX_CACHED_DELETED_TASKS.getKey(), 100)
+            .put(TimeSeriesSettings.MAX_CACHED_DELETED_TASKS.getKey(), 100)
             .build();
 
         clusterService = mock(ClusterService.class);
@@ -725,7 +727,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractTimeSeriesTest {
             Collections
                 .unmodifiableSet(
                     new HashSet<>(
-                        Arrays.asList(AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE, AnomalyDetectorSettings.MAX_CACHED_DELETED_TASKS)
+                        Arrays.asList(AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE, TimeSeriesSettings.MAX_CACHED_DELETED_TASKS)
                     )
                 )
         );

--- a/src/test/java/org/opensearch/ad/MemoryTrackerTests.java
+++ b/src/test/java/org/opensearch/ad/MemoryTrackerTests.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
@@ -29,6 +28,8 @@ import org.opensearch.monitor.jvm.JvmInfo;
 import org.opensearch.monitor.jvm.JvmInfo.Mem;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.timeseries.MemoryTracker;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
@@ -58,7 +59,7 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
     double modelDesiredSizePercentage;
     JvmService jvmService;
     AnomalyDetector detector;
-    ADCircuitBreakerService circuitBreaker;
+    CircuitBreakerService circuitBreaker;
 
     @Override
     public void setUp() throws Exception {
@@ -86,10 +87,10 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
 
         clusterService = mock(ClusterService.class);
         modelMaxPercen = 0.1f;
-        Settings settings = Settings.builder().put(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.getKey(), modelMaxPercen).build();
+        Settings settings = Settings.builder().put(AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE.getKey(), modelMaxPercen).build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
@@ -119,20 +120,20 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
         when(detector.getEnabledFeatureIds()).thenReturn(Collections.singletonList("a"));
         when(detector.getShingleSize()).thenReturn(1);
 
-        circuitBreaker = mock(ADCircuitBreakerService.class);
+        circuitBreaker = mock(CircuitBreakerService.class);
         when(circuitBreaker.isOpen()).thenReturn(false);
     }
 
     private void setUpBigHeap() {
         ByteSizeValue value = new ByteSizeValue(largeHeapSize);
         when(mem.getHeapMax()).thenReturn(value);
-        tracker = new MemoryTracker(jvmService, modelMaxSizePercentage, modelDesiredSizePercentage, clusterService, circuitBreaker);
+        tracker = new MemoryTracker(jvmService, modelMaxSizePercentage, clusterService, circuitBreaker);
     }
 
     private void setUpSmallHeap() {
         ByteSizeValue value = new ByteSizeValue(smallHeapSize);
         when(mem.getHeapMax()).thenReturn(value);
-        tracker = new MemoryTracker(jvmService, modelMaxSizePercentage, modelDesiredSizePercentage, clusterService, circuitBreaker);
+        tracker = new MemoryTracker(jvmService, modelMaxSizePercentage, clusterService, circuitBreaker);
     }
 
     public void testEstimateModelSize() {
@@ -174,7 +175,7 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
             .parallelExecutionEnabled(false)
             .compact(true)
             .precision(Precision.FLOAT_32)
-            .boundingBoxCacheFraction(AnomalyDetectorSettings.BATCH_BOUNDING_BOX_CACHE_RATIO)
+            .boundingBoxCacheFraction(TimeSeriesSettings.BATCH_BOUNDING_BOX_CACHE_RATIO)
             .internalShinglingEnabled(false)
             // same with dimension for opportunistic memory saving
             .shingleSize(1)
@@ -332,10 +333,10 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
         assertTrue(!tracker.canAllocate((long) (largeHeapSize * modelMaxPercen + 10)));
 
         long bytesToUse = 100_000;
-        tracker.consumeMemory(bytesToUse, false, MemoryTracker.Origin.HC_DETECTOR);
+        tracker.consumeMemory(bytesToUse, false, MemoryTracker.Origin.REAL_TIME_DETECTOR);
         assertTrue(!tracker.canAllocate((long) (largeHeapSize * modelMaxPercen)));
 
-        tracker.releaseMemory(bytesToUse, false, MemoryTracker.Origin.HC_DETECTOR);
+        tracker.releaseMemory(bytesToUse, false, MemoryTracker.Origin.REAL_TIME_DETECTOR);
         assertTrue(tracker.canAllocate((long) (largeHeapSize * modelMaxPercen)));
     }
 
@@ -348,12 +349,11 @@ public class MemoryTrackerTests extends OpenSearchTestCase {
         setUpSmallHeap();
         long bytesToUse = 100_000;
         assertEquals(bytesToUse, tracker.getHeapLimit());
-        assertEquals((long) (smallHeapSize * modelDesiredSizePercentage), tracker.getDesiredModelSize());
-        tracker.consumeMemory(bytesToUse, false, MemoryTracker.Origin.HC_DETECTOR);
-        tracker.consumeMemory(bytesToUse, true, MemoryTracker.Origin.HC_DETECTOR);
+        tracker.consumeMemory(bytesToUse, false, MemoryTracker.Origin.REAL_TIME_DETECTOR);
+        tracker.consumeMemory(bytesToUse, true, MemoryTracker.Origin.REAL_TIME_DETECTOR);
         assertEquals(2 * bytesToUse, tracker.getTotalMemoryBytes());
 
         assertEquals(bytesToUse, tracker.memoryToShed());
-        assertTrue(!tracker.syncMemoryState(MemoryTracker.Origin.HC_DETECTOR, 2 * bytesToUse, bytesToUse));
+        assertTrue(!tracker.syncMemoryState(MemoryTracker.Origin.REAL_TIME_DETECTOR, 2 * bytesToUse, bytesToUse));
     }
 }

--- a/src/test/java/org/opensearch/ad/breaker/ADCircuitBreakerServiceTests.java
+++ b/src/test/java/org/opensearch/ad/breaker/ADCircuitBreakerServiceTests.java
@@ -25,11 +25,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.monitor.jvm.JvmStats;
+import org.opensearch.timeseries.breaker.BreakerName;
+import org.opensearch.timeseries.breaker.CircuitBreaker;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
+import org.opensearch.timeseries.breaker.MemoryCircuitBreaker;
 
 public class ADCircuitBreakerServiceTests {
 
     @InjectMocks
-    private ADCircuitBreakerService adCircuitBreakerService;
+    private CircuitBreakerService adCircuitBreakerService;
 
     @Mock
     JvmService jvmService;

--- a/src/test/java/org/opensearch/ad/breaker/MemoryCircuitBreakerTests.java
+++ b/src/test/java/org/opensearch/ad/breaker/MemoryCircuitBreakerTests.java
@@ -21,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.monitor.jvm.JvmStats;
+import org.opensearch.timeseries.breaker.CircuitBreaker;
+import org.opensearch.timeseries.breaker.MemoryCircuitBreaker;
 
 public class MemoryCircuitBreakerTests {
 

--- a/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
+++ b/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
@@ -22,16 +22,16 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import org.junit.Before;
-import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.ml.ModelState;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.ratelimit.CheckpointMaintainWorker;
 import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
+import org.opensearch.timeseries.MemoryTracker;
 import org.opensearch.timeseries.model.Entity;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 public class AbstractCacheTest extends AbstractTimeSeriesTest {
     protected String modelId1, modelId2, modelId3, modelId4;
@@ -94,7 +94,7 @@ public class AbstractCacheTest extends AbstractTimeSeriesTest {
             memoryPerEntity,
             memoryTracker,
             clock,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             detectorId,
             checkpointWriteQueue,
             checkpointMaintainQueue,

--- a/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
@@ -22,8 +22,8 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 import org.mockito.ArgumentCaptor;
-import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.ratelimit.CheckpointMaintainRequest;
+import org.opensearch.timeseries.MemoryTracker;
 
 import test.org.opensearch.ad.util.MLUtil;
 import test.org.opensearch.ad.util.RandomModelStateConfig;
@@ -83,7 +83,7 @@ public class CacheBufferTests extends AbstractCacheTest {
         assertEquals(3 * memoryPerEntity, capturedMemoryReleased.stream().reduce(0L, (a, b) -> a + b).intValue());
         assertTrue(capturedreserved.get(0));
         assertTrue(!capturedreserved.get(1));
-        assertEquals(MemoryTracker.Origin.HC_DETECTOR, capturedOrigin.get(0));
+        assertEquals(MemoryTracker.Origin.REAL_TIME_DETECTOR, capturedOrigin.get(0));
 
         assertTrue(!cacheBuffer.expired(Duration.ofHours(1)));
     }

--- a/src/test/java/org/opensearch/ad/cluster/ClusterManagerEventListenerTests.java
+++ b/src/test/java/org/opensearch/ad/cluster/ClusterManagerEventListenerTests.java
@@ -60,7 +60,7 @@ public class ClusterManagerEventListenerTests extends AbstractTimeSeriesTest {
         clusterService = mock(ClusterService.class);
         ClusterSettings settings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.CHECKPOINT_TTL)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_CHECKPOINT_TTL)))
         );
         when(clusterService.getClusterSettings()).thenReturn(settings);
 
@@ -85,7 +85,7 @@ public class ClusterManagerEventListenerTests extends AbstractTimeSeriesTest {
             clock,
             clientUtil,
             nodeFilter,
-            AnomalyDetectorSettings.CHECKPOINT_TTL,
+            AnomalyDetectorSettings.AD_CHECKPOINT_TTL,
             Settings.EMPTY
         );
     }

--- a/src/test/java/org/opensearch/ad/ml/AbstractCosineDataTest.java
+++ b/src/test/java/org/opensearch/ad/ml/AbstractCosineDataTest.java
@@ -15,7 +15,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -30,7 +29,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.opensearch.Version;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.ratelimit.CheckpointWriteWorker;
@@ -47,6 +45,7 @@ import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
+import org.opensearch.timeseries.MemoryTracker;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
@@ -96,7 +95,7 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        numMinSamples = AnomalyDetectorSettings.NUM_MIN_SAMPLES;
+        numMinSamples = TimeSeriesSettings.NUM_MIN_SAMPLES;
 
         clock = mock(Clock.class);
         when(clock.instant()).thenReturn(Instant.now());
@@ -126,7 +125,7 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
         nodestateSetting = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         nodestateSetting.add(TimeSeriesSettings.MAX_RETRY_FOR_UNRESPONSIVE_NODE);
         nodestateSetting.add(TimeSeriesSettings.BACKOFF_MINUTES);
-        nodestateSetting.add(CHECKPOINT_SAVING_FREQ);
+        nodestateSetting.add(AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ);
         clusterSettings = new ClusterSettings(Settings.EMPTY, nodestateSetting);
 
         discoveryNode = new DiscoveryNode(
@@ -145,7 +144,7 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
             settings,
             clientUtil,
             clock,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             clusterService,
             TimeSeriesSettings.MAX_RETRY_FOR_UNRESPONSIVE_NODE,
             TimeSeriesSettings.BACKOFF_MINUTES
@@ -168,7 +167,7 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
             AnomalyDetectorSettings.MAX_IMPUTATION_NEIGHBOR_DISTANCE,
             AnomalyDetectorSettings.PREVIEW_SAMPLE_RATE,
             AnomalyDetectorSettings.MAX_PREVIEW_SAMPLES,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             threadPool,
             TimeSeriesAnalyticsPlugin.AD_THREAD_POOL_NAME
         );
@@ -180,21 +179,21 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
             clock,
             threadPool,
             stateManager,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
-            AnomalyDetectorSettings.NUM_TREES,
-            AnomalyDetectorSettings.TIME_DECAY,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.NUM_TREES,
+            TimeSeriesSettings.TIME_DECAY,
             numMinSamples,
             AnomalyDetectorSettings.MAX_SAMPLE_STRIDE,
             AnomalyDetectorSettings.MAX_TRAIN_SAMPLE,
             imputer,
             searchFeatureDao,
-            AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+            TimeSeriesSettings.THRESHOLD_MIN_PVALUE,
             featureManager,
             settings,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             checkpointWriteQueue,
             rcfSeed,
-            AnomalyDetectorSettings.MAX_COLD_START_ROUNDS
+            TimeSeriesSettings.MAX_COLD_START_ROUNDS
         );
 
         detectorId = "123";
@@ -215,14 +214,14 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
         modelManager = new ModelManager(
             mock(CheckpointDao.class),
             mock(Clock.class),
-            AnomalyDetectorSettings.NUM_TREES,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
-            AnomalyDetectorSettings.TIME_DECAY,
-            AnomalyDetectorSettings.NUM_MIN_SAMPLES,
-            AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+            TimeSeriesSettings.NUM_TREES,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.TIME_DECAY,
+            TimeSeriesSettings.NUM_MIN_SAMPLES,
+            TimeSeriesSettings.THRESHOLD_MIN_PVALUE,
             AnomalyDetectorSettings.MIN_PREVIEW_SIZE,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
+            AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ,
             entityColdStarter,
             mock(FeatureManager.class),
             mock(MemoryTracker.class),

--- a/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
+++ b/src/test/java/org/opensearch/ad/ml/CheckpointDaoTests.java
@@ -95,7 +95,6 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.indices.ADIndexManagement;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
@@ -103,6 +102,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.timeseries.constant.CommonName;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.ClientUtil;
 
 import test.org.opensearch.ad.util.JsonDeserializer;
@@ -195,7 +195,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
                 return new GenericObjectPool<>(new BasePooledObjectFactory<LinkedBuffer>() {
                     @Override
                     public LinkedBuffer create() throws Exception {
-                        return LinkedBuffer.allocate(AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES);
+                        return LinkedBuffer.allocate(TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES);
                     }
 
                     @Override
@@ -205,11 +205,11 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
                 });
             }
         }));
-        serializeRCFBufferPool.setMaxTotal(AnomalyDetectorSettings.MAX_TOTAL_RCF_SERIALIZATION_BUFFERS);
-        serializeRCFBufferPool.setMaxIdle(AnomalyDetectorSettings.MAX_TOTAL_RCF_SERIALIZATION_BUFFERS);
+        serializeRCFBufferPool.setMaxTotal(TimeSeriesSettings.MAX_TOTAL_RCF_SERIALIZATION_BUFFERS);
+        serializeRCFBufferPool.setMaxIdle(TimeSeriesSettings.MAX_TOTAL_RCF_SERIALIZATION_BUFFERS);
         serializeRCFBufferPool.setMinIdle(0);
         serializeRCFBufferPool.setBlockWhenExhausted(false);
-        serializeRCFBufferPool.setTimeBetweenEvictionRuns(AnomalyDetectorSettings.HOURLY_MAINTENANCE);
+        serializeRCFBufferPool.setTimeBetweenEvictionRuns(TimeSeriesSettings.HOURLY_MAINTENANCE);
 
         anomalyRate = 0.005;
         checkpointDao = new CheckpointDao(
@@ -225,7 +225,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             indexUtil,
             maxCheckpointBytes,
             serializeRCFBufferPool,
-            AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES,
+            TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES,
             anomalyRate
         );
 
@@ -693,7 +693,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             indexUtil,
             1, // make the max checkpoint size 1 byte only
             serializeRCFBufferPool,
-            AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES,
+            TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES,
             anomalyRate
         );
 
@@ -730,7 +730,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             indexUtil,
             1, // make the max checkpoint size 1 byte only
             mockSerializeRCFBufferPool,
-            AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES,
+            TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES,
             anomalyRate
         );
 
@@ -755,7 +755,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             indexUtil,
             1, // make the max checkpoint size 1 byte only
             serializeRCFBufferPool,
-            AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES,
+            TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES,
             anomalyRate
         );
 
@@ -803,7 +803,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             indexUtil,
             maxCheckpointBytes,
             serializeRCFBufferPool,
-            AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES,
+            TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES,
             anomalyRate
         );
     }
@@ -940,7 +940,7 @@ public class CheckpointDaoTests extends OpenSearchTestCase {
             indexUtil,
             100_000, // checkpoint_2.json is of 224603 bytes.
             serializeRCFBufferPool,
-            AnomalyDetectorSettings.SERIALIZATION_BUFFER_BYTES,
+            TimeSeriesSettings.SERIALIZATION_BUFFER_BYTES,
             anomalyRate
         );
         Optional<Entry<EntityModel, Instant>> result = checkpointDao.fromEntityModelCheckpoint(modelPair.getLeft(), this.modelId);

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -43,7 +43,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.settings.ADEnabledSetting;
@@ -56,6 +55,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.MemoryTracker;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.common.exception.TimeSeriesException;
 import org.opensearch.timeseries.constant.CommonName;
@@ -213,16 +213,16 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
             .dimensions(inputDimension * detector.getShingleSize())
             .precision(Precision.FLOAT_32)
             .randomSeed(rcfSeed)
-            .numberOfTrees(AnomalyDetectorSettings.NUM_TREES)
+            .numberOfTrees(TimeSeriesSettings.NUM_TREES)
             .shingleSize(detector.getShingleSize())
             .boundingBoxCacheFraction(TimeSeriesSettings.REAL_TIME_BOUNDING_BOX_CACHE_RATIO)
-            .timeDecay(AnomalyDetectorSettings.TIME_DECAY)
+            .timeDecay(TimeSeriesSettings.TIME_DECAY)
             .outputAfter(numMinSamples)
             .initialAcceptFraction(0.125d)
             .parallelExecutionEnabled(false)
-            .sampleSize(AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
+            .sampleSize(TimeSeriesSettings.NUM_SAMPLES_PER_TREE)
             .internalShinglingEnabled(true)
-            .anomalyRate(1 - AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE)
+            .anomalyRate(1 - TimeSeriesSettings.THRESHOLD_MIN_PVALUE)
             .transformMethod(TransformMethod.NORMALIZE)
             .alertOnce(true)
             .autoAdjust(true)
@@ -511,16 +511,16 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
             .dimensions(dimensions)
             .precision(Precision.FLOAT_32)
             .randomSeed(rcfSeed)
-            .numberOfTrees(AnomalyDetectorSettings.NUM_TREES)
+            .numberOfTrees(TimeSeriesSettings.NUM_TREES)
             .shingleSize(detector.getShingleSize())
             .boundingBoxCacheFraction(TimeSeriesSettings.REAL_TIME_BOUNDING_BOX_CACHE_RATIO)
-            .timeDecay(AnomalyDetectorSettings.TIME_DECAY)
+            .timeDecay(TimeSeriesSettings.TIME_DECAY)
             .outputAfter(numMinSamples)
             .initialAcceptFraction(0.125d)
             .parallelExecutionEnabled(false)
-            .sampleSize(AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
+            .sampleSize(TimeSeriesSettings.NUM_SAMPLES_PER_TREE)
             .internalShinglingEnabled(true)
-            .anomalyRate(1 - AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE)
+            .anomalyRate(1 - TimeSeriesSettings.THRESHOLD_MIN_PVALUE)
             .transformMethod(TransformMethod.NORMALIZE)
             .alertOnce(true)
             .autoAdjust(true);
@@ -555,7 +555,7 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
     @SuppressWarnings("unchecked")
     private void accuracyTemplate(int detectorIntervalMins, float precisionThreshold, float recallThreshold) throws Exception {
         int baseDimension = 2;
-        int dataSize = 20 * AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE;
+        int dataSize = 20 * TimeSeriesSettings.NUM_SAMPLES_PER_TREE;
         int trainTestSplit = 300;
         // detector interval
         int interval = detectorIntervalMins;
@@ -705,34 +705,34 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
             clock,
             threadPool,
             stateManager,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
-            AnomalyDetectorSettings.NUM_TREES,
-            AnomalyDetectorSettings.TIME_DECAY,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.NUM_TREES,
+            TimeSeriesSettings.TIME_DECAY,
             numMinSamples,
             AnomalyDetectorSettings.MAX_SAMPLE_STRIDE,
             AnomalyDetectorSettings.MAX_TRAIN_SAMPLE,
             imputer,
             searchFeatureDao,
-            AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+            TimeSeriesSettings.THRESHOLD_MIN_PVALUE,
             featureManager,
             settings,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             checkpointWriteQueue,
             rcfSeed,
-            AnomalyDetectorSettings.MAX_COLD_START_ROUNDS
+            TimeSeriesSettings.MAX_COLD_START_ROUNDS
         );
 
         modelManager = new ModelManager(
             mock(CheckpointDao.class),
             mock(Clock.class),
-            AnomalyDetectorSettings.NUM_TREES,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
-            AnomalyDetectorSettings.TIME_DECAY,
-            AnomalyDetectorSettings.NUM_MIN_SAMPLES,
-            AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+            TimeSeriesSettings.NUM_TREES,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.TIME_DECAY,
+            TimeSeriesSettings.NUM_MIN_SAMPLES,
+            TimeSeriesSettings.THRESHOLD_MIN_PVALUE,
             AnomalyDetectorSettings.MIN_PREVIEW_SIZE,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
+            AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ,
             entityColdStarter,
             mock(FeatureManager.class),
             mock(MemoryTracker.class),

--- a/src/test/java/org/opensearch/ad/ml/HCADModelPerfTests.java
+++ b/src/test/java/org/opensearch/ad/ml/HCADModelPerfTests.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.ad.MemoryTracker;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
@@ -43,6 +42,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.MemoryTracker;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
 import org.opensearch.timeseries.constant.CommonName;
@@ -78,7 +78,7 @@ public class HCADModelPerfTests extends AbstractCosineDataTest {
         int baseDimension,
         boolean anomalyIndependent
     ) throws Exception {
-        int dataSize = 20 * AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE;
+        int dataSize = 20 * TimeSeriesSettings.NUM_SAMPLES_PER_TREE;
         int trainTestSplit = 300;
         // detector interval
         int interval = detectorIntervalMins;
@@ -126,7 +126,7 @@ public class HCADModelPerfTests extends AbstractCosineDataTest {
                 AnomalyDetectorSettings.MAX_IMPUTATION_NEIGHBOR_DISTANCE,
                 AnomalyDetectorSettings.PREVIEW_SAMPLE_RATE,
                 AnomalyDetectorSettings.MAX_PREVIEW_SAMPLES,
-                AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+                TimeSeriesSettings.HOURLY_MAINTENANCE,
                 threadPool,
                 TimeSeriesAnalyticsPlugin.AD_THREAD_POOL_NAME
             );
@@ -135,34 +135,34 @@ public class HCADModelPerfTests extends AbstractCosineDataTest {
                 clock,
                 threadPool,
                 stateManager,
-                AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
-                AnomalyDetectorSettings.NUM_TREES,
-                AnomalyDetectorSettings.TIME_DECAY,
+                TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+                TimeSeriesSettings.NUM_TREES,
+                TimeSeriesSettings.TIME_DECAY,
                 numMinSamples,
                 AnomalyDetectorSettings.MAX_SAMPLE_STRIDE,
                 AnomalyDetectorSettings.MAX_TRAIN_SAMPLE,
                 imputer,
                 searchFeatureDao,
-                AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+                TimeSeriesSettings.THRESHOLD_MIN_PVALUE,
                 featureManager,
                 settings,
-                AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+                TimeSeriesSettings.HOURLY_MAINTENANCE,
                 checkpointWriteQueue,
                 seed,
-                AnomalyDetectorSettings.MAX_COLD_START_ROUNDS
+                TimeSeriesSettings.MAX_COLD_START_ROUNDS
             );
 
             modelManager = new ModelManager(
                 mock(CheckpointDao.class),
                 mock(Clock.class),
-                AnomalyDetectorSettings.NUM_TREES,
-                AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
-                AnomalyDetectorSettings.TIME_DECAY,
-                AnomalyDetectorSettings.NUM_MIN_SAMPLES,
-                AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+                TimeSeriesSettings.NUM_TREES,
+                TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+                TimeSeriesSettings.TIME_DECAY,
+                TimeSeriesSettings.NUM_MIN_SAMPLES,
+                TimeSeriesSettings.THRESHOLD_MIN_PVALUE,
                 AnomalyDetectorSettings.MIN_PREVIEW_SIZE,
-                AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ,
+                TimeSeriesSettings.HOURLY_MAINTENANCE,
+                AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ,
                 entityColdStarter,
                 mock(FeatureManager.class),
                 mock(MemoryTracker.class),

--- a/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
+++ b/src/test/java/org/opensearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.ad.mock.transport;
 
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_REQUEST_TIMEOUT;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.util.ParseUtils.resolveUserAndExecute;
 
 import org.apache.logging.log4j.LogManager;
@@ -76,8 +76,8 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
         this.anomalyDetectionIndices = anomalyDetectionIndices;
         this.xContentRegistry = xContentRegistry;
         this.adTaskManager = adTaskManager;
-        filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        filterByEnabled = AD_FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
 
         ThreadContext threadContext = new ThreadContext(settings);
         context = threadContext.stashContext();

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckPointMaintainRequestAdapterTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckPointMaintainRequestAdapterTests.java
@@ -59,7 +59,7 @@ public class CheckPointMaintainRequestAdapterTests extends AbstractRateLimitingT
         cache = mock(CacheProvider.class);
         checkpointDao = mock(CheckpointDao.class);
         indexName = ADCommonName.CHECKPOINT_INDEX_NAME;
-        checkpointInterval = AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ;
+        checkpointInterval = AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ;
         EntityCache entityCache = mock(EntityCache.class);
         when(cache.get()).thenReturn(entityCache);
         state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
@@ -67,7 +67,7 @@ public class CheckPointMaintainRequestAdapterTests extends AbstractRateLimitingT
         clusterService = mock(ClusterService.class);
         ClusterSettings settings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ)))
         );
         when(clusterService.getClusterSettings()).thenReturn(settings);
         adapter = new CheckPointMaintainRequestAdapter(

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointMaintainWorkerTests.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.constant.ADCommonName;
@@ -45,6 +44,8 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 import test.org.opensearch.ad.util.MLUtil;
 import test.org.opensearch.ad.util.RandomModelStateConfig;
@@ -71,9 +72,9 @@ public class CheckpointMaintainWorkerTests extends AbstractRateLimitingTest {
                         Arrays
                             .asList(
                                 AnomalyDetectorSettings.AD_EXPECTED_CHECKPOINT_MAINTAIN_TIME_IN_MILLISECS,
-                                AnomalyDetectorSettings.CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_BATCH_SIZE,
-                                AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ
+                                AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ
                             )
                     )
                 )
@@ -85,7 +86,7 @@ public class CheckpointMaintainWorkerTests extends AbstractRateLimitingTest {
         CacheProvider cache = mock(CacheProvider.class);
         checkpointDao = mock(CheckpointDao.class);
         String indexName = ADCommonName.CHECKPOINT_INDEX_NAME;
-        Setting<TimeValue> checkpointInterval = AnomalyDetectorSettings.CHECKPOINT_SAVING_FREQ;
+        Setting<TimeValue> checkpointInterval = AnomalyDetectorSettings.AD_CHECKPOINT_SAVING_FREQ;
         EntityCache entityCache = mock(EntityCache.class);
         when(cache.get()).thenReturn(entityCache);
         ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().fullModel(true).build());
@@ -104,19 +105,19 @@ public class CheckpointMaintainWorkerTests extends AbstractRateLimitingTest {
         cpMaintainWorker = new CheckpointMaintainWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             settings,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
             writeWorker,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             nodeStateManager,
             adapter
         );

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -45,7 +45,6 @@ import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.get.MultiGetItemResponse;
 import org.opensearch.action.get.MultiGetResponse;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.caching.EntityCache;
 import org.opensearch.ad.constant.ADCommonName;
@@ -74,8 +73,10 @@ import org.opensearch.threadpool.ThreadPoolStats.Stats;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.model.Entity;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.stats.StatNames;
 
 import test.org.opensearch.ad.util.MLUtil;
@@ -113,7 +114,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_CONCURRENCY,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE
                             )
@@ -156,18 +157,18 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         worker = new CheckpointReadWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             modelManager,
             checkpoint,
             coldstartQueue,
@@ -175,7 +176,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             nodeStateManager,
             anomalyDetectionIndices,
             cacheProvider,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             checkpointWriteQueue,
             adStats
         );
@@ -535,18 +536,18 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         worker = new CheckpointReadWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             modelManager,
             checkpoint,
             coldstartQueue,
@@ -554,7 +555,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             nodeStateManager,
             anomalyDetectionIndices,
             cacheProvider,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             checkpointWriteQueue,
             adStats
         );
@@ -565,7 +566,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         assertEquals(CheckpointReadWorker.WORKER_NAME, worker.getWorkerName());
 
         // make RequestQueue.expired return true
-        when(clock.instant()).thenReturn(Instant.now().plusSeconds(AnomalyDetectorSettings.HOURLY_MAINTENANCE.getSeconds() + 1));
+        when(clock.instant()).thenReturn(Instant.now().plusSeconds(TimeSeriesSettings.HOURLY_MAINTENANCE.getSeconds() + 1));
 
         // removed the expired queue
         worker.maintenance();
@@ -587,18 +588,18 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         worker = new CheckpointReadWorker(
             2000,
             1,
-            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             modelManager,
             checkpoint,
             coldstartQueue,
@@ -606,7 +607,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             nodeStateManager,
             anomalyDetectionIndices,
             cacheProvider,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             checkpointWriteQueue,
             adStats
         );
@@ -621,7 +622,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
 
         Settings newSettings = Settings
             .builder()
-            .put(AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT.getKey(), "0.0001")
+            .put(AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT.getKey(), "0.0001")
             .build();
         Settings.Builder target = Settings.builder();
         clusterSettings.updateDynamicSettings(newSettings, target, Settings.builder(), "test");
@@ -634,24 +635,24 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
     public void testOpenCircuitBreaker() {
         maintenanceSetup();
 
-        ADCircuitBreakerService breaker = mock(ADCircuitBreakerService.class);
+        CircuitBreakerService breaker = mock(CircuitBreakerService.class);
         when(breaker.isOpen()).thenReturn(true);
 
         worker = new CheckpointReadWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
             breaker,
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             modelManager,
             checkpoint,
             coldstartQueue,
@@ -659,7 +660,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             nodeStateManager,
             anomalyDetectionIndices,
             cacheProvider,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             checkpointWriteQueue,
             adStats
         );

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointWriteWorkerTests.java
@@ -45,7 +45,6 @@ import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkItemResponse.Failure;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.ml.CheckpointDao;
 import org.opensearch.ad.ml.EntityModel;
@@ -64,7 +63,9 @@ import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.constant.CommonName;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 import test.org.opensearch.ad.util.MLUtil;
 import test.org.opensearch.ad.util.RandomModelStateConfig;
@@ -89,7 +90,7 @@ public class CheckpointWriteWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_CONCURRENCY,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_BATCH_SIZE
                             )
@@ -107,24 +108,24 @@ public class CheckpointWriteWorkerTests extends AbstractRateLimitingTest {
         // Integer.MAX_VALUE makes a huge heap
         worker = new CheckpointWriteWorker(
             Integer.MAX_VALUE,
-            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+            TimeSeriesSettings.CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             checkpoint,
             ADCommonName.CHECKPOINT_INDEX_NAME,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             nodeStateManager,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+            TimeSeriesSettings.HOURLY_MAINTENANCE
         );
 
         state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().build());
@@ -211,24 +212,24 @@ public class CheckpointWriteWorkerTests extends AbstractRateLimitingTest {
         // create a worker to use mockThreadPool
         worker = new CheckpointWriteWorker(
             Integer.MAX_VALUE,
-            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+            TimeSeriesSettings.CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             mockThreadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             checkpoint,
             ADCommonName.CHECKPOINT_INDEX_NAME,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             nodeStateManager,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+            TimeSeriesSettings.HOURLY_MAINTENANCE
         );
 
         // our concurrency is 2, so first 2 requests cause two batches. And the

--- a/src/test/java/org/opensearch/ad/ratelimit/ColdEntityWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ColdEntityWorkerTests.java
@@ -27,12 +27,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
     ClusterService clusterService;
@@ -53,8 +54,8 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
-                                AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
+                                AnomalyDetectorSettings.AD_COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE
                             )
                     )
@@ -68,19 +69,19 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
         coldWorker = new ColdEntityWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             settings,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
             readWorker,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             nodeStateManager
         );
 
@@ -99,7 +100,7 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
 
             TimeValue value = invocation.getArgument(1);
             // since we have only 1 request each time
-            long expectedExecutionPerRequestMilli = AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS
+            long expectedExecutionPerRequestMilli = AnomalyDetectorSettings.AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS
                 .getDefault(Settings.EMPTY);
             long delay = value.getMillis();
             assertTrue(delay == expectedExecutionPerRequestMilli);
@@ -143,8 +144,8 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
-                                AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
+                                AnomalyDetectorSettings.AD_COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE
                             )
                     )
@@ -156,19 +157,19 @@ public class ColdEntityWorkerTests extends AbstractRateLimitingTest {
         coldWorker = new ColdEntityWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
             readWorker,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             nodeStateManager
         );
 

--- a/src/test/java/org/opensearch/ad/ratelimit/EntityColdStartWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/EntityColdStartWorkerTests.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.Random;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.caching.CacheProvider;
 import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.EntityModel;
@@ -40,6 +39,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 import test.org.opensearch.ad.util.MLUtil;
 
@@ -60,8 +61,8 @@ public class EntityColdStartWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
-                                AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_CONCURRENCY
+                                AnomalyDetectorSettings.AD_ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_ENTITY_COLD_START_QUEUE_CONCURRENCY
                             )
                     )
                 )
@@ -76,20 +77,20 @@ public class EntityColdStartWorkerTests extends AbstractRateLimitingTest {
         worker = new EntityColdStartWorker(
             Integer.MAX_VALUE,
             AnomalyDetectorSettings.ENTITY_REQUEST_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
+            AnomalyDetectorSettings.AD_ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             entityColdStarter,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            TimeSeriesSettings.HOURLY_MAINTENANCE,
             nodeStateManager,
             cacheProvider
         );

--- a/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
@@ -49,6 +48,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.TestHelpers;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.RestHandlerUtils;
 
 public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
@@ -69,7 +70,7 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
                     new HashSet<>(
                         Arrays
                             .asList(
-                                AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
                                 AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_CONCURRENCY,
                                 AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_BATCH_SIZE
                             )
@@ -85,23 +86,23 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
 
         resultWriteQueue = new ResultWriteWorker(
             Integer.MAX_VALUE,
-            AnomalyDetectorSettings.RESULT_WRITE_QUEUE_SIZE_IN_BYTES,
-            AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+            TimeSeriesSettings.RESULT_WRITE_QUEUE_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
             clusterService,
             new Random(42),
-            mock(ADCircuitBreakerService.class),
+            mock(CircuitBreakerService.class),
             threadPool,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            TimeSeriesSettings.MAX_QUEUED_TASKS_RATIO,
             clock,
-            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
-            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
-            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            TimeSeriesSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.LOW_SEGMENT_PRUNE_RATIO,
+            TimeSeriesSettings.MAINTENANCE_FREQ_CONSTANT,
+            TimeSeriesSettings.QUEUE_MAINTENANCE,
             resultHandler,
             xContentRegistry(),
             nodeStateManager,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+            TimeSeriesSettings.HOURLY_MAINTENANCE
         );
 
         detectResult = TestHelpers.randomHCADAnomalyDetectResult(0.8, Double.NaN, null);

--- a/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
+++ b/src/test/java/org/opensearch/ad/settings/AnomalyDetectorSettingsTests.java
@@ -58,7 +58,7 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
                             LegacyOpenDistroAnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW,
                             LegacyOpenDistroAnomalyDetectorSettings.INDEX_PRESSURE_SOFT_LIMIT,
                             LegacyOpenDistroAnomalyDetectorSettings.MAX_PRIMARY_SHARDS,
-                            LegacyOpenDistroAnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES,
+                            LegacyOpenDistroAnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES,
                             LegacyOpenDistroAnomalyDetectorSettings.MAX_CACHE_MISS_HANDLING_PER_SECOND,
                             LegacyOpenDistroAnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE,
                             LegacyOpenDistroAnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS,
@@ -77,8 +77,8 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
                 .containsAll(
                     Arrays
                         .asList(
-                            AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS,
-                            AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS,
+                            AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS,
+                            AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS,
                             AnomalyDetectorSettings.MAX_ANOMALY_FEATURES,
                             AnomalyDetectorSettings.AD_REQUEST_TIMEOUT,
                             AnomalyDetectorSettings.DETECTION_INTERVAL,
@@ -91,33 +91,33 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
                             AnomalyDetectorSettings.AD_BACKOFF_INITIAL_DELAY,
                             AnomalyDetectorSettings.AD_MAX_RETRY_FOR_BACKOFF,
                             AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
-                            AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE,
-                            AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY,
+                            AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE,
+                            AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY,
                             AnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW,
                             AnomalyDetectorSettings.AD_INDEX_PRESSURE_SOFT_LIMIT,
                             AnomalyDetectorSettings.AD_INDEX_PRESSURE_HARD_LIMIT,
                             AnomalyDetectorSettings.AD_MAX_PRIMARY_SHARDS,
-                            AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES,
+                            AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES,
                             AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE,
                             AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS,
                             AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR,
                             AnomalyDetectorSettings.BATCH_TASK_PIECE_SIZE,
                             AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_CONCURRENCY,
                             AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_CONCURRENCY,
-                            AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_CONCURRENCY,
+                            AnomalyDetectorSettings.AD_ENTITY_COLD_START_QUEUE_CONCURRENCY,
                             AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_CONCURRENCY,
                             AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_BATCH_SIZE,
                             AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_BATCH_SIZE,
                             AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_BATCH_SIZE,
-                            AnomalyDetectorSettings.DEDICATED_CACHE_SIZE,
-                            AnomalyDetectorSettings.COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
-                            AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
-                            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
-                            AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
-                            AnomalyDetectorSettings.ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
-                            AnomalyDetectorSettings.EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
-                            AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY,
-                            AnomalyDetectorSettings.PAGE_SIZE,
+                            AnomalyDetectorSettings.AD_DEDICATED_CACHE_SIZE,
+                            AnomalyDetectorSettings.AD_COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT,
+                            AnomalyDetectorSettings.AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT,
+                            AnomalyDetectorSettings.AD_CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+                            AnomalyDetectorSettings.AD_RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+                            AnomalyDetectorSettings.AD_ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT,
+                            AnomalyDetectorSettings.AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS,
+                            AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY,
+                            AnomalyDetectorSettings.AD_PAGE_SIZE,
                             TimeSeriesSettings.MAX_RETRY_FOR_UNRESPONSIVE_NODE,
                             TimeSeriesSettings.BACKOFF_MINUTES
                         )
@@ -127,11 +127,11 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
 
     public void testAllLegacyOpenDistroSettingsFallback() {
         assertEquals(
-            AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(Settings.EMPTY),
+            AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(Settings.EMPTY),
             LegacyOpenDistroAnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(Settings.EMPTY)
         );
         assertEquals(
-            AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(Settings.EMPTY),
+            AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS.get(Settings.EMPTY),
             LegacyOpenDistroAnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(Settings.EMPTY)
         );
         assertEquals(
@@ -179,7 +179,7 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
             LegacyOpenDistroAnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD.get(Settings.EMPTY)
         );
         assertEquals(
-            AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.get(Settings.EMPTY),
+            AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE.get(Settings.EMPTY),
             LegacyOpenDistroAnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.get(Settings.EMPTY)
         );
         // MAX_ENTITIES_FOR_PREVIEW does not use legacy setting
@@ -191,8 +191,8 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
             LegacyOpenDistroAnomalyDetectorSettings.MAX_PRIMARY_SHARDS.get(Settings.EMPTY)
         );
         assertEquals(
-            AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(Settings.EMPTY),
-            LegacyOpenDistroAnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(Settings.EMPTY)
+            AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(Settings.EMPTY),
+            LegacyOpenDistroAnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(Settings.EMPTY)
         );
         assertEquals(
             AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE.get(Settings.EMPTY),
@@ -218,11 +218,11 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(10));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_anomaly_detectors", 99).build();
-        assertEquals(AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(99));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(99));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(1000));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_multi_entity_anomaly_detectors", 98).build();
-        assertEquals(AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(98));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS.get(settings), Integer.valueOf(98));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(10));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_anomaly_features", 7).build();
@@ -282,19 +282,19 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_RETRY_FOR_BACKOFF.get(settings), Integer.valueOf(3));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_retry_for_end_run_exception", 86).build();
-        assertEquals(AnomalyDetectorSettings.MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings), Integer.valueOf(86));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings), Integer.valueOf(86));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings), Integer.valueOf(6));
 
         settings = Settings.builder().put("plugins.anomaly_detection.filter_by_backend_roles", true).build();
-        assertEquals(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings), Boolean.valueOf(true));
-        assertEquals(LegacyOpenDistroAnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings), Boolean.valueOf(false));
+        assertEquals(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings), Boolean.valueOf(true));
+        assertEquals(LegacyOpenDistroAnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings), Boolean.valueOf(false));
 
         settings = Settings.builder().put("plugins.anomaly_detection.model_max_size_percent", 0.3).build();
-        assertEquals(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.get(settings), Double.valueOf(0.3));
+        assertEquals(AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE.get(settings), Double.valueOf(0.3));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.get(settings), Double.valueOf(0.1));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_entities_per_query", 83).build();
-        assertEquals(AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY.get(settings), Integer.valueOf(83));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY.get(settings), Integer.valueOf(83));
         assertEquals(LegacyOpenDistroAnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY.get(settings), Integer.valueOf(1000));
 
         settings = Settings.builder().put("plugins.anomaly_detection.max_entities_for_preview", 22).build();
@@ -361,8 +361,8 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
             .put("opendistro.anomaly_detection.batch_task_piece_interval_seconds", 26)
             .build();
 
-        assertEquals(AnomalyDetectorSettings.MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(1));
-        assertEquals(AnomalyDetectorSettings.MAX_MULTI_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(2));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings), Integer.valueOf(1));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS.get(settings), Integer.valueOf(2));
         assertEquals(AnomalyDetectorSettings.MAX_ANOMALY_FEATURES.get(settings), Integer.valueOf(3));
         assertEquals(AnomalyDetectorSettings.AD_REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(4));
         assertEquals(AnomalyDetectorSettings.DETECTION_INTERVAL.get(settings), TimeValue.timeValueMinutes(5));
@@ -378,9 +378,9 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
         assertEquals(TimeSeriesSettings.BACKOFF_MINUTES.get(settings), TimeValue.timeValueMinutes(12));
         assertEquals(AnomalyDetectorSettings.AD_BACKOFF_INITIAL_DELAY.get(settings), TimeValue.timeValueMillis(13));
         assertEquals(AnomalyDetectorSettings.AD_MAX_RETRY_FOR_BACKOFF.get(settings), Integer.valueOf(14));
-        assertEquals(AnomalyDetectorSettings.MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings), Integer.valueOf(15));
-        assertEquals(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings), Boolean.valueOf(true));
-        assertEquals(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.get(settings), Double.valueOf(0.6D));
+        assertEquals(AnomalyDetectorSettings.AD_MAX_RETRY_FOR_END_RUN_EXCEPTION.get(settings), Integer.valueOf(15));
+        assertEquals(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings), Boolean.valueOf(true));
+        assertEquals(AnomalyDetectorSettings.AD_MODEL_MAX_SIZE_PERCENTAGE.get(settings), Double.valueOf(0.6D));
         // MAX_ENTITIES_FOR_PREVIEW uses default instead of legacy fallback
         assertEquals(AnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW.get(settings), Integer.valueOf(5));
         // INDEX_PRESSURE_SOFT_LIMIT uses default instead of legacy fallback
@@ -412,7 +412,7 @@ public class AnomalyDetectorSettingsTests extends OpenSearchTestCase {
                 LegacyOpenDistroAnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
                 LegacyOpenDistroAnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE,
                 LegacyOpenDistroAnomalyDetectorSettings.MAX_PRIMARY_SHARDS,
-                LegacyOpenDistroAnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES,
+                LegacyOpenDistroAnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES,
                 LegacyOpenDistroAnomalyDetectorSettings.MAX_CACHE_MISS_HANDLING_PER_SECOND,
                 LegacyOpenDistroAnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE,
                 LegacyOpenDistroAnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS,

--- a/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
+++ b/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
@@ -14,7 +14,7 @@ package org.opensearch.ad.stats;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_MODEL_SIZE_PER_NODE;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -107,11 +107,11 @@ public class ADStatsTests extends OpenSearchTestCase {
         nodeStatName1 = "nodeStat1";
         nodeStatName2 = "nodeStat2";
 
-        Settings settings = Settings.builder().put(MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
+        Settings settings = Settings.builder().put(AD_MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SIZE_PER_NODE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AD_MAX_MODEL_SIZE_PER_NODE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
+++ b/src/test/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.stats.suppliers;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_MODEL_SIZE_PER_NODE;
 import static org.opensearch.ad.stats.suppliers.ModelsOnNodeSupplier.MODEL_STATE_STAT_KEYS;
 
 import java.time.Clock;
@@ -90,11 +90,11 @@ public class ModelsOnNodeSupplierTests extends OpenSearchTestCase {
 
     @Test
     public void testGet() {
-        Settings settings = Settings.builder().put(MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
+        Settings settings = Settings.builder().put(AD_MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SIZE_PER_NODE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AD_MAX_MODEL_SIZE_PER_NODE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
@@ -13,7 +13,7 @@ package org.opensearch.ad.transport;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_MAX_MODEL_SIZE_PER_NODE;
 
 import java.time.Clock;
 import java.util.Arrays;
@@ -79,11 +79,11 @@ public class ADStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
         nodeStatName1 = "nodeStat1";
         nodeStatName2 = "nodeStat2";
 
-        Settings settings = Settings.builder().put(MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
+        Settings settings = Settings.builder().put(AD_MAX_MODEL_SIZE_PER_NODE.getKey(), 10).build();
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MAX_MODEL_SIZE_PER_NODE)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AD_MAX_MODEL_SIZE_PER_NODE)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyDetectorJobActionTests.java
@@ -57,7 +57,7 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
 
         Settings build = Settings.builder().build();

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -65,7 +65,6 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.constant.ADCommonMessages;
@@ -108,6 +107,7 @@ import org.opensearch.timeseries.AbstractTimeSeriesTest;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TestHelpers;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.EndRunException;
 import org.opensearch.timeseries.common.exception.InternalFailure;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
@@ -149,7 +149,7 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
     private String adID;
     private String featureId;
     private String featureName;
-    private ADCircuitBreakerService adCircuitBreakerService;
+    private CircuitBreakerService adCircuitBreakerService;
     private ADStats adStats;
     private double confidence;
     private double anomalyGrade;
@@ -172,7 +172,7 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
         super.setUp();
         super.setUpLog4jForJUnit(AnomalyResultTransportAction.class);
 
-        setupTestNodes(AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY, AnomalyDetectorSettings.PAGE_SIZE);
+        setupTestNodes(AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY, AnomalyDetectorSettings.AD_PAGE_SIZE);
 
         transportService = testNodes[0].transportService;
         clusterService = testNodes[0].clusterService;
@@ -253,7 +253,7 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
 
         thresholdModelID = SingleStreamModelIdMapper.getThresholdModelId(adID); // "123-threshold";
         // when(normalModelPartitioner.getThresholdModelId(any(String.class))).thenReturn(thresholdModelID);
-        adCircuitBreakerService = mock(ADCircuitBreakerService.class);
+        adCircuitBreakerService = mock(CircuitBreakerService.class);
         when(adCircuitBreakerService.isOpen()).thenReturn(false);
 
         ThreadPool threadPool = mock(ThreadPool.class);
@@ -460,8 +460,8 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
         setupTestNodes(
             failureTransportInterceptor,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY,
-            AnomalyDetectorSettings.PAGE_SIZE
+            AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY,
+            AnomalyDetectorSettings.AD_PAGE_SIZE
         );
 
         // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
@@ -683,8 +683,8 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
         setupTestNodes(
             failureTransportInterceptor,
             Settings.EMPTY,
-            AnomalyDetectorSettings.MAX_ENTITIES_PER_QUERY,
-            AnomalyDetectorSettings.PAGE_SIZE
+            AnomalyDetectorSettings.AD_MAX_ENTITIES_PER_QUERY,
+            AnomalyDetectorSettings.AD_PAGE_SIZE
         );
 
         // mock hashing ring response. This has to happen after setting up test nodes with the failure interceptor
@@ -735,7 +735,7 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
 
     public void testCircuitBreaker() {
 
-        ADCircuitBreakerService breakerService = mock(ADCircuitBreakerService.class);
+        CircuitBreakerService breakerService = mock(CircuitBreakerService.class);
         when(breakerService.isOpen()).thenReturn(true);
 
         // These constructors register handler in transport service

--- a/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorActionTests.java
@@ -49,7 +49,7 @@ public class DeleteAnomalyDetectorActionTests extends OpenSearchIntegTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         adTaskManager = mock(ADTaskManager.class);

--- a/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
@@ -89,7 +89,7 @@ public class DeleteAnomalyDetectorTests extends AbstractTimeSeriesTest {
         clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         transportService = new TransportService(

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
@@ -93,7 +93,7 @@ public class GetAnomalyDetectorTests extends AbstractTimeSeriesTest {
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -86,7 +86,7 @@ public class GetAnomalyDetectorTransportActionTests extends OpenSearchSingleNode
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         adTaskManager = mock(ADTaskManager.class);

--- a/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportActionTests.java
@@ -87,7 +87,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
         clusterService = mock(ClusterService.class);
         clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
@@ -199,7 +199,7 @@ public class IndexAnomalyDetectorTransportActionTests extends OpenSearchIntegTes
 
     @Test
     public void testIndexTransportActionWithUserAndFilterOn() {
-        Settings settings = Settings.builder().put(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.getKey(), true).build();
+        Settings settings = Settings.builder().put(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.getKey(), true).build();
         ThreadContext threadContext = new ThreadContext(settings);
         threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -46,7 +46,6 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.ad.AnomalyDetectorRunner;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.feature.FeatureManager;
 import org.opensearch.ad.feature.Features;
 import org.opensearch.ad.indices.ADIndexManagement;
@@ -73,6 +72,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.TestHelpers;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.util.RestHandlerUtils;
@@ -88,7 +88,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
     private FeatureManager featureManager;
     private ModelManager modelManager;
     private Task task;
-    private ADCircuitBreakerService circuitBreaker;
+    private CircuitBreakerService circuitBreaker;
 
     @Override
     @Before
@@ -104,8 +104,8 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
                         Arrays
                             .asList(
                                 AnomalyDetectorSettings.MAX_ANOMALY_FEATURES,
-                                AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES,
-                                AnomalyDetectorSettings.PAGE_SIZE,
+                                AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES,
+                                AnomalyDetectorSettings.AD_PAGE_SIZE,
                                 AnomalyDetectorSettings.MAX_CONCURRENT_PREVIEW
                             )
                     )
@@ -130,7 +130,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
         featureManager = mock(FeatureManager.class);
         modelManager = mock(ModelManager.class);
         runner = new AnomalyDetectorRunner(modelManager, featureManager, AnomalyDetectorSettings.MAX_PREVIEW_RESULTS);
-        circuitBreaker = mock(ADCircuitBreakerService.class);
+        circuitBreaker = mock(CircuitBreakerService.class);
         when(circuitBreaker.isOpen()).thenReturn(false);
         action = new PreviewAnomalyDetectorTransportAction(
             Settings.EMPTY,
@@ -278,7 +278,7 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
     @Test
     public void testPreviewTransportActionNoContext() throws IOException, InterruptedException {
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
-        Settings settings = Settings.builder().put(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.getKey(), true).build();
+        Settings settings = Settings.builder().put(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.getKey(), true).build();
         Client client = mock(Client.class);
         ThreadContext threadContext = new ThreadContext(settings);
         threadContext.putTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "alice|odfe,aes|engineering,operations");

--- a/src/test/java/org/opensearch/ad/transport/ProfileTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ProfileTransportActionTests.java
@@ -114,7 +114,7 @@ public class ProfileTransportActionTests extends OpenSearchIntegTestCase {
     }
 
     private void setUpModelSize(int maxModel) {
-        Settings nodeSettings = Settings.builder().put(AnomalyDetectorSettings.MAX_MODEL_SIZE_PER_NODE.getKey(), maxModel).build();
+        Settings nodeSettings = Settings.builder().put(AnomalyDetectorSettings.AD_MAX_MODEL_SIZE_PER_NODE.getKey(), maxModel).build();
         internalCluster().startNode(nodeSettings);
     }
 

--- a/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
@@ -37,7 +37,6 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.ad.breaker.ADCircuitBreakerService;
 import org.opensearch.ad.cluster.HashRing;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.constant.ADCommonMessages;
@@ -56,6 +55,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.stats.StatNames;
 import org.opensearch.transport.Transport;
@@ -110,7 +110,7 @@ public class RCFResultTests extends OpenSearchTestCase {
         );
 
         ModelManager manager = mock(ModelManager.class);
-        ADCircuitBreakerService adCircuitBreakerService = mock(ADCircuitBreakerService.class);
+        CircuitBreakerService adCircuitBreakerService = mock(CircuitBreakerService.class);
         RCFResultTransportAction action = new RCFResultTransportAction(
             mock(ActionFilters.class),
             transportService,
@@ -168,7 +168,7 @@ public class RCFResultTests extends OpenSearchTestCase {
         );
 
         ModelManager manager = mock(ModelManager.class);
-        ADCircuitBreakerService adCircuitBreakerService = mock(ADCircuitBreakerService.class);
+        CircuitBreakerService adCircuitBreakerService = mock(CircuitBreakerService.class);
         RCFResultTransportAction action = new RCFResultTransportAction(
             mock(ActionFilters.class),
             transportService,
@@ -284,7 +284,7 @@ public class RCFResultTests extends OpenSearchTestCase {
         );
 
         ModelManager manager = mock(ModelManager.class);
-        ADCircuitBreakerService breakerService = mock(ADCircuitBreakerService.class);
+        CircuitBreakerService breakerService = mock(CircuitBreakerService.class);
         RCFResultTransportAction action = new RCFResultTransportAction(
             mock(ActionFilters.class),
             transportService,
@@ -335,7 +335,7 @@ public class RCFResultTests extends OpenSearchTestCase {
         );
 
         ModelManager manager = mock(ModelManager.class);
-        ADCircuitBreakerService adCircuitBreakerService = mock(ADCircuitBreakerService.class);
+        CircuitBreakerService adCircuitBreakerService = mock(CircuitBreakerService.class);
         RCFResultTransportAction action = new RCFResultTransportAction(
             mock(ActionFilters.class),
             transportService,

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
@@ -92,7 +92,7 @@ public class SearchAnomalyDetectorInfoActionTests extends OpenSearchIntegTestCas
         clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
     }

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -88,7 +88,7 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
         clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES)))
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         clusterState = createClusterState();

--- a/src/test/java/org/opensearch/ad/transport/handler/ADSearchHandlerTests.java
+++ b/src/test/java/org/opensearch/ad/transport/handler/ADSearchHandlerTests.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES;
 import static org.opensearch.timeseries.TestHelpers.matchAllRequest;
 
 import org.junit.Before;
@@ -50,8 +50,8 @@ public class ADSearchHandlerTests extends ADUnitTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        settings = Settings.builder().put(FILTER_BY_BACKEND_ROLES.getKey(), false).build();
-        clusterSettings = clusterSetting(settings, FILTER_BY_BACKEND_ROLES);
+        settings = Settings.builder().put(AD_FILTER_BY_BACKEND_ROLES.getKey(), false).build();
+        clusterSettings = clusterSetting(settings, AD_FILTER_BY_BACKEND_ROLES);
         clusterService = new ClusterService(settings, clusterSettings, null);
         client = mock(Client.class);
         searchHandler = new ADSearchHandler(settings, clusterService, client);
@@ -74,7 +74,7 @@ public class ADSearchHandlerTests extends ADUnitTestCase {
     }
 
     public void testFilterEnabledWithWrongSearch() {
-        settings = Settings.builder().put(FILTER_BY_BACKEND_ROLES.getKey(), true).build();
+        settings = Settings.builder().put(AD_FILTER_BY_BACKEND_ROLES.getKey(), true).build();
         clusterService = new ClusterService(settings, clusterSettings, null);
 
         searchHandler = new ADSearchHandler(settings, clusterService, client);
@@ -83,7 +83,7 @@ public class ADSearchHandlerTests extends ADUnitTestCase {
     }
 
     public void testFilterEnabled() {
-        settings = Settings.builder().put(FILTER_BY_BACKEND_ROLES.getKey(), true).build();
+        settings = Settings.builder().put(AD_FILTER_BY_BACKEND_ROLES.getKey(), true).build();
         clusterService = new ClusterService(settings, clusterSettings, null);
 
         searchHandler = new ADSearchHandler(settings, clusterService, client);

--- a/src/test/java/org/opensearch/timeseries/feature/NoPowermockSearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/NoPowermockSearchFeatureDaoTests.java
@@ -103,6 +103,7 @@ import org.opensearch.timeseries.dataprocessor.LinearUniformImputer;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.Feature;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.SecurityClientUtil;
 
 import com.google.common.collect.ImmutableList;
@@ -164,7 +165,7 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             Settings.EMPTY,
             Collections
                 .unmodifiableSet(
-                    new HashSet<>(Arrays.asList(AnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW, AnomalyDetectorSettings.PAGE_SIZE))
+                    new HashSet<>(Arrays.asList(AnomalyDetectorSettings.MAX_ENTITIES_FOR_PREVIEW, AnomalyDetectorSettings.AD_PAGE_SIZE))
                 )
         );
         clusterService = mock(ClusterService.class);
@@ -185,7 +186,7 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             clientUtil,
             settings,
             clusterService,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
             clock,
             1,
             1,
@@ -371,7 +372,7 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             clientUtil,
             settings,
             clusterService,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
             clock,
             2,
             1,
@@ -417,7 +418,7 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             clientUtil,
             settings,
             clusterService,
-            AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
             clock,
             2,
             1,

--- a/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoParamTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoParamTests.java
@@ -51,7 +51,6 @@ import org.opensearch.action.search.MultiSearchResponse.Item;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.model.AnomalyDetector;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
@@ -80,6 +79,7 @@ import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.dataprocessor.Imputer;
 import org.opensearch.timeseries.dataprocessor.LinearUniformImputer;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.ParseUtils;
 import org.opensearch.timeseries.util.SecurityClientUtil;
 import org.powermock.api.mockito.PowerMockito;
@@ -179,7 +179,7 @@ public class SearchFeatureDaoParamTests {
         }).when(nodeStateManager).getConfig(any(String.class), eq(AnalysisType.AD), any(ActionListener.class));
         clientUtil = new SecurityClientUtil(nodeStateManager, settings);
         searchFeatureDao = spy(
-            new SearchFeatureDao(client, xContent, imputer, clientUtil, settings, null, AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
+            new SearchFeatureDao(client, xContent, imputer, clientUtil, settings, null, TimeSeriesSettings.NUM_SAMPLES_PER_TREE)
         );
 
         detectionInterval = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);

--- a/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
@@ -56,7 +56,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.ad.model.AnomalyDetector;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.client.Client;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
@@ -96,6 +95,7 @@ import org.opensearch.timeseries.dataprocessor.Imputer;
 import org.opensearch.timeseries.dataprocessor.LinearUniformImputer;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.ParseUtils;
 import org.opensearch.timeseries.util.SecurityClientUtil;
 import org.powermock.api.mockito.PowerMockito;
@@ -182,7 +182,7 @@ public class SearchFeatureDaoTests {
         }).when(nodeStateManager).getConfig(any(String.class), eq(AnalysisType.AD), any(ActionListener.class));
         clientUtil = new SecurityClientUtil(nodeStateManager, settings);
         searchFeatureDao = spy(
-            new SearchFeatureDao(client, xContent, imputer, clientUtil, settings, null, AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
+            new SearchFeatureDao(client, xContent, imputer, clientUtil, settings, null, TimeSeriesSettings.NUM_SAMPLES_PER_TREE)
         );
 
         detectionInterval = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);

--- a/src/test/java/test/org/opensearch/ad/util/MLUtil.java
+++ b/src/test/java/test/org/opensearch/ad/util/MLUtil.java
@@ -24,9 +24,9 @@ import java.util.stream.IntStream;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelManager.ModelType;
 import org.opensearch.ad.ml.ModelState;
-import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.timeseries.model.Entity;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 
 import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
@@ -39,7 +39,7 @@ import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
  */
 public class MLUtil {
     private static Random random = new Random(42);
-    private static int minSampleSize = AnomalyDetectorSettings.NUM_MIN_SAMPLES;
+    private static int minSampleSize = TimeSeriesSettings.NUM_MIN_SAMPLES;
 
     private static String randomString(int targetStringLength) {
         int leftLimit = 97; // letter 'a'
@@ -96,19 +96,19 @@ public class MLUtil {
 
     public static EntityModel createNonEmptyModel(String detectorId, int sampleSize, Entity entity) {
         Queue<double[]> samples = createQueueSamples(sampleSize);
-        int numDataPoints = random.nextInt(1000) + AnomalyDetectorSettings.NUM_MIN_SAMPLES;
+        int numDataPoints = random.nextInt(1000) + TimeSeriesSettings.NUM_MIN_SAMPLES;
         ThresholdedRandomCutForest trcf = new ThresholdedRandomCutForest(
             ThresholdedRandomCutForest
                 .builder()
                 .dimensions(1)
-                .sampleSize(AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
-                .numberOfTrees(AnomalyDetectorSettings.NUM_TREES)
-                .timeDecay(AnomalyDetectorSettings.TIME_DECAY)
-                .outputAfter(AnomalyDetectorSettings.NUM_MIN_SAMPLES)
+                .sampleSize(TimeSeriesSettings.NUM_SAMPLES_PER_TREE)
+                .numberOfTrees(TimeSeriesSettings.NUM_TREES)
+                .timeDecay(TimeSeriesSettings.TIME_DECAY)
+                .outputAfter(TimeSeriesSettings.NUM_MIN_SAMPLES)
                 .initialAcceptFraction(0.125d)
                 .parallelExecutionEnabled(false)
                 .internalShinglingEnabled(true)
-                .anomalyRate(1 - AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE)
+                .anomalyRate(1 - TimeSeriesSettings.THRESHOLD_MIN_PVALUE)
                 .transformMethod(TransformMethod.NORMALIZE)
                 .alertOnce(true)
                 .autoAdjust(true)


### PR DESCRIPTION
### Description
This PR extracts shared components from `ADTaskCacheManager` into `TaskCacheManager` to support the requirements of the forecasting feature. To enable the extraction, this PR also did the following refactoring.

**Renamings**:

- **Method-level in `ADTaskCacheManager`**:
  - `addDeletedDetector` to `addDeletedConfig`
  - `addDeletedDetectorTask` to `addDeletedTask`
  - `hasDeletedDetectorTask` to `hasDeletedTask`
  - `pollDeletedDetector` to `pollDeletedConfig`
  - `pollDeletedDetectorTask` to `pollDeletedTask`

- **Variable-level in `AnomalyDetectorSettings`**:
  - `CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT` to `AD_CHECKPOINT_MAINTAIN_QUEUE_MAX_HEAP_PERCENT`
  - `CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT` to `AD_CHECKPOINT_READ_QUEUE_MAX_HEAP_PERCENT`
  - `CHECKPOINT_SAVING_FREQ` to `AD_CHECKPOINT_SAVING_FREQ`
  - `CHECKPOINT_TTL` to `AD_CHECKPOINT_TTL`
  - `CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT` to `AD_CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT`
  - `COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT` to `AD_COLD_ENTITY_QUEUE_MAX_HEAP_PERCENT`
  - `DEDICATED_CACHE_SIZE` to `AD_DEDICATED_CACHE_SIZE`
  - `ENTITY_COLD_START_QUEUE_CONCURRENCY` to `AD_ENTITY_COLD_START_QUEUE_CONCURRENCY`
  - `ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT` to `AD_ENTITY_COLD_START_QUEUE_MAX_HEAP_PERCENT`
  - `EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS` to `AD_EXPECTED_COLD_ENTITY_EXECUTION_TIME_IN_MILLISECS`
  - `FILTER_BY_BACKEND_ROLES` to `AD_FILTER_BY_BACKEND_ROLES`
  - `MAX_ENTITIES_PER_QUERY` to `AD_MAX_ENTITIES_PER_QUERY`
  - `MAX_MODEL_SIZE_PER_NODE` to `AD_MAX_MODEL_SIZE_PER_NODE`
  - `MAX_MULTI_ENTITY_ANOMALY_DETECTORS` to `AD_MAX_HC_ANOMALY_DETECTORS`
  - `MAX_RETRY_FOR_END_RUN_EXCEPTION` to `AD_MAX_RETRY_FOR_END_RUN_EXCEPTION`
  - `MAX_SINGLE_ENTITY_ANOMALY_DETECTORS` to `AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS`
  - `MODEL_MAX_SIZE_PERCENTAGE` to `AD_MODEL_MAX_SIZE_PERCENTAGE`
  - `PAGE_SIZE` to `AD_PAGE_SIZE`
  - `RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT` to `AD_RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT`

- **Class-level**:
  - `ADRealtimeTaskCache` renamed to `RealtimeTaskCache`

- **Package-level**:
  - Shifted from `org.opensearch.ad.breaker` to `org.opensearch.timeseries.breaker`

**Migrations**:

- Variables transferred from `AnomalyDetectorSettings` to `TimeSeriesSettings`:
  - `BATCH_BOUNDING_BOX_CACHE_RATIO`
  - `CHECKPOINT_MAINTAIN_REQUEST_SIZE_IN_BYTES`
  - `CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES`
  - `DEFAULT_AD_JOB_LOC_DURATION_SECONDS` (renamed to `DEFAULT_JOB_LOC_DURATION_SECONDS`)
  - `ENTITY_REQUEST_SIZE_IN_BYTES`
  - `HOURLY_MAINTENANCE`
  - `INTERVAL_RATIO_FOR_REQUESTS`
  - `LOW_SEGMENT_PRUNE_RATIO`
  - `MAINTENANCE_FREQ_CONSTANT`
  - `MAX_COLD_START_ROUNDS`
  - `MAX_QUEUED_TASKS_RATIO`
  - `MAX_TOTAL_RCF_SERIALIZATION_BUFFERS`
  - `MAX_CHECKPOINT_BYTES`
  - `MEDIUM_SEGMENT_PRUNE_RATIO`
  - `NUM_MIN_SAMPLES`
  - `NUM_SAMPLES_PER_TREE`
  - `NUM_TREES`
  - `QUEUE_MAINTENANCE`
  - `RESULT_WRITE_QUEUE_SIZE_IN_BYTES`
  - `SERIALIZATION_BUFFER_BYTES`
  - `THRESHOLD_MIN_PVALUE`
  - `TIME_DECAY`

**Deletions**:
- Obsolete settings and methods:
  - `DESIRED_MODEL_SIZE_PERCENTAGE` in `AnomalyDetectorSettings`
  - `getDesiredModelSize` in `MemoryTracker`

**Modifications**:
- `MemoryTracker` enums renamed for clear differentiation between real-time and historical memory usage, adding `REAL_TIME_FORECASTER` for a harmonized single-stream and HC analysis approach.

**Deprecations**

- deprecated the following AnomalyDetectorSettings variables and explained reasons in the comment
  - `AD_MAX_RETRY_FOR_UNRESPONSIVE_NODE`
  - `ENTITY_REQUEST_SIZE_IN_BYTES`
  - `ENTITY_FEATURE_REQUEST_SIZE_IN_BYTES`

**Tests**:
- Changes validated with a successful Gradle build.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/981

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).



