### PR TITLE
Revert "Enforce DOCUMENT Replication for AD Indices and Adjust Primar…

### DIFF
--- a/src/main/java/org/opensearch/ad/indices/ADIndexManagement.java
+++ b/src/main/java/org/opensearch/ad/indices/ADIndexManagement.java
@@ -19,8 +19,6 @@ import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_RESULT_HISTO
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.ANOMALY_DETECTION_STATE_INDEX_MAPPING_FILE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.ANOMALY_RESULTS_INDEX_MAPPING_FILE;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_INDEX_MAPPING_FILE;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
 
 import java.io.IOException;
 import java.util.EnumMap;
@@ -66,7 +64,7 @@ public class ADIndexManagement extends IndexManagement<ADIndex> {
      * @param settings       OS cluster setting
      * @param nodeFilter     Used to filter eligible nodes to host AD indices
      * @param maxUpdateRunningTimes max number of retries to update index mapping and setting
-     * @throws IOException when failing to get mapping file
+     * @throws IOException
      */
     public ADIndexManagement(
         Client client,
@@ -197,10 +195,7 @@ public class ADIndexManagement extends IndexManagement<ADIndex> {
     @Override
     public void initStateIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if
-            // anomalies found).
-            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-            CreateIndexRequest request = new CreateIndexRequest(ADCommonName.DETECTION_STATE_INDEX, replicationSettings)
+            CreateIndexRequest request = new CreateIndexRequest(ADCommonName.DETECTION_STATE_INDEX)
                 .mapping(getStateMappings(), XContentType.JSON)
                 .settings(settings);
             adminClient.indices().create(request, markMappingUpToDate(ADIndex.STATE, actionListener));
@@ -224,11 +219,7 @@ public class ADIndexManagement extends IndexManagement<ADIndex> {
         } catch (IOException e) {
             throw new EndRunException("", "Cannot find checkpoint mapping file", true);
         }
-        // AD indices need RAW (e.g., we want users to be able to consume AD results as soon as possible and send out an alert if anomalies
-        // found).
-        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-        CreateIndexRequest request = new CreateIndexRequest(ADCommonName.CHECKPOINT_INDEX_NAME, replicationSettings)
-            .mapping(mapping, XContentType.JSON);
+        CreateIndexRequest request = new CreateIndexRequest(ADCommonName.CHECKPOINT_INDEX_NAME).mapping(mapping, XContentType.JSON);
         choosePrimaryShards(request, true);
         adminClient.indices().create(request, markMappingUpToDate(ADIndex.CHECKPOINT, actionListener));
     }

--- a/src/main/java/org/opensearch/forecast/indices/ForecastIndexManagement.java
+++ b/src/main/java/org/opensearch/forecast/indices/ForecastIndexManagement.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.forecast.indices;
 
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.forecast.constant.ForecastCommonName.DUMMY_FORECAST_RESULT_ID;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_CHECKPOINT_INDEX_MAPPING_FILE;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_MAX_PRIMARY_SHARDS;
@@ -20,7 +19,6 @@ import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_RESULT_
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_RESULT_HISTORY_RETENTION_PERIOD;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_RESULT_HISTORY_ROLLOVER_PERIOD;
 import static org.opensearch.forecast.settings.ForecastSettings.FORECAST_STATE_INDEX_MAPPING_FILE;
-import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
 
 import java.io.IOException;
 import java.util.EnumMap;
@@ -63,7 +61,7 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
      * @param settings       OS cluster setting
      * @param nodeFilter     Used to filter eligible nodes to host forecast indices
      * @param maxUpdateRunningTimes max number of retries to update index mapping and setting
-     * @throws IOException when failing to get mapping file
+     * @throws IOException
      */
     public ForecastIndexManagement(
         Client client,
@@ -179,8 +177,7 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
     @Override
     public void initStateIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-            CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_STATE_INDEX, replicationSettings)
+            CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_STATE_INDEX)
                 .mapping(getStateMappings(), XContentType.JSON)
                 .settings(settings);
             adminClient.indices().create(request, markMappingUpToDate(ForecastIndex.STATE, actionListener));
@@ -204,10 +201,7 @@ public class ForecastIndexManagement extends IndexManagement<ForecastIndex> {
         } catch (IOException e) {
             throw new EndRunException("", "Cannot find checkpoint mapping file", true);
         }
-        // forecast indices need RAW (e.g., we want users to be able to consume forecast results as soon as
-        // possible and send out an alert if a threshold is breached).
-        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-        CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_CHECKPOINT_INDEX_NAME, replicationSettings)
+        CreateIndexRequest request = new CreateIndexRequest(ForecastCommonName.FORECAST_CHECKPOINT_INDEX_NAME)
             .mapping(mapping, XContentType.JSON);
         choosePrimaryShards(request, true);
         adminClient.indices().create(request, markMappingUpToDate(ForecastIndex.CHECKPOINT, actionListener));

--- a/src/main/java/org/opensearch/forecast/settings/ForecastSettings.java
+++ b/src/main/java/org/opensearch/forecast/settings/ForecastSettings.java
@@ -122,7 +122,7 @@ public final class ForecastSettings {
 
     // max number of primary shards of a forecast index
     public static final Setting<Integer> FORECAST_MAX_PRIMARY_SHARDS = Setting
-        .intSetting("plugins.forecast.max_primary_shards", 20, 0, 200, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .intSetting("plugins.forecast.max_primary_shards", 10, 0, 200, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     // saving checkpoint every 12 hours.
     // To support 1 million entities in 36 data nodes, each node has roughly 28K models.

--- a/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
+++ b/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
@@ -11,8 +11,6 @@
 
 package org.opensearch.timeseries.indices;
 
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.indices.replication.common.ReplicationType.DOCUMENT;
 import static org.opensearch.timeseries.constant.CommonMessages.CAN_NOT_FIND_RESULT_INDEX;
 
 import java.io.IOException;
@@ -428,10 +426,7 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
      * @throws IOException IOException from {@link IndexManagement#getConfigMappings}
      */
     public void initConfigIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
-        // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as possible
-        // and send out an alert if anomalies found).
-        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-        CreateIndexRequest request = new CreateIndexRequest(CommonName.CONFIG_INDEX, replicationSettings)
+        CreateIndexRequest request = new CreateIndexRequest(CommonName.CONFIG_INDEX)
             .mapping(getConfigMappings(), XContentType.JSON)
             .settings(settings);
         adminClient.indices().create(request, actionListener);
@@ -482,11 +477,7 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
      */
     public void initJobIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as
-            // possible and send out an alert if anomalies found).
-            Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-            CreateIndexRequest request = new CreateIndexRequest(CommonName.JOB_INDEX, replicationSettings)
-                .mapping(getJobMappings(), XContentType.JSON);
+            CreateIndexRequest request = new CreateIndexRequest(CommonName.JOB_INDEX).mapping(getJobMappings(), XContentType.JSON);
             request
                 .settings(
                     Settings
@@ -937,10 +928,7 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
 
         CreateIndexRequest createRequest = rollOverRequest.getCreateIndexRequest();
 
-        // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as possible
-        // and send out an alert if anomalies found).
-        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-        createRequest.index(rolloverIndexPattern).settings(replicationSettings).mapping(resultMapping, XContentType.JSON);
+        createRequest.index(rolloverIndexPattern).mapping(resultMapping, XContentType.JSON);
 
         choosePrimaryShards(createRequest, true);
 
@@ -965,10 +953,7 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
         IndexType resultIndex,
         ActionListener<CreateIndexResponse> actionListener
     ) {
-        // time series indices need RAW (e.g., we want users to be able to consume AD results as soon as possible
-        // and send out an alert if anomalies found).
-        Settings replicationSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, DOCUMENT.name()).build();
-        CreateIndexRequest request = new CreateIndexRequest(resultIndexName, replicationSettings).mapping(resultMapping, XContentType.JSON);
+        CreateIndexRequest request = new CreateIndexRequest(resultIndexName).mapping(resultMapping, XContentType.JSON);
         if (alias != null) {
             request.alias(new Alias(alias));
         }


### PR DESCRIPTION
This reverts commit bc1649922ef39619424fc16c64af5836e48a4a12.

### Description
Per request in issue - https://github.com/opensearch-project/anomaly-detection/issues/989, reverting this change as core now supporting real time reads for segment replication enabled indices (https://github.com/opensearch-project/OpenSearch/issues/8536)

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/989

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
