### PR TITLE
upgrading commons-lang3 version to fix conflict issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-runtime', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-api', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
-    implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
 
 
     implementation "org.jacoco:org.jacoco.agent:0.8.5"

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-runtime', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-api', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
 
     implementation "org.jacoco:org.jacoco.agent:0.8.5"
     implementation ("org.jacoco:org.jacoco.ant:0.8.5") {
@@ -221,7 +221,6 @@ configurations.all {
         force "net.bytebuddy:byte-buddy-agent:1.14.6"
         force "com.google.code.gson:gson:2.8.9"
         force "junit:junit:4.13.2"
-        force "org.apache.commons:commons-lang3:${versions.commonslang}"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -221,6 +221,7 @@ configurations.all {
         force "net.bytebuddy:byte-buddy-agent:1.14.6"
         force "com.google.code.gson:gson:2.8.9"
         force "junit:junit:4.13.2"
+        force "org.apache.commons:commons-lang3:3.12.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,8 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-runtime', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-api', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
+    implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
+
 
     implementation "org.jacoco:org.jacoco.agent:0.8.5"
     implementation ("org.jacoco:org.jacoco.ant:0.8.5") {

--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ configurations.all {
         force "net.bytebuddy:byte-buddy-agent:1.14.6"
         force "com.google.code.gson:gson:2.8.9"
         force "junit:junit:4.13.2"
-        force "org.apache.commons:commons-lang3:3.12.0"
+        force "org.apache.commons:commons-lang3:${versions.commonslang}"
     }
 }
 


### PR DESCRIPTION
### Description
Found this version conflict issue in recent build, adding this line to force commons-lang3 to use 3.12.0

### Issues Resolved
```
* What went wrong:
Could not determine the dependencies of task ':thirdPartyAudit'.
> Could not resolve all dependencies for configuration ':runtimeClasspath'.
   > Conflict found for the following module:
       - org.apache.commons:commons-lang3 between versions 3.13.0 and 3.12.0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
