### PR TITLE
Ensure integ tests run with security after plugin rename

### DIFF
--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -74,7 +74,7 @@ jobs:
           if [ $security -gt 0 ]
           then
             echo "Security plugin is available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin -i
           else
             echo "Security plugin is NOT available, skipping integration tests"
           fi

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # anomaly-detection
+      # time-series-analytics
       - name: Checkout AD
         uses: actions/checkout@v2
 
@@ -31,8 +31,8 @@ jobs:
         run: |
           ./gradlew assemble
       # example of variables:
-      # plugin = opensearch-anomaly-detection-2.4.0.0-SNAPSHOT.zip
-      # version = 2.4.0, plugin_version = 2.4.0.0, qualifier = SNAPSHOT
+      # plugin = opensearch-time-series-analytics-2.10.0.0-SNAPSHOT.zip
+      # version = 2.10.0, plugin_version = 2.10.0.0, qualifier = SNAPSHOT
       - name: Pull and Run Docker
         run: |
           plugin=`basename $(ls build/distributions/*.zip)`
@@ -53,8 +53,8 @@ jobs:
           if docker pull opensearchstaging/opensearch:$docker_version
           then
             echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
-            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-anomaly-detection ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-anomaly-detection; fi" >> Dockerfile
-            echo "ADD anomaly-detection/build/distributions/$plugin /tmp/" >> Dockerfile
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-time-series-analytics ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-time-series-analytics; fi" >> Dockerfile
+            echo "ADD time-series-analytics/build/distributions/$plugin /tmp/" >> Dockerfile
             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile
             docker build -t opensearch-ad:test .
             echo "imagePresent=true" >> $GITHUB_ENV

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -53,6 +53,7 @@ jobs:
           if docker pull opensearchstaging/opensearch:$docker_version
           then
             echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-anomaly-detection ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-anomaly-detection; fi" >> Dockerfile
             echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-time-series-analytics ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-time-series-analytics; fi" >> Dockerfile
             echo "ADD anomaly-detection/build/distributions/$plugin /tmp/" >> Dockerfile
             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -54,7 +54,7 @@ jobs:
           then
             echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
             echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-time-series-analytics ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-time-series-analytics; fi" >> Dockerfile
-            echo "ADD time-series-analytics/build/distributions/$plugin /tmp/" >> Dockerfile
+            echo "ADD anomaly-detection/build/distributions/$plugin /tmp/" >> Dockerfile
             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile
             docker build -t opensearch-ad:test .
             echo "imagePresent=true" >> $GITHUB_ENV

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Pull and Run Docker
         run: |
           plugin=`basename $(ls build/distributions/*.zip)`
-          version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
-          plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
-          qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
+          version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-4`
+          qualifier=`echo $plugin|awk -F- '{print $6}'| cut -d. -f 1-1`
 
           if $qualifier!=SNAPSHOT
           then

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -75,7 +75,7 @@ jobs:
           if [ $security -gt 0 ]
           then
             echo "Security plugin is available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin -i
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin
           else
             echo "Security plugin is NOT available, skipping integration tests"
           fi

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -73,7 +73,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         char[] password = new char[15];
         for (int i = 0; i < 15; i++) {
             char nextChar = characters.charAt(rng.nextInt(characters.length()));
-            while (username.indexOf(nextChar) > 0) {
+            while (username.indexOf(nextChar) > -1) {
                 nextChar = characters.charAt(rng.nextInt(characters.length()));
             }
             password[i] = nextChar;

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -66,12 +66,12 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
      * @return a random password.
      */
     public static String generatePassword() {
-        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
 
         Random rng = new Random();
 
-        char[] password = new char[10];
-        for (int i = 0; i < 10; i++) {
+        char[] password = new char[15];
+        for (int i = 0; i < 15; i++) {
             password[i] = characters.charAt(rng.nextInt(characters.length()));
         }
 
@@ -202,7 +202,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         // User Cat has AD full access, but is part of different backend role so Cat should not be able to access
         // Alice detector
         Exception exception = expectThrows(IOException.class, () -> { getConfig(aliceDetector.getId(), catClient); });
-        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access detector: " + aliceDetector.getId()));
+        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access config: " + aliceDetector.getId()));
     }
 
     private void confirmingClientIsAdmin() throws IOException {
@@ -336,7 +336,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Exception exception = expectThrows(IOException.class, () -> {
             startAnomalyDetector(aliceDetector.getId(), new DateRange(now.minus(10, ChronoUnit.DAYS), now), catClient);
         });
-        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access detector: " + aliceDetector.getId()));
+        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access config: " + aliceDetector.getId()));
     }
 
     public void testStopApiFilterByEnabled() throws IOException {
@@ -346,7 +346,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         // User Cat has AD full access, but is part of different backend role so Cat should not be able to access
         // Alice detector
         Exception exception = expectThrows(IOException.class, () -> { stopAnomalyDetector(aliceDetector.getId(), catClient, true); });
-        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access detector: " + aliceDetector.getId()));
+        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access config: " + aliceDetector.getId()));
     }
 
     public void testDeleteApiFilterByEnabled() throws IOException {
@@ -356,7 +356,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         // User Cat has AD full access, but is part of different backend role so Cat should not be able to access
         // Alice detector
         Exception exception = expectThrows(IOException.class, () -> { deleteAnomalyDetector(aliceDetector.getId(), catClient); });
-        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access detector: " + aliceDetector.getId()));
+        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access config: " + aliceDetector.getId()));
     }
 
     public void testCreateAnomalyDetectorWithNoBackendRole() throws IOException {
@@ -438,7 +438,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         // User Cat has AD full access, but is part of different backend role so Cat should not be able to access
         // Alice detector
         Exception exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(aliceDetector.getId(), catClient, input); });
-        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access detector: " + aliceDetector.getId()));
+        Assert.assertTrue(exception.getMessage().contains("User does not have permissions to access config: " + aliceDetector.getId()));
     }
 
     public void testPreviewAnomalyDetectorWithNoReadPermissionOfIndex() throws IOException {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -65,14 +65,18 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
      * Create an unguessable password. Simple password are weak due to https://tinyurl.com/383em9zk
      * @return a random password.
      */
-    public static String generatePassword() {
+    public static String generatePassword(String username) {
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
 
         Random rng = new Random();
 
         char[] password = new char[15];
         for (int i = 0; i < 15; i++) {
-            password[i] = characters.charAt(rng.nextInt(characters.length()));
+            char nextChar = characters.charAt(rng.nextInt(characters.length()));
+            while (username.indexOf(nextChar) > 0) {
+                nextChar = characters.charAt(rng.nextInt(characters.length()));
+            }
+            password[i] = nextChar;
         }
 
         return new String(password);
@@ -84,49 +88,49 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             throw new IllegalArgumentException("Secure Tests are running but HTTPS is not set");
         createIndexRole(indexAllAccessRole, "*");
         createSearchRole(indexSearchAccessRole, "*");
-        String alicePassword = generatePassword();
+        String alicePassword = generatePassword(aliceUser);
         createUser(aliceUser, alicePassword, new ArrayList<>(Arrays.asList("odfe")));
         aliceClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), aliceUser, alicePassword)
             .setSocketTimeout(60000)
             .build();
 
-        String bobPassword = generatePassword();
+        String bobPassword = generatePassword(bobUser);
         createUser(bobUser, bobPassword, new ArrayList<>(Arrays.asList("odfe")));
         bobClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), bobUser, bobPassword)
             .setSocketTimeout(60000)
             .build();
 
-        String catPassword = generatePassword();
+        String catPassword = generatePassword(catUser);
         createUser(catUser, catPassword, new ArrayList<>(Arrays.asList("aes")));
         catClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), catUser, catPassword)
             .setSocketTimeout(60000)
             .build();
 
-        String dogPassword = generatePassword();
+        String dogPassword = generatePassword(dogUser);
         createUser(dogUser, dogPassword, new ArrayList<>(Arrays.asList()));
         dogClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), dogUser, dogPassword)
             .setSocketTimeout(60000)
             .build();
 
-        String elkPassword = generatePassword();
+        String elkPassword = generatePassword(elkUser);
         createUser(elkUser, elkPassword, new ArrayList<>(Arrays.asList("odfe")));
         elkClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), elkUser, elkPassword)
             .setSocketTimeout(60000)
             .build();
 
-        String fishPassword = generatePassword();
+        String fishPassword = generatePassword(fishUser);
         createUser(fishUser, fishPassword, new ArrayList<>(Arrays.asList("odfe", "aes")));
         fishClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), fishUser, fishPassword)
             .setSocketTimeout(60000)
             .build();
 
-        String goatPassword = generatePassword();
+        String goatPassword = generatePassword(goatUser);
         createUser(goatUser, goatPassword, new ArrayList<>(Arrays.asList("opensearch")));
         goatClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), goatUser, goatPassword)
             .setSocketTimeout(60000)
             .build();
 
-        String lionPassword = generatePassword();
+        String lionPassword = generatePassword(lionUser);
         createUser(lionUser, lionPassword, new ArrayList<>(Arrays.asList("opensearch")));
         lionClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), lionUser, lionPassword)
             .setSocketTimeout(60000)


### PR DESCRIPTION
### Description

The security test workflow is currently skipping running tests with security quietly. See the example from the latest commit on main [here](https://github.com/opensearch-project/anomaly-detection/actions/runs/6103610427/job/16564313124) where `Run AD Test` is skipped. 

The expressions to set values in the github workflow are not getting executed as expected after the plugin was renamed to `time-series-analytics`

Specifically these lines:

```
plugin=`basename $(ls build/distributions/*.zip)`
version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
if $qualifier!=SNAPSHOT
then
  docker_version=$version-$qualifier
else
  docker_version=$version
fi
```

`echo $plugin|awk -F- '{print $4}'` is getting evaluated to `analytics` instead of `3.0.0.0` because of the extra hyphen in

```
opensearch-time-series-analytics-3.0.0.0-SNAPSHOT.zip
```

compared to

```
opensearch-anomaly-detection-3.0.0.0-SNAPSHOT.zip
```

### Issues Resolved

- https://github.com/opensearch-project/anomaly-detection/issues/1025

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
