### PR TITLE
Fix failing BWC Tests

### DIFF
--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Run AD Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests ..."
-          ./gradlew bwcTestSuite -Dtests.security.manager=false
+          ./gradlew bwcTestSuite -Dtests.security.manager=false -i

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Run AD Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests ..."
-          ./gradlew bwcTestSuite -Dtests.security.manager=false -i
+          ./gradlew bwcTestSuite -Dtests.security.manager=false

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@
  * GitHub history for details.
  */
 
+import java.nio.file.Paths
 import java.util.concurrent.Callable
 import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -36,11 +37,7 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
         bwcVersionShort = "2.10.0"
-        bwcVersion = bwcVersionShort + ".0"
-        bwcOpenSearchADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + bwcVersionShort + '/latest/linux/x64/tar/builds/' +
-                'opensearch/plugins/opensearch-anomaly-detection-' + bwcVersion + '.zip'
-        bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + bwcVersionShort + '/latest/linux/x64/tar/builds/' +
-                'opensearch/plugins/opensearch-job-scheduler-' + bwcVersion + '.zip'
+        bwcVersion = bwcVersionShort + ".0-SNAPSHOT"
         baseName = "adBwcCluster"
         bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
         bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
@@ -65,10 +62,30 @@ buildscript {
 }
 
 plugins {
+    id "de.undercouch.download" version "5.3.0"
     id 'com.netflix.nebula.ospackage' version "11.0.0"
     id "com.diffplug.spotless" version "6.18.0"
     id 'java-library'
     id 'org.gradle.test-retry' version '1.5.4'
+}
+
+ext {
+    getPluginDownloadLink = { plugin, version ->
+        var repo = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/" +
+                   "opensearch-$plugin/$version/"
+        var metadataFile = Paths.get(projectDir.toString(), "build", "maven-metadata.xml").toAbsolutePath().toFile()
+        download.run {
+            src repo + "maven-metadata.xml"
+            dest metadataFile
+        }
+        def metadata = new XmlParser().parse(metadataFile)
+        def securitySnapshotVersion = metadata.versioning.snapshotVersions[0].snapshotVersion[0].value[0].text()
+
+        return repo + "opensearch-$plugin-${securitySnapshotVersion}.zip"
+    }
+
+    bwcOpenSearchADDownload = getPluginDownloadLink('anomaly-detection', bwcVersion)
+    bwcOpenSearchJSDownload = getPluginDownloadLink('job-scheduler', bwcVersion)
 }
 
 tasks.withType(JavaCompile) {

--- a/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
@@ -167,6 +167,7 @@ public class ADBackwardsCompatibilityIT extends OpenSearchRestTestCase {
                 case MIXED:
                     // TODO: We have no way to specify whether send request to old node or new node now.
                     // Add more test later when it's possible to specify request node.
+                    System.out.println("pluginNames: " + pluginNames);
                     Assert.assertTrue(pluginNames.contains("opensearch-anomaly-detection"));
                     Assert.assertTrue(pluginNames.contains("opensearch-job-scheduler"));
 

--- a/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/ad/bwc/ADBackwardsCompatibilityIT.java
@@ -167,8 +167,7 @@ public class ADBackwardsCompatibilityIT extends OpenSearchRestTestCase {
                 case MIXED:
                     // TODO: We have no way to specify whether send request to old node or new node now.
                     // Add more test later when it's possible to specify request node.
-                    System.out.println("pluginNames: " + pluginNames);
-                    Assert.assertTrue(pluginNames.contains("opensearch-anomaly-detection"));
+                    Assert.assertTrue(pluginNames.contains("opensearch-anomaly-detection") || pluginNames.contains("opensearch-time-series-analytics"));
                     Assert.assertTrue(pluginNames.contains("opensearch-job-scheduler"));
 
                     // Create single entity detector and start realtime job


### PR DESCRIPTION
### Description

I have seen failing BWC tests on multiple PRs. Examples include https://github.com/opensearch-project/anomaly-detection/pull/1026 and https://github.com/opensearch-project/anomaly-detection/pull/1023.

This PR ensures greater BWC test reliability by fetching plugin zips from sonatype instead of ci.opensearch.org. The difference is that SNAPSHOTs are published regularly to sonatype (within minutes of a merged PR) so those zips are most likely to have the version of the code that this plugin should be integrating with.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
