### PR TITLE
Upgrade AD's bwc baseline version to 1.3.2 to resolve cluster join issue

### DIFF
--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -14,6 +14,8 @@ jobs:
         java: [ 11, 17 ]
     name: Build and Test Anomaly Detection Plugin on Windows
     runs-on: windows-latest
+    env:
+      JENKINS_URL: build.ci.opensearch.org
     steps:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
@@ -45,6 +47,8 @@ jobs:
 
     name: Build and Test Anomaly detection Plugin
     runs-on: ${{ matrix.os }}
+    env:
+      JENKINS_URL: build.ci.opensearch.org
 
     steps:
       - name: Setup Java ${{ matrix.java }}

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,6 +16,8 @@ jobs:
 
     name: Security test workflow for Anomaly Detection
     runs-on: ubuntu-latest
+    env:
+      JENKINS_URL: build.ci.opensearch.org
 
     steps:
       - name: Setup Java ${{ matrix.java }}

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@
 import java.util.concurrent.Callable
 import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.opensearch.gradle.info.BuildParams
 
 buildscript {
     ext {
@@ -38,10 +39,8 @@ buildscript {
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-' + plugin_no_snapshot + '.zip'
         anomaly_detection_build_download = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
                 '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-' + plugin_no_snapshot + '.zip'
-        bwcOpenSearchADDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
-                'opensearch-anomaly-detection-1.1.0.0.zip'
-        bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/bundle-build/1.1.0/20210930/linux/x64/builds/opensearch/plugins/' +
-                'opensearch-job-scheduler-1.1.0.0.zip'
+        bwcOpenSearchADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.2/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-1.3.2.0.zip'
+        bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.2/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-1.3.2.0.zip'
 
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
@@ -222,10 +221,9 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()
-boolean isCiServer = System.getenv().containsKey("CI")
 test {
     retry {
-        if (isCiServer) {
+        if (BuildParams.isCi()) {
             failOnPassedAfterRetry = false
             maxRetries = 6
             maxFailures = 10
@@ -250,7 +248,7 @@ tasks.named("check").configure { dependsOn(integTest) }
 
 integTest {
     retry {
-        if (isCiServer) {
+        if (BuildParams.isCi()) {
             failOnPassedAfterRetry = false
             maxRetries = 6
             maxFailures = 10
@@ -403,7 +401,7 @@ task integTestRemote(type: RestIntegTestTask) {
     }
 }
 
-String bwcMinVersion = "1.1.0.0"
+String bwcMinVersion = "1.3.2.0"
 String bwcBundleVersion = "1.3.2.0"
 Boolean bwcBundleTest = (project.findProperty('customDistributionDownloadType') != null &&
         project.properties['customDistributionDownloadType'] == "bundle");
@@ -446,7 +444,7 @@ String bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
                     node.setting("plugins.security.system_indices.enabled", "true")
                 }
             } else {
-                versions = ["1.1.0", opensearch_version]
+                versions = ["1.3.2", opensearch_version]
                 plugin(provider(new Callable<RegularFile>(){
                     @Override
                     RegularFile call() throws Exception {
@@ -570,10 +568,12 @@ task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTas
     dependsOn "${baseName}#mixedClusterTask"
     useCluster testClusters."${baseName}0"
     if (bwcBundleTest){
+        println 'Running in bwcBundleTest mode:' + BuildParams.isCi()
         doFirst {
             testClusters."${baseName}0".nextNodeToNextVersion()
         }
     } else {
+        println 'Running in CI mode:' + BuildParams.isCi()
         doFirst {
             testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
         }


### PR DESCRIPTION
### Description
Issue:
- In versions between 1.1 and 2.10, the task :adBwcCluster#twoThirdsUpgradedClusterTask fails.
- Symptoms mirror those in [OpenSearch Issue #5076](https://github.com/opensearch-project/OpenSearch/issues/5076).
- Logs show nodes from old and new versions failing to join as a cluster, resulting in a "master not found" exception.
- Similar things happened between 1.1 and 2.9/2.8 when task :adBwcCluster#mixedClusterTask executes.

Resolution:
- Upgraded the bwc version to 1.3.2, aligning with other plugins which use 1.3+ as their baseline.
  - [Cross-Cluster Replication PR #469](https://github.com/opensearch-project/cross-cluster-replication/pull/469)
  - [Security PR #2253](https://github.com/opensearch-project/security/pull/2253)
  - [ML Commons PR #681](https://github.com/opensearch-project/ml-commons/pull/681)
- Post-upgrade, the twoThirdsUpgradedClusterTask runs successfully, suggesting potential incompatibility between versions 1.1 and 2.x or test infra issue.

This PR also backports retry logic in https://github.com/opensearch-project/anomaly-detection/pull/1017 to 2.x. 

Testing:
- Executed `./gradlew bwcTestSuite -Dtests.security.manager=false` and all tests passed.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/964

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
