### PR TITLE
React to Tracer changes in TransportService from core#9415

### DIFF
--- a/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
@@ -52,6 +52,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.constant.CommonName;
@@ -99,7 +100,8 @@ public class DeleteAnomalyDetectorTests extends AbstractTimeSeriesTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         client = mock(Client.class);

--- a/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
@@ -48,6 +48,7 @@ import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.common.exception.TimeSeriesException;
@@ -125,7 +126,8 @@ public class EntityProfileTests extends AbstractTimeSeriesTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
         settings = Settings.EMPTY;
 

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
@@ -49,6 +49,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.constant.CommonMessages;
@@ -103,7 +104,8 @@ public class GetAnomalyDetectorTests extends AbstractTimeSeriesTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         nodeFilter = mock(DiscoveryNodeFilterer.class);

--- a/src/test/java/org/opensearch/ad/transport/RCFPollingTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFPollingTests.java
@@ -41,6 +41,7 @@ import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.common.exception.TimeSeriesException;
@@ -112,7 +113,8 @@ public class RCFPollingTests extends AbstractTimeSeriesTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
         future = new PlainActionFuture<>();
 

--- a/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
@@ -54,6 +54,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.common.exception.LimitExceededException;
@@ -106,7 +107,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -164,7 +166,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -280,7 +283,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -331,7 +335,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -58,6 +58,7 @@ import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.transport.Transport;
@@ -101,7 +102,8 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         client = mock(Client.class);

--- a/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
@@ -38,6 +38,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -55,7 +56,8 @@ public class ThresholdResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -84,7 +86,8 @@ public class ThresholdResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);

--- a/src/test/java/test/org/opensearch/ad/util/FakeNode.java
+++ b/src/test/java/test/org/opensearch/ad/util/FakeNode.java
@@ -48,6 +48,7 @@ import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.tasks.MockTaskManager;
 import org.opensearch.threadpool.ThreadPool;
@@ -90,7 +91,8 @@ public class FakeNode implements Releasable {
             transportInterceptor,
             boundTransportAddressDiscoveryNodeFunction,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         ) {
             @Override
             protected TaskManager createTaskManager(


### PR DESCRIPTION
### Description

React to changes from https://github.com/opensearch-project/OpenSearch/pull/9415. TransportService constructor changed to take in a `Tracer`. Since all instances of this are in tests, I added the `NoopTracer.INSTANCE` to all instances where a `TransportService` is instantiated.

Creating this PR because I saw the error in a Draft PR I have open: https://github.com/opensearch-project/anomaly-detection/pull/1027

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
