### PR TITLE
Updates jupiter from 5.9.2 to 5.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,8 +157,8 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.0'
     // jupiter is required to run unit tests not inherited from OpenSearchTestCase (e.g., PreviousValueImputerTests)
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    testImplementation  'org.junit.jupiter:junit-jupiter-params:5.9.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    testImplementation  'org.junit.jupiter:junit-jupiter-params:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
     testImplementation "org.opensearch:opensearch-core:${opensearch_version}"
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.2")
     testCompileOnly 'junit:junit:4.13.2'


### PR DESCRIPTION
### Description
Integ test failed on 3.0 because of the following error:

```
* What went wrong:
Execution failed for task ':integTest'.
> Could not resolve all dependencies for configuration ':testRuntimeClasspath'.
   > Conflict found for the following module:
       - org.junit.jupiter:junit-jupiter-api between versions 5.10.0 and 5.9.2
```

### Issues Resolved
Fixes https://github.com/opensearch-project/anomaly-detection/issues/990

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
