### PR TITLE
[2.x] Fix TransportService constructor due to changes in core plus guava bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -741,7 +741,7 @@ dependencies {
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${job_scheduler_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    compileOnly group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
+    compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.2-jre'
     compileOnly group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     implementation group: 'org.javassist', name: 'javassist', version:'3.28.0-GA'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'

--- a/release-notes/opensearch-anomaly-detection.release-notes-2.11.0.0.md
+++ b/release-notes/opensearch-anomaly-detection.release-notes-2.11.0.0.md
@@ -1,0 +1,10 @@
+Compatible with OpenSearch 2.11.0.
+
+### Refactor
+
+* [2.x] Fix TransportService constructor due to changes in core plus guava bump ([#1069](https://github.com/opensearch-project/anomaly-detection/pull/1069))
+
+### Infrastructure
+
+* Add dependabot.yml ([#1026](https://github.com/opensearch-project/anomaly-detection/pull/1026))
+

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -128,7 +128,9 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
@@ -233,7 +235,16 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         detectionIndices = mock(AnomalyDetectionIndices.class);
         adTaskCacheManager = mock(ADTaskCacheManager.class);
         hashRing = mock(HashRing.class);
-        transportService = mock(TransportService.class);
+        transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            null,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
+        );
         threadPool = mock(ThreadPool.class);
         threadContext = new ThreadContext(settings);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/DeleteAnomalyDetectorTests.java
@@ -58,6 +58,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
 
@@ -99,7 +100,8 @@ public class DeleteAnomalyDetectorTests extends AbstractADTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         client = mock(Client.class);

--- a/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityProfileTests.java
@@ -52,6 +52,7 @@ import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.transport.ConnectTransportException;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
@@ -124,7 +125,9 @@ public class EntityProfileTests extends AbstractADTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
+
         );
         settings = Settings.EMPTY;
 

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorTests.java
@@ -59,6 +59,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
 
@@ -106,7 +107,8 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         nodeFilter = mock(DiscoveryNodeFilterer.class);

--- a/src/test/java/org/opensearch/ad/transport/RCFPollingTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFPollingTests.java
@@ -45,6 +45,7 @@ import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.transport.ConnectTransportException;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
@@ -112,7 +113,8 @@ public class RCFPollingTests extends AbstractADTest {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
         future = new PlainActionFuture<>();
 

--- a/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/RCFResultTests.java
@@ -57,6 +57,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -106,7 +107,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -164,7 +166,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -280,7 +283,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -331,7 +335,8 @@ public class RCFResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);

--- a/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -59,6 +59,7 @@ import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -101,7 +102,8 @@ public class SearchAnomalyResultActionTests extends HistoricalAnalysisIntegTestC
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         client = mock(Client.class);

--- a/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ThresholdResultTests.java
@@ -38,6 +38,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -55,7 +56,8 @@ public class ThresholdResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);
@@ -84,7 +86,8 @@ public class ThresholdResultTests extends OpenSearchTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> null,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         );
 
         ModelManager manager = mock(ModelManager.class);

--- a/src/test/java/test/org/opensearch/ad/util/FakeNode.java
+++ b/src/test/java/test/org/opensearch/ad/util/FakeNode.java
@@ -81,7 +81,8 @@ public class FakeNode implements Releasable {
                 new NetworkService(Collections.emptyList()),
                 PageCacheRecycler.NON_RECYCLING_INSTANCE,
                 new NamedWriteableRegistry(ClusterModule.getNamedWriteables()),
-                new NoneCircuitBreakerService()
+                new NoneCircuitBreakerService(),
+                NoopTracer.INSTANCE
             ) {
                 @Override
                 public TransportAddress[] addressesFromString(String address) {

--- a/src/test/java/test/org/opensearch/ad/util/FakeNode.java
+++ b/src/test/java/test/org/opensearch/ad/util/FakeNode.java
@@ -49,6 +49,7 @@ import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.tasks.MockTaskManager;
 import org.opensearch.threadpool.ThreadPool;
@@ -91,7 +92,8 @@ public class FakeNode implements Releasable {
             transportInterceptor,
             boundTransportAddressDiscoveryNodeFunction,
             null,
-            Collections.emptySet()
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
         ) {
             @Override
             protected TaskManager createTaskManager(


### PR DESCRIPTION
### Description
Add a tracer field for the TransportService constructor in our test cases

Core change to add tracer in MockNioTransport https://github.com/opensearch-project/OpenSearch/pull/10143/files#diff-f37f7447c76ba79901c3298a1addce39d103ce72efc5a75a1f7602a4e2829b62R115

core changes to add tracker in TransportService https://github.com/opensearch-project/OpenSearch/commit/27cddec134844a8061b9a7f9cc5eee2e4622feec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
