### PR TITLE
Change build workflow to run on production docker image

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
+        distribution: temurin
         with:
           java-version: ${{ matrix.java }}
 

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - name: Checkout Anomaly Detection
         uses: actions/checkout@v4
@@ -77,6 +78,7 @@ jobs:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
 
       - name: Checkout AD

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -40,16 +40,20 @@ jobs:
 
       - name: Assemble anomaly-detection
         run: |
-          ./gradlew assemble
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew assemble
       - name: Build and Run Tests
         run: |
-          ./gradlew build
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew build
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
-          ./gradlew integTest -PnumNodes=3
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -PnumNodes=3
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v3
         with:
@@ -75,16 +79,13 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew build
+          ./gradlew build
       - name: Publish to Maven Local
         run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew publishToMavenLocal
+          ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -PnumNodes=3
+          ./gradlew integTest -PnumNodes=3
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -9,34 +9,59 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch
+
+  Build-ad-linux:
+    needs: Get-CI-Image-Tag
+    strategy:
+      matrix:
+        java: [11, 17, 20]
+      fail-fast: false
+    name: Build and Test Anomaly detection Plugin
     runs-on: ubuntu-latest
-    outputs:
-      ci-image-version-linux: ${{ steps.step-ci-image-version-linux.outputs.ci-image-version-linux }}
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: --user root
+
     steps:
-      - name: Install crane
-        uses: iarekylew00t/crane-installer@v1
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v3
         with:
-          crane-release: v0.15.2
-      - name: Checkout opensearch-build repository
-        uses: actions/checkout@v2
-        with:
-          repository: "opensearch-project/opensearch-build"
-          ref: "main"
-          path: "opensearch-build"
-      - name: Get ci image version from opensearch-build repository scripts
-        id: step-ci-image-version-linux
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - name: Checkout AD
+        uses: actions/checkout@v4
+
+      - name: Assemble anomaly-detection
         run: |
-          crane version
-          CI_IMAGE_VERSION=`opensearch-build/docker/ci/get-ci-images.sh -p centos7 -u opensearch -t build | head -1`
-          echo $CI_IMAGE_VERSION
-          echo "ci-image-version-linux=$CI_IMAGE_VERSION" >> $GITHUB_OUTPUT
+          ./gradlew assemble
+      - name: Build and Run Tests
+        run: |
+          ./gradlew build
+      - name: Publish to Maven Local
+        run: |
+          ./gradlew publishToMavenLocal
+      - name: Multi Nodes Integration Testing
+        run: |
+          ./gradlew integTest -PnumNodes=3
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./build/reports/jacoco/test/jacocoTestReport.xml
+          flags: plugin
+
   Build-ad-windows:
     strategy:
       matrix:
         java: [11, 17, 20]
     name: Build and Test Anomaly Detection Plugin on Windows
     runs-on: windows-latest
-    needs: Get-CI-Image-Tag
     env:
       JENKINS_URL: build.ci.opensearch.org
     steps:
@@ -62,15 +87,14 @@ jobs:
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           flags: plugin
-  Build-ad:
+
+  Build-ad-macos:
     strategy:
       matrix:
         java: [11, 17, 20]
-        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     name: Build and Test Anomaly detection Plugin
-    runs-on: ${{ matrix.os }}
-    needs: Get-CI-Image-Tag
+    runs-on: macos-latest
     env:
       JENKINS_URL: build.ci.opensearch.org
 

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -75,13 +75,16 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew build
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
-          ./gradlew integTest -PnumNodes=3
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -PnumNodes=3
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -8,12 +8,35 @@ on:
       - "*"
 
 jobs:
+  Get-CI-Image-Tag:
+    runs-on: ubuntu-latest
+    outputs:
+      ci-image-version-linux: ${{ steps.step-ci-image-version-linux.outputs.ci-image-version-linux }}
+    steps:
+      - name: Install crane
+        uses: iarekylew00t/crane-installer@v1
+        with:
+          crane-release: v0.15.2
+      - name: Checkout opensearch-build repository
+        uses: actions/checkout@v2
+        with:
+          repository: "opensearch-project/opensearch-build"
+          ref: "main"
+          path: "opensearch-build"
+      - name: Get ci image version from opensearch-build repository scripts
+        id: step-ci-image-version-linux
+        run: |
+          crane version
+          CI_IMAGE_VERSION=`opensearch-build/docker/ci/get-ci-images.sh -p centos7 -u opensearch -t build | head -1`
+          echo $CI_IMAGE_VERSION
+          echo "ci-image-version-linux=$CI_IMAGE_VERSION" >> $GITHUB_OUTPUT
   Build-ad-windows:
     strategy:
       matrix:
-        java: [ 11, 17, 20 ]
+        java: [11, 17, 20]
     name: Build and Test Anomaly Detection Plugin on Windows
     runs-on: windows-latest
+    needs: Get-CI-Image-Tag
     env:
       JENKINS_URL: build.ci.opensearch.org
     steps:
@@ -41,12 +64,12 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11,17,20]
+        java: [11, 17, 20]
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
-
     name: Build and Test Anomaly detection Plugin
     runs-on: ${{ matrix.os }}
+    needs: Get-CI-Image-Tag
     env:
       JENKINS_URL: build.ci.opensearch.org
 

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11,17,20]
+        java: [11, 17, 20]
       fail-fast: false
 
     name: Test Anomaly detection BWC
@@ -21,6 +21,7 @@ jobs:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
 
       # anomaly-detection

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11,17,20]
+        java: [11, 17, 20]
       fail-fast: false
 
     name: Security test workflow for Anomaly Detection
@@ -21,6 +21,7 @@ jobs:
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
 
       # time-series-analytics


### PR DESCRIPTION
### Description
Change build workflow to run on production docker image. Also fixes the workflows to run after they were broken by #1035 merge.

### Issues Resolved
Resolves #1073 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
