### PR TITLE
Update CI to use jdk-21

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [17]
+        java: [11, 17, 21]
       fail-fast: false
 
     name: Run Anomaly detection model performance benchmark

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -16,7 +16,7 @@ jobs:
   Build-ad-windows:
     strategy:
       matrix:
-        java: [ 11, 17, 20 ]
+        java: [ 11, 17, 21 ]
     name: Build and Test Anomaly Detection Plugin on Windows
     runs-on: windows-latest
     env:
@@ -49,7 +49,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [11, 17, 20]
+        java: [ 11, 17, 21 ]
       fail-fast: false
     name: Build and Test Anomaly detection Plugin
     runs-on: ubuntu-latest
@@ -89,7 +89,7 @@ jobs:
   Build-ad-macos:
     strategy:
       matrix:
-        java: [11,17,20]
+        java: [ 11, 17, 21 ]
       fail-fast: false
 
     name: Build and Test Anomaly detection Plugin

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -17,7 +17,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [11,17,20]
+        java: [11,17,21]
       fail-fast: false
 
     name: Test Anomaly detection BWC

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11,17,20]
+        java: [11,17,21]
       fail-fast: false
 
     name: Security test workflow for Anomaly Detection


### PR DESCRIPTION
### Description
This updates the CI system to use jdk-21, which is latest LTS supported version.

### Issues Resolved
Related: https://github.com/opensearch-project/OpenSearch/issues/10334

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
