### PR TITLE
Add profile transport action to AD client

### DIFF
--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -8,8 +8,8 @@ package org.opensearch.ad.client;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.ad.transport.ProfileRequest;
-import org.opensearch.ad.transport.ProfileResponse;
+import org.opensearch.ad.transport.ADTaskProfileRequest;
+import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 
@@ -56,10 +56,10 @@ public interface AnomalyDetectionClient {
     /**
      * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
      * @param profileRequest profile request to fetch detector profile
-     * @return ActionFuture of ProfileResponse
+     * @return ActionFuture of ADTaskProfileResponse
      */
-    default ActionFuture<ProfileResponse> getDetectorProfile(ProfileRequest profileRequest) {
-        PlainActionFuture<ProfileResponse> actionFuture = PlainActionFuture.newFuture();
+    default ActionFuture<ADTaskProfileResponse> getDetectorProfile(ADTaskProfileRequest profileRequest) {
+        PlainActionFuture<ADTaskProfileResponse> actionFuture = PlainActionFuture.newFuture();
         getDetectorProfile(profileRequest, actionFuture);
         return actionFuture;
     }
@@ -69,6 +69,6 @@ public interface AnomalyDetectionClient {
      * @param profileRequest profile request to fetch detector profile
      * @param listener a listener to be notified of the result
      */
-    void getDetectorProfile(ProfileRequest profileRequest, ActionListener<ProfileResponse> listener);
+    void getDetectorProfile(ADTaskProfileRequest profileRequest, ActionListener<ADTaskProfileResponse> listener);
 
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -8,6 +8,8 @@ package org.opensearch.ad.client;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.ad.transport.ProfileRequest;
+import org.opensearch.ad.transport.ProfileResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 
@@ -40,7 +42,7 @@ public interface AnomalyDetectionClient {
      */
     default ActionFuture<SearchResponse> searchAnomalyResults(SearchRequest searchRequest) {
         PlainActionFuture<SearchResponse> actionFuture = PlainActionFuture.newFuture();
-        searchAnomalyDetectors(searchRequest, actionFuture);
+        searchAnomalyResults(searchRequest, actionFuture);
         return actionFuture;
     }
 
@@ -50,5 +52,23 @@ public interface AnomalyDetectionClient {
      * @param listener a listener to be notified of the result
      */
     void searchAnomalyResults(SearchRequest searchRequest, ActionListener<SearchResponse> listener);
+
+    /**
+     * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
+     * @param profileRequest profile request to fetch detector profile
+     * @return ActionFuture of ProfileResponse
+     */
+    default ActionFuture<ProfileResponse> getDetectorProfile(ProfileRequest profileRequest) {
+        PlainActionFuture<ProfileResponse> actionFuture = PlainActionFuture.newFuture();
+        getDetectorProfile(profileRequest, actionFuture);
+        return actionFuture;
+    }
+
+    /**
+     * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
+     * @param profileRequest profile request to fetch detector profile
+     * @param listener a listener to be notified of the result
+     */
+    void getDetectorProfile(ProfileRequest profileRequest, ActionListener<ProfileResponse> listener);
 
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -8,7 +8,6 @@ package org.opensearch.ad.client;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.ad.transport.ADTaskProfileRequest;
 import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
@@ -55,20 +54,20 @@ public interface AnomalyDetectionClient {
 
     /**
      * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
-     * @param profileRequest profile request to fetch detector profile
+     * @param detectorId the detector ID to fetch the profile for
      * @return ActionFuture of ADTaskProfileResponse
      */
-    default ActionFuture<ADTaskProfileResponse> getDetectorProfile(ADTaskProfileRequest profileRequest) {
+    default ActionFuture<ADTaskProfileResponse> getDetectorProfile(String detectorId) {
         PlainActionFuture<ADTaskProfileResponse> actionFuture = PlainActionFuture.newFuture();
-        getDetectorProfile(profileRequest, actionFuture);
+        getDetectorProfile(detectorId, actionFuture);
         return actionFuture;
     }
 
     /**
      * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
-     * @param profileRequest profile request to fetch detector profile
+     * @param detectorId the detector ID to fetch the profile for
      * @param listener a listener to be notified of the result
      */
-    void getDetectorProfile(ADTaskProfileRequest profileRequest, ActionListener<ADTaskProfileResponse> listener);
+    void getDetectorProfile(String detectorId, ActionListener<ADTaskProfileResponse> listener);
 
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -6,11 +6,9 @@
 package org.opensearch.ad.client;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.transport.ADTaskProfileAction;
 import org.opensearch.ad.transport.ADTaskProfileRequest;
 import org.opensearch.ad.transport.ADTaskProfileResponse;

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -7,9 +7,9 @@ package org.opensearch.ad.client;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.transport.ProfileAction;
-import org.opensearch.ad.transport.ProfileRequest;
-import org.opensearch.ad.transport.ProfileResponse;
+import org.opensearch.ad.transport.ADTaskProfileAction;
+import org.opensearch.ad.transport.ADTaskProfileRequest;
+import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
 import org.opensearch.ad.transport.SearchAnomalyResultAction;
 import org.opensearch.client.Client;
@@ -37,12 +37,9 @@ public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
     }
 
     @Override
-    public void getDetectorProfile(ProfileRequest profileRequest, ActionListener<ProfileResponse> listener) {
-        this.client
-            .execute(
-                ProfileAction.INSTANCE,
-                profileRequest,
-                ActionListener.wrap(profileResponse -> { listener.onResponse(profileResponse); }, listener::onFailure)
-            );
+    public void getDetectorProfile(ADTaskProfileRequest profileRequest, ActionListener<ADTaskProfileResponse> listener) {
+        this.client.execute(ADTaskProfileAction.INSTANCE, profileRequest, ActionListener.wrap(profileResponse -> {
+            listener.onResponse(profileResponse);
+        }, listener::onFailure));
     }
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -5,21 +5,35 @@
 
 package org.opensearch.ad.client;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.transport.ADTaskProfileAction;
 import org.opensearch.ad.transport.ADTaskProfileRequest;
 import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
 import org.opensearch.ad.transport.SearchAnomalyResultAction;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
 
 public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
     private final Client client;
+    private final ClusterService clusterService;
+    private final HotDataNodePredicate eligibleNodeFilter;
 
-    public AnomalyDetectionNodeClient(Client client) {
+    public AnomalyDetectionNodeClient(Client client, ClusterService clusterService) {
         this.client = client;
+        this.clusterService = clusterService;
+        this.eligibleNodeFilter = new HotDataNodePredicate();
     }
 
     @Override
@@ -37,9 +51,56 @@ public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
     }
 
     @Override
-    public void getDetectorProfile(ADTaskProfileRequest profileRequest, ActionListener<ADTaskProfileResponse> listener) {
-        this.client.execute(ADTaskProfileAction.INSTANCE, profileRequest, ActionListener.wrap(profileResponse -> {
-            listener.onResponse(profileResponse);
-        }, listener::onFailure));
+    public void getDetectorProfile(String detectorId, ActionListener<ADTaskProfileResponse> listener) {
+
+        // TODO: clean up
+        // Logic to determine eligible nodes comes from org.opensearch.timeseries.util.DiscoveryNodeFilterer
+        // There is no clean way to consume that within this client's constructor since it will be instantiated
+        // outside of this plugin typically. So we re-use that logic here
+        ClusterState state = this.clusterService.state();
+        final List<DiscoveryNode> eligibleNodes = new ArrayList<>();
+        for (DiscoveryNode node : state.nodes()) {
+            if (this.eligibleNodeFilter.test(node)) {
+                eligibleNodes.add(node);
+            }
+        }
+        final DiscoveryNode[] eligibleNodesAsArray = eligibleNodes.toArray(new DiscoveryNode[0]);
+
+        ADTaskProfileRequest profileRequest = new ADTaskProfileRequest(detectorId, eligibleNodesAsArray);
+        this.client.execute(ADTaskProfileAction.INSTANCE, profileRequest, getADTaskProfileResponseActionListener(listener));
+    }
+
+    // We need to wrap AD-specific response type listeners around an internal listener, and re-generate the response from a generic
+    // ActionResponse. This is needed to prevent classloader issues and ClassCastExceptions when executed by other plugins.
+    private ActionListener<ADTaskProfileResponse> getADTaskProfileResponseActionListener(ActionListener<ADTaskProfileResponse> listener) {
+        ActionListener<ADTaskProfileResponse> internalListener = ActionListener
+            .wrap(profileResponse -> { listener.onResponse(profileResponse); }, listener::onFailure);
+        ActionListener<ADTaskProfileResponse> actionListener = wrapActionListener(internalListener, actionResponse -> {
+            ADTaskProfileResponse response = ADTaskProfileResponse.fromActionResponse(actionResponse);
+            return response;
+        });
+        return actionListener;
+    }
+
+    private <T extends ActionResponse> ActionListener<T> wrapActionListener(
+        final ActionListener<T> listener,
+        final Function<ActionResponse, T> recreate
+    ) {
+        ActionListener<T> actionListener = ActionListener.wrap(r -> {
+            listener.onResponse(recreate.apply(r));
+            ;
+        }, e -> { listener.onFailure(e); });
+        return actionListener;
+    }
+
+    static class HotDataNodePredicate implements Predicate<DiscoveryNode> {
+        @Override
+        public boolean test(DiscoveryNode discoveryNode) {
+            return discoveryNode.isDataNode()
+                && discoveryNode
+                    .getAttributes()
+                    .getOrDefault(ADCommonName.BOX_TYPE_KEY, ADCommonName.HOT_BOX_TYPE)
+                    .equals(ADCommonName.HOT_BOX_TYPE);
+        }
     }
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -7,6 +7,9 @@ package org.opensearch.ad.client;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.transport.ProfileAction;
+import org.opensearch.ad.transport.ProfileRequest;
+import org.opensearch.ad.transport.ProfileResponse;
 import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
 import org.opensearch.ad.transport.SearchAnomalyResultAction;
 import org.opensearch.client.Client;
@@ -31,5 +34,15 @@ public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
         this.client.execute(SearchAnomalyResultAction.INSTANCE, searchRequest, ActionListener.wrap(searchResponse -> {
             listener.onResponse(searchResponse);
         }, listener::onFailure));
+    }
+
+    @Override
+    public void getDetectorProfile(ProfileRequest profileRequest, ActionListener<ProfileResponse> listener) {
+        this.client
+            .execute(
+                ProfileAction.INSTANCE,
+                profileRequest,
+                ActionListener.wrap(profileResponse -> { listener.onResponse(profileResponse); }, listener::onFailure)
+            );
     }
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -75,15 +75,4 @@ public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
         }, e -> { listener.onFailure(e); });
         return actionListener;
     }
-
-    static class HotDataNodePredicate implements Predicate<DiscoveryNode> {
-        @Override
-        public boolean test(DiscoveryNode discoveryNode) {
-            return discoveryNode.isDataNode()
-                && discoveryNode
-                    .getAttributes()
-                    .getOrDefault(ADCommonName.BOX_TYPE_KEY, ADCommonName.HOT_BOX_TYPE)
-                    .equals(ADCommonName.HOT_BOX_TYPE);
-        }
-    }
 }

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileResponse.java
@@ -57,7 +57,7 @@ public class ADTaskProfileResponse extends BaseNodesResponse<ADTaskProfileNodeRe
                 return new ADTaskProfileResponse(input);
             }
         } catch (IOException e) {
-            throw new UncheckedIOException("failed to parse ActionResponse into MLModelGetResponse", e);
+            throw new UncheckedIOException("failed to parse ActionResponse into ADTaskProfileResponse", e);
         }
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/ADTaskProfileResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/ADTaskProfileResponse.java
@@ -11,12 +11,18 @@
 
 package org.opensearch.ad.transport;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
@@ -40,4 +46,18 @@ public class ADTaskProfileResponse extends BaseNodesResponse<ADTaskProfileNodeRe
         return in.readList(ADTaskProfileNodeResponse::readNodeResponse);
     }
 
+    public static ADTaskProfileResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof ADTaskProfileResponse) {
+            return (ADTaskProfileResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new ADTaskProfileResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into MLModelGetResponse", e);
+        }
+    }
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
@@ -7,12 +7,16 @@ package org.opensearch.ad.client;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.transport.ProfileRequest;
+import org.opensearch.ad.transport.ProfileResponse;
 import org.opensearch.core.action.ActionListener;
 
 public class AnomalyDetectionClientTests {
@@ -20,7 +24,13 @@ public class AnomalyDetectionClientTests {
     AnomalyDetectionClient anomalyDetectionClient;
 
     @Mock
-    SearchResponse searchResponse;
+    SearchResponse searchDetectorsResponse;
+
+    @Mock
+    SearchResponse searchResultsResponse;
+
+    @Mock
+    ProfileResponse profileResponse;
 
     @Before
     public void setUp() {
@@ -30,24 +40,37 @@ public class AnomalyDetectionClientTests {
         anomalyDetectionClient = new AnomalyDetectionClient() {
             @Override
             public void searchAnomalyDetectors(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-                listener.onResponse(searchResponse);
+                listener.onResponse(searchDetectorsResponse);
             }
 
             @Override
             public void searchAnomalyResults(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-                listener.onResponse(searchResponse);
+                listener.onResponse(searchResultsResponse);
+            }
+
+            @Override
+            public void getDetectorProfile(ProfileRequest profileRequest, ActionListener<ProfileResponse> listener) {
+                listener.onResponse(profileResponse);
             }
         };
     }
 
     @Test
     public void searchAnomalyDetectors() {
-        assertEquals(searchResponse, anomalyDetectionClient.searchAnomalyDetectors(new SearchRequest()).actionGet());
+        assertEquals(searchDetectorsResponse, anomalyDetectionClient.searchAnomalyDetectors(new SearchRequest()).actionGet());
     }
 
     @Test
     public void searchAnomalyResults() {
-        assertEquals(searchResponse, anomalyDetectionClient.searchAnomalyResults(new SearchRequest()).actionGet());
+        assertEquals(searchResultsResponse, anomalyDetectionClient.searchAnomalyResults(new SearchRequest()).actionGet());
+    }
+
+    @Test
+    public void getDetectorProfile() {
+        assertEquals(
+            profileResponse,
+            anomalyDetectionClient.getDetectorProfile(new ProfileRequest("test-id", Collections.emptySet(), false)).actionGet()
+        );
     }
 
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
@@ -13,7 +13,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.transport.ADTaskProfileRequest;
 import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.core.action.ActionListener;
 
@@ -47,7 +46,7 @@ public class AnomalyDetectionClientTests {
             }
 
             @Override
-            public void getDetectorProfile(ADTaskProfileRequest profileRequest, ActionListener<ADTaskProfileResponse> listener) {
+            public void getDetectorProfile(String detectorId, ActionListener<ADTaskProfileResponse> listener) {
                 listener.onResponse(profileResponse);
             }
         };
@@ -65,7 +64,7 @@ public class AnomalyDetectionClientTests {
 
     @Test
     public void getDetectorProfile() {
-        assertEquals(profileResponse, anomalyDetectionClient.getDetectorProfile(new ADTaskProfileRequest("foo", null)).actionGet());
+        assertEquals(profileResponse, anomalyDetectionClient.getDetectorProfile("foo").actionGet());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
@@ -7,16 +7,14 @@ package org.opensearch.ad.client;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.transport.ProfileRequest;
-import org.opensearch.ad.transport.ProfileResponse;
+import org.opensearch.ad.transport.ADTaskProfileRequest;
+import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.core.action.ActionListener;
 
 public class AnomalyDetectionClientTests {
@@ -30,7 +28,7 @@ public class AnomalyDetectionClientTests {
     SearchResponse searchResultsResponse;
 
     @Mock
-    ProfileResponse profileResponse;
+    ADTaskProfileResponse profileResponse;
 
     @Before
     public void setUp() {
@@ -49,7 +47,7 @@ public class AnomalyDetectionClientTests {
             }
 
             @Override
-            public void getDetectorProfile(ProfileRequest profileRequest, ActionListener<ProfileResponse> listener) {
+            public void getDetectorProfile(ADTaskProfileRequest profileRequest, ActionListener<ADTaskProfileResponse> listener) {
                 listener.onResponse(profileResponse);
             }
         };
@@ -67,10 +65,7 @@ public class AnomalyDetectionClientTests {
 
     @Test
     public void getDetectorProfile() {
-        assertEquals(
-            profileResponse,
-            anomalyDetectionClient.getDetectorProfile(new ProfileRequest("test-id", Collections.emptySet(), false)).actionGet()
-        );
+        assertEquals(profileResponse, anomalyDetectionClient.getDetectorProfile(new ADTaskProfileRequest("foo", null)).actionGet());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -39,6 +39,7 @@ import org.opensearch.ad.transport.ADTaskProfileNodeResponse;
 import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -161,13 +162,14 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
 
     @Test
     public void testGetDetectorProfile_Populated() {
+        DiscoveryNode localNode = clusterService().localNode();
         ADTaskProfile adTaskProfile = new ADTaskProfile("foo-task-id", 0, 0L, false, 0, 0L, localNode.getId());
 
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
 
             ActionListener<ADTaskProfileResponse> listener = (ActionListener<ADTaskProfileResponse>) args[2];
-            ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(clusterService().localNode(), adTaskProfile, null);
+            ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(localNode, adTaskProfile, null);
 
             List<ADTaskProfileNodeResponse> nodeResponses = Arrays.asList(nodeResponse);
             listener.onResponse(new ADTaskProfileResponse(new ClusterName("test-cluster"), nodeResponses, Collections.emptyList()));

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -39,7 +39,6 @@ import org.opensearch.ad.transport.ADTaskProfileNodeResponse;
 import org.opensearch.ad.transport.ADTaskProfileResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
-import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -162,15 +161,13 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
 
     @Test
     public void testGetDetectorProfile_Populated() {
-
-        DiscoveryNode localNode = clusterService().localNode();
         ADTaskProfile adTaskProfile = new ADTaskProfile("foo-task-id", 0, 0L, false, 0, 0L, localNode.getId());
 
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
 
             ActionListener<ADTaskProfileResponse> listener = (ActionListener<ADTaskProfileResponse>) args[2];
-            ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(localNode, adTaskProfile, null);
+            ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(clusterService().localNode(), adTaskProfile, null);
 
             List<ADTaskProfileNodeResponse> nodeResponses = Arrays.asList(nodeResponse);
             listener.onResponse(new ADTaskProfileResponse(new ClusterName("test-cluster"), nodeResponses, Collections.emptyList()));
@@ -181,9 +178,9 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
         ADTaskProfileResponse response = adClient.getDetectorProfile("foo").actionGet(10000);
         String responseTaskId = response.getNodes().get(0).getAdTaskProfile().getTaskId();
 
-        verify(clientSpy, times(1)).execute(any(ADTaskProfileAction.class), any(), any());
         assertNotEquals(0, response.getNodes().size());
         assertEquals(responseTaskId, adTaskProfile.getTaskId());
+        verify(clientSpy, times(1)).execute(any(ADTaskProfileAction.class), any(), any());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -157,16 +157,14 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
         ADTaskProfileResponse response = adClient.getDetectorProfile(profileRequest).actionGet(10000);
         List<ADTaskProfileNodeResponse> responses = response.getNodes();
 
-        // We should get node responses back from the local node, but there should be no profiles found
+        verify(clientSpy, times(1)).execute(any(ADTaskProfileAction.class), any(), any());
+        // We should get node response back from the local node, but there should be no profiles found
         assertEquals(1, responses.size());
         assertEquals(null, responses.get(0).getAdTaskProfile());
-
-        verify(clientSpy, times(1)).execute(any(ADTaskProfileAction.class), any(), any());
-
     }
 
     @Test
-    public void testGetDetectorProfile_Populated() throws IOException {
+    public void testGetDetectorProfile_Populated() {
 
         DiscoveryNode localNode = clusterService().localNode();
         ADTaskProfile adTaskProfile = new ADTaskProfile("foo-task-id", 0, 0L, false, 0, 0L, localNode.getId());

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -6,7 +6,10 @@
 package org.opensearch.ad.client;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.opensearch.ad.indices.ADIndexManagement.ALL_AD_RESULTS_INDEX_PATTERN;
 import static org.opensearch.ad.model.AnomalyDetector.DETECTOR_TYPE_FIELD;
@@ -14,9 +17,13 @@ import static org.opensearch.ad.model.AnomalyDetector.DETECTOR_TYPE_FIELD;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.action.search.SearchRequest;
@@ -24,11 +31,17 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ad.HistoricalAnalysisIntegTestCase;
 import org.opensearch.ad.constant.ADCommonName;
+import org.opensearch.ad.model.ADTaskProfile;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorType;
-import org.opensearch.ad.model.DetectorProfileName;
-import org.opensearch.ad.transport.ProfileRequest;
-import org.opensearch.ad.transport.ProfileResponse;
+import org.opensearch.ad.transport.ADTaskProfileAction;
+import org.opensearch.ad.transport.ADTaskProfileNodeResponse;
+import org.opensearch.ad.transport.ADTaskProfileRequest;
+import org.opensearch.ad.transport.ADTaskProfileResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -42,16 +55,19 @@ import com.google.common.collect.ImmutableList;
 // The exhaustive set of transport action scenarios are within the respective transport action
 // test suites themselves. We do not want to unnecessarily duplicate all of those tests here.
 public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTestCase {
+    private final Logger logger = LogManager.getLogger(this.getClass());
 
     private String indexName = "test-data";
     private Instant startTime = Instant.now().minus(2, ChronoUnit.DAYS);
+    private Client clientSpy;
     private AnomalyDetectionNodeClient adClient;
     private PlainActionFuture<SearchResponse> searchResponseFuture;
-    private PlainActionFuture<ProfileResponse> profileFuture;
+    private PlainActionFuture<ADTaskProfileResponse> profileFuture;
 
     @Before
     public void setup() {
-        adClient = new AnomalyDetectionNodeClient(client());
+        clientSpy = spy(client());
+        adClient = new AnomalyDetectionNodeClient(clientSpy);
     }
 
     @Test
@@ -73,7 +89,7 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
 
     @Test
     public void searchAnomalyDetectors_Populated() throws IOException {
-        ingestTestData(indexName, startTime, 1, "test", 3000);
+        ingestTestData(indexName, startTime, 1, "test", 10);
         String detectorType = AnomalyDetectorType.SINGLE_ENTITY.name();
         AnomalyDetector detector = TestHelpers
             .randomAnomalyDetector(
@@ -134,12 +150,45 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
         deleteIndexIfExists(CommonName.CONFIG_INDEX);
         deleteIndexIfExists(ALL_AD_RESULTS_INDEX_PATTERN);
         deleteIndexIfExists(ADCommonName.DETECTION_STATE_INDEX);
+        DiscoveryNode localNode = clusterService().localNode();
 
         profileFuture = mock(PlainActionFuture.class);
-        ProfileRequest profileRequest = new ProfileRequest("test-id", new HashSet<DetectorProfileName>(), false);
-        ProfileResponse response = adClient.getDetectorProfile(profileRequest).actionGet(10000);
+        ADTaskProfileRequest profileRequest = new ADTaskProfileRequest("foo", localNode);
+        ADTaskProfileResponse response = adClient.getDetectorProfile(profileRequest).actionGet(10000);
+        List<ADTaskProfileNodeResponse> responses = response.getNodes();
 
-        assertEquals(response.getActiveEntities(), 0);
+        // We should get node responses back from the local node, but there should be no profiles found
+        assertEquals(1, responses.size());
+        assertEquals(null, responses.get(0).getAdTaskProfile());
+
+        verify(clientSpy, times(1)).execute(any(ADTaskProfileAction.class), any(), any());
+
+    }
+
+    @Test
+    public void testGetDetectorProfile_Populated() throws IOException {
+
+        DiscoveryNode localNode = clusterService().localNode();
+        ADTaskProfile adTaskProfile = new ADTaskProfile("foo-task-id", 0, 0L, false, 0, 0L, localNode.getId());
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+
+            ActionListener<ADTaskProfileResponse> listener = (ActionListener<ADTaskProfileResponse>) args[2];
+            ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(localNode, adTaskProfile, null);
+
+            List<ADTaskProfileNodeResponse> nodeResponses = Arrays.asList(nodeResponse);
+            listener.onResponse(new ADTaskProfileResponse(new ClusterName("test-cluster"), nodeResponses, Collections.emptyList()));
+
+            return null;
+        }).when(clientSpy).execute(any(ADTaskProfileAction.class), any(), any());
+
+        ADTaskProfileRequest profileRequest = new ADTaskProfileRequest("foo", localNode);
+        ADTaskProfileResponse response = adClient.getDetectorProfile(profileRequest).actionGet(10000);
+        String responseTaskId = response.getNodes().get(0).getAdTaskProfile().getTaskId();
+
+        verify(clientSpy, times(1)).execute(any(ADTaskProfileAction.class), any(), any());
+        assertEquals(responseTaskId, adTaskProfile.getTaskId());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/transport/ADTaskProfileResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADTaskProfileResponseTests.java
@@ -21,6 +21,7 @@ import org.opensearch.ad.ADUnitTestCase;
 import org.opensearch.ad.model.ADTaskProfile;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 
 import com.google.common.collect.ImmutableList;
@@ -52,5 +53,20 @@ public class ADTaskProfileResponseTests extends ADUnitTestCase {
         ADTaskProfileResponse response2 = new ADTaskProfileResponse(input2);
         assertEquals(1, response2.getNodes().size());
         assertEquals(taskId, response2.getNodes().get(0).getAdTaskProfile().getTaskId());
+    }
+
+    public void testFromActionResponse() throws IOException {
+        String taskId = randomAlphaOfLength(5);
+        ADTaskProfile adTaskProfile = new ADTaskProfile();
+        adTaskProfile.setTaskId(taskId);
+        Version remoteAdVersion = Version.CURRENT;
+        ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(randomDiscoveryNode(), adTaskProfile, remoteAdVersion);
+
+        List<ADTaskProfileNodeResponse> nodeResponses = ImmutableList.of(nodeResponse);
+        ADTaskProfileResponse response = new ADTaskProfileResponse(new ClusterName("test"), nodeResponses, ImmutableList.of());
+
+        ADTaskProfileResponse reserializedResponse = ADTaskProfileResponse.fromActionResponse((ActionResponse) response);
+        assertEquals(1, reserializedResponse.getNodes().size());
+        assertEquals(taskId, reserializedResponse.getNodes().get(0).getAdTaskProfile().getTaskId());
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ADTaskProfileResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADTaskProfileResponseTests.java
@@ -23,6 +23,7 @@ import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 
 import com.google.common.collect.ImmutableList;
 
@@ -68,5 +69,27 @@ public class ADTaskProfileResponseTests extends ADUnitTestCase {
         ADTaskProfileResponse reserializedResponse = ADTaskProfileResponse.fromActionResponse((ActionResponse) response);
         assertEquals(1, reserializedResponse.getNodes().size());
         assertEquals(taskId, reserializedResponse.getNodes().get(0).getAdTaskProfile().getTaskId());
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeNodesTo(output, nodeResponses);
+        StreamInput input = output.bytes().streamInput();
+
+        ActionResponse invalidActionResponse = new TestActionResponse(input);
+        assertThrows(Exception.class, () -> ADTaskProfileResponse.fromActionResponse(invalidActionResponse));
+
     }
+
+    // A test ActionResponse class with an inactive writeTo class. Used to ensure exceptions
+    // are thrown when parsing implementations of such class.
+    private class TestActionResponse extends ActionResponse {
+        public TestActionResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            return;
+        }
+    }
+
 }


### PR DESCRIPTION
### Description
Adds a profile transport action method to the AD client. Note this method only takes in a `detectorId` string vs. the full `ADTaskProfileRequest` as required by the transport action. This is to simplify the interface and requirements from caller's side, as generating the request is not trivial and requires some AD-specific logic, including the constructed `DiscoveryNodeFilterer` used to determine the eligible AD nodes for the transport action to distribute the `ADTaskProfileRequest` to.

Additionally, this updates the `ADTaskProfileResponse` to add a helper method to serialize from a generic `ActionResponse`. This is needed to prevent classloader issues and ClassCastExceptions when this is constructed from external plugins using the AD client. 

Adds relevant tests and some minor cleanup on existing tests.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
