### PR TITLE
Refactor client's getDetectorProfile to use GetAnomalyDetectorTransportAction

### DIFF
--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -8,6 +8,7 @@ package org.opensearch.ad.client;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.ad.transport.GetAnomalyDetectorRequest;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
@@ -54,20 +55,20 @@ public interface AnomalyDetectionClient {
 
     /**
      * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
-     * @param detectorId the detector ID to fetch the profile for
+     * @param profileRequest request to fetch the detector profile
      * @return ActionFuture of GetAnomalyDetectorResponse
      */
-    default ActionFuture<GetAnomalyDetectorResponse> getDetectorProfile(String detectorId) {
+    default ActionFuture<GetAnomalyDetectorResponse> getDetectorProfile(GetAnomalyDetectorRequest profileRequest) {
         PlainActionFuture<GetAnomalyDetectorResponse> actionFuture = PlainActionFuture.newFuture();
-        getDetectorProfile(detectorId, actionFuture);
+        getDetectorProfile(profileRequest, actionFuture);
         return actionFuture;
     }
 
     /**
      * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
-     * @param detectorId the detector ID to fetch the profile for
+     * @param profileRequest request to fetch the detector profile
      * @param listener a listener to be notified of the result
      */
-    void getDetectorProfile(String detectorId, ActionListener<GetAnomalyDetectorResponse> listener);
+    void getDetectorProfile(GetAnomalyDetectorRequest profileRequest, ActionListener<GetAnomalyDetectorResponse> listener);
 
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -8,7 +8,7 @@ package org.opensearch.ad.client;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.ad.transport.ADTaskProfileResponse;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 
@@ -55,10 +55,10 @@ public interface AnomalyDetectionClient {
     /**
      * Get detector profile - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector
      * @param detectorId the detector ID to fetch the profile for
-     * @return ActionFuture of ADTaskProfileResponse
+     * @return ActionFuture of GetAnomalyDetectorResponse
      */
-    default ActionFuture<ADTaskProfileResponse> getDetectorProfile(String detectorId) {
-        PlainActionFuture<ADTaskProfileResponse> actionFuture = PlainActionFuture.newFuture();
+    default ActionFuture<GetAnomalyDetectorResponse> getDetectorProfile(String detectorId) {
+        PlainActionFuture<GetAnomalyDetectorResponse> actionFuture = PlainActionFuture.newFuture();
         getDetectorProfile(detectorId, actionFuture);
         return actionFuture;
     }
@@ -68,6 +68,6 @@ public interface AnomalyDetectionClient {
      * @param detectorId the detector ID to fetch the profile for
      * @param listener a listener to be notified of the result
      */
-    void getDetectorProfile(String detectorId, ActionListener<ADTaskProfileResponse> listener);
+    void getDetectorProfile(String detectorId, ActionListener<GetAnomalyDetectorResponse> listener);
 
 }

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -15,7 +15,6 @@ import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
 import org.opensearch.ad.transport.SearchAnomalyResultAction;
 import org.opensearch.client.Client;
-import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 
@@ -41,9 +40,8 @@ public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
     }
 
     @Override
-    public void getDetectorProfile(String detectorId, ActionListener<GetAnomalyDetectorResponse> listener) {
-        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest(detectorId, Versions.MATCH_ANY, true, false, "", "", false, null);
-        this.client.execute(GetAnomalyDetectorAction.INSTANCE, request, getAnomalyDetectorResponseActionListener(listener));
+    public void getDetectorProfile(GetAnomalyDetectorRequest profileRequest, ActionListener<GetAnomalyDetectorResponse> listener) {
+        this.client.execute(GetAnomalyDetectorAction.INSTANCE, profileRequest, getAnomalyDetectorResponseActionListener(listener));
     }
 
     // We need to wrap AD-specific response type listeners around an internal listener, and re-generate the response from a generic

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionNodeClient.java
@@ -9,25 +9,21 @@ import java.util.function.Function;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.transport.ADTaskProfileAction;
-import org.opensearch.ad.transport.ADTaskProfileRequest;
-import org.opensearch.ad.transport.ADTaskProfileResponse;
+import org.opensearch.ad.transport.GetAnomalyDetectorAction;
+import org.opensearch.ad.transport.GetAnomalyDetectorRequest;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
 import org.opensearch.ad.transport.SearchAnomalyResultAction;
 import org.opensearch.client.Client;
-import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
-import org.opensearch.timeseries.util.DiscoveryNodeFilterer;
 
 public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
     private final Client client;
-    private final DiscoveryNodeFilterer nodeFilterer;
 
-    public AnomalyDetectionNodeClient(Client client, ClusterService clusterService) {
+    public AnomalyDetectionNodeClient(Client client) {
         this.client = client;
-        this.nodeFilterer = new DiscoveryNodeFilterer(clusterService);
     }
 
     @Override
@@ -45,19 +41,21 @@ public class AnomalyDetectionNodeClient implements AnomalyDetectionClient {
     }
 
     @Override
-    public void getDetectorProfile(String detectorId, ActionListener<ADTaskProfileResponse> listener) {
-        final DiscoveryNode[] eligibleNodes = this.nodeFilterer.getEligibleDataNodes();
-        ADTaskProfileRequest profileRequest = new ADTaskProfileRequest(detectorId, eligibleNodes);
-        this.client.execute(ADTaskProfileAction.INSTANCE, profileRequest, getADTaskProfileResponseActionListener(listener));
+    public void getDetectorProfile(String detectorId, ActionListener<GetAnomalyDetectorResponse> listener) {
+        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest(detectorId, Versions.MATCH_ANY, true, false, "", "", false, null);
+        this.client.execute(GetAnomalyDetectorAction.INSTANCE, request, getAnomalyDetectorResponseActionListener(listener));
     }
 
     // We need to wrap AD-specific response type listeners around an internal listener, and re-generate the response from a generic
     // ActionResponse. This is needed to prevent classloader issues and ClassCastExceptions when executed by other plugins.
-    private ActionListener<ADTaskProfileResponse> getADTaskProfileResponseActionListener(ActionListener<ADTaskProfileResponse> listener) {
-        ActionListener<ADTaskProfileResponse> internalListener = ActionListener
-            .wrap(profileResponse -> { listener.onResponse(profileResponse); }, listener::onFailure);
-        ActionListener<ADTaskProfileResponse> actionListener = wrapActionListener(internalListener, actionResponse -> {
-            ADTaskProfileResponse response = ADTaskProfileResponse.fromActionResponse(actionResponse);
+    private ActionListener<GetAnomalyDetectorResponse> getAnomalyDetectorResponseActionListener(
+        ActionListener<GetAnomalyDetectorResponse> listener
+    ) {
+        ActionListener<GetAnomalyDetectorResponse> internalListener = ActionListener.wrap(getAnomalyDetectorResponse -> {
+            listener.onResponse(getAnomalyDetectorResponse);
+        }, listener::onFailure);
+        ActionListener<GetAnomalyDetectorResponse> actionListener = wrapActionListener(internalListener, actionResponse -> {
+            GetAnomalyDetectorResponse response = GetAnomalyDetectorResponse.fromActionResponse(actionResponse);
             return response;
         });
         return actionListener;

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorResponse.java
@@ -11,13 +11,18 @@
 
 package org.opensearch.ad.transport;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import org.opensearch.ad.model.ADTask;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.DetectorProfile;
 import org.opensearch.ad.model.EntityProfile;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.rest.RestStatus;
@@ -211,5 +216,20 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
 
     public AnomalyDetector getDetector() {
         return detector;
+    }
+
+    public static GetAnomalyDetectorResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof GetAnomalyDetectorResponse) {
+            return (GetAnomalyDetectorResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new GetAnomalyDetectorResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into GetAnomalyDetectorResponse", e);
+        }
     }
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
@@ -13,7 +13,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.ad.transport.ADTaskProfileResponse;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.core.action.ActionListener;
 
 public class AnomalyDetectionClientTests {
@@ -27,7 +27,7 @@ public class AnomalyDetectionClientTests {
     SearchResponse searchResultsResponse;
 
     @Mock
-    ADTaskProfileResponse profileResponse;
+    GetAnomalyDetectorResponse profileResponse;
 
     @Before
     public void setUp() {
@@ -46,7 +46,7 @@ public class AnomalyDetectionClientTests {
             }
 
             @Override
-            public void getDetectorProfile(String detectorId, ActionListener<ADTaskProfileResponse> listener) {
+            public void getDetectorProfile(String detectorId, ActionListener<GetAnomalyDetectorResponse> listener) {
                 listener.onResponse(profileResponse);
             }
         };

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
@@ -13,7 +13,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.transport.GetAnomalyDetectorRequest;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 
 public class AnomalyDetectionClientTests {
@@ -46,7 +48,7 @@ public class AnomalyDetectionClientTests {
             }
 
             @Override
-            public void getDetectorProfile(String detectorId, ActionListener<GetAnomalyDetectorResponse> listener) {
+            public void getDetectorProfile(GetAnomalyDetectorRequest profileRequest, ActionListener<GetAnomalyDetectorResponse> listener) {
                 listener.onResponse(profileResponse);
             }
         };
@@ -64,7 +66,17 @@ public class AnomalyDetectionClientTests {
 
     @Test
     public void getDetectorProfile() {
-        assertEquals(profileResponse, anomalyDetectionClient.getDetectorProfile("foo").actionGet());
+        GetAnomalyDetectorRequest profileRequest = new GetAnomalyDetectorRequest(
+            "foo",
+            Versions.MATCH_ANY,
+            true,
+            false,
+            "",
+            "",
+            false,
+            null
+        );
+        assertEquals(profileResponse, anomalyDetectionClient.getDetectorProfile(profileRequest).actionGet());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -21,8 +21,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.OpenSearchStatusException;
@@ -57,8 +55,6 @@ import com.google.common.collect.ImmutableList;
 // The exhaustive set of transport action scenarios are within the respective transport action
 // test suites themselves. We do not want to unnecessarily duplicate all of those tests here.
 public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTestCase {
-    private final Logger logger = LogManager.getLogger(this.getClass());
-
     private String indexName = "test-data";
     private Instant startTime = Instant.now().minus(2, ChronoUnit.DAYS);
     private Client clientSpy;

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -37,8 +37,10 @@ import org.opensearch.ad.model.AnomalyDetectorType;
 import org.opensearch.ad.model.DetectorProfile;
 import org.opensearch.ad.model.DetectorState;
 import org.opensearch.ad.transport.GetAnomalyDetectorAction;
+import org.opensearch.ad.transport.GetAnomalyDetectorRequest;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.client.Client;
+import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -150,9 +152,20 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
         deleteIndexIfExists(ALL_AD_RESULTS_INDEX_PATTERN);
         deleteIndexIfExists(ADCommonName.DETECTION_STATE_INDEX);
 
+        GetAnomalyDetectorRequest profileRequest = new GetAnomalyDetectorRequest(
+            "foo",
+            Versions.MATCH_ANY,
+            true,
+            false,
+            "",
+            "",
+            false,
+            null
+        );
+
         OpenSearchStatusException exception = expectThrows(
             OpenSearchStatusException.class,
-            () -> adClient.getDetectorProfile("foo").actionGet(10000)
+            () -> adClient.getDetectorProfile(profileRequest).actionGet(10000)
         );
 
         assertTrue(exception.getMessage().contains(FAIL_TO_FIND_CONFIG_MSG));
@@ -204,7 +217,18 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
             return null;
         }).when(clientSpy).execute(any(GetAnomalyDetectorAction.class), any(), any());
 
-        GetAnomalyDetectorResponse response = adClient.getDetectorProfile(detectorId).actionGet(10000);
+        GetAnomalyDetectorRequest profileRequest = new GetAnomalyDetectorRequest(
+            detectorId,
+            Versions.MATCH_ANY,
+            true,
+            false,
+            "",
+            "",
+            false,
+            null
+        );
+
+        GetAnomalyDetectorResponse response = adClient.getDetectorProfile(profileRequest).actionGet(10000);
 
         assertNotEquals(null, response.getDetector());
         assertNotEquals(null, response.getDetectorProfile());


### PR DESCRIPTION
### Description
The previous implementation of `getDetectorProfile()` used the `ADTaskProfileAction` which had the following limitations:
- very specific to tasks and may not contain other general AD-related things, such as detector name, AD-job status, etc.
- required `ClusterService` to be passed in the client construction which added effort from the caller's end
- the response was inherently more complex, and contained a list of individual node responses from each node in the cluster
- difficulty in interfacing historical vs. realtime tasks and propagating those results

This changes that to use the `GetAnomalyDetectorTransportAction`, which is a more high-level transport action that more closely emulates that of the [profile API](https://opensearch.org/docs/latest/observing-your-data/ad/api/#profile-detector), and resolves the limitations mentioned above.

Additionally, I remove the limitation of passing a String `detectorId`. Now that the request is a `GetAnomalyDetectorRequest`, it is much simpler for the caller to construct and pass this than the previously implemented `ADTaskProfileRequest`. This also allows more flexibility and control on the caller's side regarding what data they are interested in retrieving vs. ignoring.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
