### PR TITLE
Require JDK version for java spotless check

### DIFF
--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -13,7 +13,21 @@ jobs:
     with:
       product: opensearch
 
+  spotless:
+    if: github.repository == 'opensearch-project/anomaly-detection'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Spotless requires JDK 17+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Spotless Check
+        run: ./gradlew spotlessCheck
+
   Build-ad-windows:
+    needs: spotless
     strategy:
       matrix:
         java: [ 11, 17, 20 ]
@@ -46,7 +60,7 @@ jobs:
           flags: plugin
 
   Build-ad-linux:
-    needs: Get-CI-Image-Tag
+    needs: [Get-CI-Image-Tag, spotless]
     strategy:
       matrix:
         java: [11, 17, 20]
@@ -87,6 +101,7 @@ jobs:
           flags: plugin
 
   Build-ad-macos:
+    needs: spotless
     strategy:
       matrix:
         java: [11,17,20]


### PR DESCRIPTION
### Description
Require JDK version for java spotless check to resolve build failure caused by the following errors:
```
> Task :spotlessJava FAILED
Step 'eclipse jdt formatter' found problem in 'src/main/java/org/opensearch/timeseries/breaker/BreakerName.java':
You are running Spotless on JVM 11, which limits you to eclipse jdt formatter 4.26.
If you upgrade your JVM to 17+, then you can use eclipse jdt formatter 4.27, which may have fixed this problem.
java.lang.Exception: You are running Spotless on JVM 11, which limits you to eclipse jdt formatter 4.26.
If you upgrade your JVM to 17+, then you can use eclipse jdt formatter 4.27, which may have fixed this problem.
	at com.diffplug.spotless.Jvm$Support$1.apply(Jvm.java:209)
	at com.diffplug.spotless.FormatterStepImpl$Standard.format(FormatterStepImpl.java:82)
	at com.diffplug.spotless.FormatterStep$Strict.format(FormatterStep.java:88)
	at com.diffplug.spotless.Formatter.compute(Formatter.java:246)
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
