### PR TITLE
Improve GetAnomalyDetectorTransportAction to accept generic ActionRequest

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorRequest.java
@@ -11,10 +11,14 @@
 
 package org.opensearch.ad.transport;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.timeseries.model.Entity;
@@ -118,5 +122,20 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
     @Override
     public ActionRequestValidationException validate() {
         return null;
+    }
+
+    public static GetAnomalyDetectorRequest fromActionRequest(final ActionRequest actionRequest) {
+        if (actionRequest instanceof GetAnomalyDetectorRequest) {
+            return (GetAnomalyDetectorRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new GetAnomalyDetectorRequest(input);
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("failed to parse ActionRequest into GetAnomalyDetectorRequest", e);
+        }
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.get.MultiGetItemResponse;
 import org.opensearch.action.get.MultiGetRequest;
 import org.opensearch.action.get.MultiGetResponse;
@@ -75,7 +76,7 @@ import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.Sets;
 
-public class GetAnomalyDetectorTransportAction extends HandledTransportAction<GetAnomalyDetectorRequest, GetAnomalyDetectorResponse> {
+public class GetAnomalyDetectorTransportAction extends HandledTransportAction<ActionRequest, GetAnomalyDetectorResponse> {
 
     private static final Logger LOG = LogManager.getLogger(GetAnomalyDetectorTransportAction.class);
 
@@ -131,7 +132,9 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     }
 
     @Override
-    protected void doExecute(Task task, GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> actionListener) {
+    protected void doExecute(Task task, ActionRequest actionRequest, ActionListener<GetAnomalyDetectorResponse> actionListener) {
+        GetAnomalyDetectorRequest request = GetAnomalyDetectorRequest.fromActionRequest(actionRequest);
+
         String detectorID = request.getDetectorID();
         User user = getUserContext(client);
         ActionListener<GetAnomalyDetectorResponse> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_DETECTOR);


### PR DESCRIPTION
### Description
Previously there was no serialization and deserialization of the `GetAnomalyDetectorRequest` passed to the transport action. Because this transport action is exposed via the AD node client, it is possible a user executes this from a different classloader of AD classes, such that there is ClassCastExceptions when propagating the `GetAnomalyDetectorRequest`. Similar to other existing req/resp objects, this PR adds a `fromActionRequest` method to serialize & deserialize a base `ActionRequest` into a `GetAnomalyDetectorRequest` when running `execute()` to prevent such errors.

I've confirmed this works by triggering the error, and seeing the fix, by executing this using the [skills repo](https://github.com/opensearch-project/skills)'s `SearchAnomalyDetectorsTool`. This tool, for a certain codepath, uses the AD node client's `getDetectorProfile()` call which expects a `GetAnomalyDetectorRequest`. Prior to this change, this triggers a ClassCastException. After this change, the tool works as expected.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
