### PR TITLE
Inject NamedWriteableRegistry in AD node client

### DIFF
--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorResponse.java
@@ -22,6 +22,8 @@ import org.opensearch.ad.model.DetectorProfile;
 import org.opensearch.ad.model.EntityProfile;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -218,16 +220,21 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
         return detector;
     }
 
-    public static GetAnomalyDetectorResponse fromActionResponse(ActionResponse actionResponse) {
+    public static GetAnomalyDetectorResponse fromActionResponse(
+        ActionResponse actionResponse,
+        NamedWriteableRegistry namedWriteableRegistry
+    ) {
         if (actionResponse instanceof GetAnomalyDetectorResponse) {
             return (GetAnomalyDetectorResponse) actionResponse;
         }
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos);
             actionResponse.writeTo(osso);
-            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
-                return new GetAnomalyDetectorResponse(input);
-            }
+            InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()));
+            NamedWriteableAwareStreamInput namedWriteableAwareInput = new NamedWriteableAwareStreamInput(input, namedWriteableRegistry);
+            return new GetAnomalyDetectorResponse(namedWriteableAwareInput);
         } catch (IOException e) {
             throw new UncheckedIOException("failed to parse ActionResponse into GetAnomalyDetectorResponse", e);
         }

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionNodeClientTests.java
@@ -40,6 +40,7 @@ import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -64,7 +65,7 @@ public class AnomalyDetectionNodeClientTests extends HistoricalAnalysisIntegTest
     @Before
     public void setup() {
         clientSpy = spy(client());
-        adClient = new AnomalyDetectionNodeClient(clientSpy);
+        adClient = new AnomalyDetectionNodeClient(clientSpy, mock(NamedWriteableRegistry.class));
     }
 
     @Test

--- a/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/GetAnomalyDetectorResponseTests.java
@@ -17,8 +17,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
@@ -76,6 +79,21 @@ public class GetAnomalyDetectorResponseTests extends OpenSearchSingleNodeTestCas
         assertEquals(response.getDetector(), parsedResponse.getDetector());
     }
 
+    public void testFromActionResponse() throws IOException {
+        GetAnomalyDetectorResponse response = createGetAnomalyDetectorResponse(true, true);
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+
+        GetAnomalyDetectorResponse reserializedResponse = GetAnomalyDetectorResponse
+            .fromActionResponse((ActionResponse) response, writableRegistry());
+        assertEquals(response, reserializedResponse);
+
+        ActionResponse invalidActionResponse = new TestActionResponse(input);
+        assertThrows(Exception.class, () -> GetAnomalyDetectorResponse.fromActionResponse(invalidActionResponse, writableRegistry()));
+
+    }
+
     private GetAnomalyDetectorResponse createGetAnomalyDetectorResponse(boolean returnJob, boolean returnTask) throws IOException {
         GetAnomalyDetectorResponse response = new GetAnomalyDetectorResponse(
             randomLong(),
@@ -94,5 +112,18 @@ public class GetAnomalyDetectorResponseTests extends OpenSearchSingleNodeTestCas
             false
         );
         return response;
+    }
+
+    // A test ActionResponse class with an inactive writeTo class. Used to ensure exceptions
+    // are thrown when parsing implementations of such class.
+    private class TestActionResponse extends ActionResponse {
+        public TestActionResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            return;
+        }
     }
 }


### PR DESCRIPTION
### Description
Currently, when serializing the `GetAnomalyDetectorResponse` via `fromActionResponse` (triggered by executing via the node client from a separate plugin) it is not passing a named-writeable-aware stream input, which causes serialization to fail for certain sub-fields within `GetAnomalyDetectorResponse` that are trying to read named writeables via `readNamedWriteable()`. Error seen:
```
Caused by: java.lang.UnsupportedOperationException: can't read named writeable from StreamInput
```

This fixes that by changing the constructor of the node client to pass in a `NamedWriteableRegistry`, to finally pass down to `fromActionResponse` to construct a valid `NamedWriteableAwareStreamInput` to successfully serialize and return a `GetAnomalyDetectorResponse`.

Note `fromActionResponse()` is only used in the node client so the blast radius is small. Also note this serialization is only needed for this response type since the other response types currently in the node client are generic `SearchResponse`s which don't require the ser/deser that AD-implemented objs do to get around the `ClassLoaderException`s caused by plugin-to-plugin communication.

Testing:
- added unit test to cover `fromActionResponse` with a mock registry
- tested end-to-end with a patched version of the skills repo (see PR here: https://github.com/opensearch-project/skills/pull/235) that passes down that plugin's `NamedWriteableRegistry` to the client. Was able to reproduce the issue, and confirmed it works as expected after this fix.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
