### PR TITLE
Conditionally skip rolling upgrade BWC on major version change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -640,8 +640,11 @@ task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
 
 // A bwc test suite which runs all the bwc tasks combined.
 task bwcTestSuite(type: StandaloneRestIntegTestTask) {
-    exclude '**/*Test*'
-    exclude '**/*IT*'
+    filter {
+        excludeTestsMatching '**.*Test*'
+        excludeTestsMatching '**.*IT*'
+        setFailOnNoMatchingTests(false)
+    }
     dependsOn tasks.named("${baseName}#mixedClusterTask")
     dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
     dependsOn tasks.named("${baseName}#fullRestartClusterTask")

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ buildscript {
         bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
         bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
 
+        isSameMajorVersion = opensearch_version.split("\\.")[0] == bwcVersionShort.split("\\.")[0]
+
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
         // This option turn on log printing during tests. 
@@ -185,6 +187,12 @@ allprojects {
 
     plugins.withId('jacoco') {
         jacoco.toolVersion = '0.8.11'
+    }
+
+    // Needed for Gradle 9.0
+    tasks.withType(StandaloneRestIntegTestTask).configureEach {
+        testClassesDirs = sourceSets.test.output.classesDirs
+        classpath = sourceSets.test.runtimeClasspath
     }
 }
 
@@ -539,6 +547,7 @@ List<Provider<RegularFile>> plugins = [
 // Creates 2 test clusters with 3 nodes of the old version. 
 2.times {i -> 
     task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
+        onlyIf { isSameMajorVersion || (i == 1) }
         useCluster testClusters."${baseName}$i"
         filter {
             includeTestsMatching "org.opensearch.ad.bwc.*IT"
@@ -555,6 +564,7 @@ List<Provider<RegularFile>> plugins = [
 // This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
 // This is also used as a one third upgraded cluster for a rolling upgrade.
 task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
+    onlyIf { isSameMajorVersion }
     useCluster testClusters."${baseName}0"
     dependsOn "${baseName}#oldVersionClusterTask0"
     doFirst {
@@ -574,6 +584,7 @@ task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
 // This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
 // This is used for rolling upgrade.
 task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
+    onlyIf { isSameMajorVersion }
     dependsOn "${baseName}#mixedClusterTask"
     useCluster testClusters."${baseName}0"
     doFirst {
@@ -593,6 +604,7 @@ task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTas
 // This results in a fully upgraded cluster.
 // This is used for rolling upgrade.
 task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
+    onlyIf { isSameMajorVersion }
     dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
     useCluster testClusters."${baseName}0"
     doFirst {


### PR DESCRIPTION
### Description

BWC tests are currently [failing on the main branch](https://github.com/opensearch-project/anomaly-detection/actions/workflows/test_bwc.yml?query=branch%3Amain) because of core major version incompatibilities that prevent a cluster from forming if all nodes are not in the same major version.

This skips the set of rolling upgrade/mixed cluster tests when the major versions differ:
 - no change to current behavior comparing 2.x vs. the baseline
 - tests will no longer fail on mixed cluster but will still run on a full restart allowing proper BWC tests across versions

Additional change makes the BWC tests Gradle 9.0 compatible so they don't fail on an exception (as of 8.4).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
