### PR TITLE
change request type to ActionRequest BaseGetConfigTransportAction to …

### DIFF
--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -271,9 +271,9 @@ public class AnomalyDetector extends Config {
         } else {
             this.imputationOption = null;
         }
-        this.recencyEmphasis = input.readInt();
-        this.seasonIntervals = input.readInt();
-        this.historyIntervals = input.readInt();
+        this.recencyEmphasis = input.readOptionalInt();
+        this.seasonIntervals = input.readOptionalInt();
+        this.historyIntervals = input.readOptionalInt();
         if (input.readBoolean()) {
             this.rules = input.readList(Rule::new);
         }
@@ -333,9 +333,9 @@ public class AnomalyDetector extends Config {
         } else {
             output.writeBoolean(false);
         }
-        output.writeInt(recencyEmphasis);
-        output.writeInt(seasonIntervals);
-        output.writeInt(historyIntervals);
+        output.writeOptionalInt(recencyEmphasis);
+        output.writeOptionalInt(seasonIntervals);
+        output.writeOptionalInt(historyIntervals);
         if (rules != null) {
             output.writeBoolean(true);
             output.writeList(rules);

--- a/src/main/java/org/opensearch/timeseries/transport/BaseGetConfigTransportAction.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BaseGetConfigTransportAction.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.get.MultiGetItemResponse;
 import org.opensearch.action.get.MultiGetRequest;
@@ -74,7 +75,7 @@ import org.opensearch.transport.TransportService;
 import com.google.common.collect.Sets;
 
 public abstract class BaseGetConfigTransportAction<GetConfigResponseType extends ActionResponse, TaskCacheManagerType extends TaskCacheManager, TaskTypeEnum extends TaskType, TaskClass extends TimeSeriesTask, IndexType extends Enum<IndexType> & TimeSeriesIndex, IndexManagementType extends IndexManagement<IndexType>, TaskManagerType extends TaskManager<TaskCacheManagerType, TaskTypeEnum, TaskClass, IndexType, IndexManagementType>, ConfigType extends Config, EntityProfileActionType extends ActionType<EntityProfileResponse>, EntityProfileRunnerType extends EntityProfileRunner<EntityProfileActionType>, TaskProfileType extends TaskProfile<TaskClass>, ConfigProfileType extends ConfigProfile<TaskClass, TaskProfileType>, ProfileActionType extends ActionType<ProfileResponse>, TaskProfileRunnerType extends TaskProfileRunner<TaskClass, TaskProfileType>, ProfileRunnerType extends ProfileRunner<TaskCacheManagerType, TaskTypeEnum, TaskClass, IndexType, IndexManagementType, TaskProfileType, TaskManagerType, ConfigProfileType, ProfileActionType, TaskProfileRunnerType>>
-    extends HandledTransportAction<GetConfigRequest, GetConfigResponseType> {
+    extends HandledTransportAction<ActionRequest, GetConfigResponseType> {
 
     private static final Logger LOG = LogManager.getLogger(BaseGetConfigTransportAction.class);
 
@@ -156,8 +157,9 @@ public abstract class BaseGetConfigTransportAction<GetConfigResponseType extends
     }
 
     @Override
-    public void doExecute(Task task, GetConfigRequest request, ActionListener<GetConfigResponseType> actionListener) {
-        String configID = request.getConfigID();
+    public void doExecute(Task task, ActionRequest request, ActionListener<GetConfigResponseType> actionListener) {
+        GetConfigRequest getConfigRequest = GetConfigRequest.fromActionRequest(request);
+        String configID = getConfigRequest.getConfigID();
         User user = ParseUtils.getUserContext(client);
         ActionListener<GetConfigResponseType> listener = wrapRestActionListener(actionListener, FAIL_TO_GET_FORECASTER);
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
@@ -166,7 +168,7 @@ public abstract class BaseGetConfigTransportAction<GetConfigResponseType extends
                 configID,
                 filterByEnabled,
                 listener,
-                (config) -> getExecute(request, listener),
+                (config) -> getExecute(getConfigRequest, listener),
                 client,
                 clusterService,
                 xContentRegistry,


### PR DESCRIPTION
…fix class cast exception

### Description
1. change request type to ActionRequest BaseGetConfigTransportAction to fix class cast exception. `ActionRequest` is the basic class and defined in core, so the class loader for this class will be OpenSearch core instead of Ad plugin. If we change to `GetConfigRequest` that defined in AD plugin, the class loader for this class will Ad plugin class loader in Ad plugin, and skills plugin class loader in Skill plugin, that will cause class cast exception.

please note, skill plugin don't depends on Ad plugin, so they don't have parent and child relationship.

2. `recencyEmphasis`, `seasonIntervals`, `historyIntervals` are `Integer` type, basically they could be null, change to read/write Optional.

3. try to add a unit test for `AnomalyDetector` serialization and deserialization



### Issues Resolved

https://github.com/opensearch-project/anomaly-detection/issues/1220

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
