### PR TITLE
Set baseline JDK version to JDK-21

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 17
+          java-version: 21
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4.0.1
         with:

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -18,10 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Spotless requires JDK 17+
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Spotless Check
         run: ./gradlew spotlessCheck
@@ -30,7 +29,7 @@ jobs:
     needs: spotless
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 21 ]
     name: Build and Test Anomaly Detection Plugin on Windows
     runs-on: windows-latest
     env:
@@ -63,7 +62,7 @@ jobs:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
       fail-fast: false
     name: Build and Test Anomaly detection Plugin
     runs-on: ubuntu-latest
@@ -104,7 +103,7 @@ jobs:
     needs: spotless
     strategy:
       matrix:
-        java: [11,17,21]
+        java: [21]
       fail-fast: false
 
     name: Build and Test Anomaly detection Plugin

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -17,7 +17,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [11,17,21]
+        java: [21]
       fail-fast: false
 
     name: Test Anomaly detection BWC

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -11,7 +11,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [11,17,21]
+        java: [21]
       fail-fast: false
 
     name: Security test workflow for Anomaly Detection

--- a/build.gradle
+++ b/build.gradle
@@ -192,8 +192,8 @@ allprojects {
 }
 
 java {
-  targetCompatibility = JavaVersion.VERSION_11
-  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_21
+  sourceCompatibility = JavaVersion.VERSION_21
 }
 
 ext {


### PR DESCRIPTION
### Description

Sets the baseline JDK version to JDK-21

### Issues Resolved

Resolves #1223

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
