### PR TITLE
Fix Duplicate Scheduling of Index Rollover in ADIndexManagement

### DIFF
--- a/src/main/java/org/opensearch/ad/indices/ADIndexManagement.java
+++ b/src/main/java/org/opensearch/ad/indices/ADIndexManagement.java
@@ -96,7 +96,6 @@ public class ADIndexManagement extends IndexManagement<ADIndex> {
             AnomalyDetector::parse,
             ADCommonName.CUSTOM_RESULT_INDEX_PREFIX + "*"
         );
-        this.clusterService.addLocalNodeClusterManagerListener(this);
 
         this.indexStates = new EnumMap<ADIndex, IndexState>(ADIndex.class);
 


### PR DESCRIPTION
### Description
ADIndexManagement inherits from IndexManagement, which implements LocalNodeClusterManagerListener, causing it to listen for master node changes. This listener schedules index rollover and deletion. However, ADIndexManagement was inadvertently listening to the cluster manager event again, leading to duplicate scheduling of these tasks.

This commit removes the redundant listener call in ADIndexManagement, ensuring that index rollover and deletion are scheduled only once per interval.

Testing:
* Verified that index rollover and deletion now execute once per interval as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
