### PR TITLE
Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         js_resource_folder = "src/test/resources/job-scheduler"
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
-        bwcVersionShort = "2.15.0"
+        bwcVersionShort = "2.16.0"
         bwcVersion = bwcVersionShort + ".0"
         bwcOpenSearchADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + bwcVersionShort + '/latest/linux/x64/tar/builds/' +
                 'opensearch/plugins/opensearch-anomaly-detection-' + bwcVersion + '.zip'

--- a/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
@@ -13,11 +13,16 @@ package org.opensearch.timeseries;
 
 import static java.util.Collections.unmodifiableList;
 import static org.opensearch.ad.constant.ADCommonName.ANOMALY_RESULT_INDEX_ALIAS;
+import static org.opensearch.ad.constant.ADCommonName.CHECKPOINT_INDEX_NAME;
+import static org.opensearch.ad.constant.ADCommonName.DETECTION_STATE_INDEX;
+import static org.opensearch.ad.indices.ADIndexManagement.ALL_AD_RESULTS_INDEX_PATTERN;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_COOLDOWN_MINUTES;
+import static org.opensearch.timeseries.constant.CommonName.ALL_AD_DETECTOR_INDEX_PATTERN;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -249,6 +254,7 @@ import org.opensearch.forecast.transport.ValidateForecasterAction;
 import org.opensearch.forecast.transport.ValidateForecasterTransportAction;
 import org.opensearch.forecast.transport.handler.ForecastIndexMemoryPressureAwareResultHandler;
 import org.opensearch.forecast.transport.handler.ForecastSearchHandler;
+import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
 import org.opensearch.jobscheduler.spi.ScheduledJobParser;
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
@@ -257,6 +263,7 @@ import org.opensearch.monitor.jvm.JvmService;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.ScriptPlugin;
+import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
@@ -313,7 +320,7 @@ import io.protostuff.runtime.RuntimeSchema;
 /**
  * Entry point of time series analytics plugin.
  */
-public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, ScriptPlugin, JobSchedulerExtension {
+public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, ScriptPlugin, SystemIndexPlugin, JobSchedulerExtension {
 
     private static final Logger LOG = LogManager.getLogger(TimeSeriesAnalyticsPlugin.class);
 
@@ -1670,6 +1677,17 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
                 new ActionHandler<>(ValidateForecasterAction.INSTANCE, ValidateForecasterTransportAction.class),
                 new ActionHandler<>(SuggestForecasterParamAction.INSTANCE, SuggestForecasterParamTransportAction.class)
             );
+    }
+
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        List<SystemIndexDescriptor> systemIndexDescriptors = new ArrayList<>();
+        systemIndexDescriptors.add(new SystemIndexDescriptor(ALL_AD_RESULTS_INDEX_PATTERN, "Time Series Analytics Results index pattern"));
+        systemIndexDescriptors
+            .add(new SystemIndexDescriptor(ALL_AD_DETECTOR_INDEX_PATTERN, "Time Series Analytics Detector index pattern"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(CHECKPOINT_INDEX_NAME, "Time Series Analytics Checkpoints index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(DETECTION_STATE_INDEX, "Time Series Analytics Detection State index"));
+        return systemIndexDescriptors;
     }
 
     @Override

--- a/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
@@ -17,7 +17,10 @@ import static org.opensearch.ad.constant.ADCommonName.CHECKPOINT_INDEX_NAME;
 import static org.opensearch.ad.constant.ADCommonName.DETECTION_STATE_INDEX;
 import static org.opensearch.ad.indices.ADIndexManagement.ALL_AD_RESULTS_INDEX_PATTERN;
 import static org.opensearch.ad.settings.AnomalyDetectorSettings.AD_COOLDOWN_MINUTES;
-import static org.opensearch.timeseries.constant.CommonName.ALL_AD_DETECTOR_INDEX_PATTERN;
+import static org.opensearch.forecast.constant.ForecastCommonName.FORECAST_CHECKPOINT_INDEX_NAME;
+import static org.opensearch.forecast.constant.ForecastCommonName.FORECAST_STATE_INDEX;
+import static org.opensearch.timeseries.constant.CommonName.CONFIG_INDEX;
+import static org.opensearch.timeseries.constant.CommonName.JOB_INDEX;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -814,10 +817,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
                 StatNames.CONFIG_INDEX_STATUS.getName(),
                 new TimeSeriesStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.CONFIG_INDEX))
             )
-            .put(
-                StatNames.JOB_INDEX_STATUS.getName(),
-                new TimeSeriesStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.JOB_INDEX))
-            )
+            .put(StatNames.JOB_INDEX_STATUS.getName(), new TimeSeriesStat<>(true, new IndexStatusSupplier(indexUtils, JOB_INDEX)))
             .put(
                 StatNames.MODEL_COUNT.getName(),
                 new TimeSeriesStat<>(false, new ADModelsOnNodeCountSupplier(adModelManager, adCacheProvider))
@@ -1199,10 +1199,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
                 StatNames.CONFIG_INDEX_STATUS.getName(),
                 new TimeSeriesStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.CONFIG_INDEX))
             )
-            .put(
-                StatNames.JOB_INDEX_STATUS.getName(),
-                new TimeSeriesStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.JOB_INDEX))
-            )
+            .put(StatNames.JOB_INDEX_STATUS.getName(), new TimeSeriesStat<>(true, new IndexStatusSupplier(indexUtils, JOB_INDEX)))
             .put(StatNames.MODEL_COUNT.getName(), new TimeSeriesStat<>(false, new ForecastModelsOnNodeCountSupplier(forecastCacheProvider)))
             .build();
 
@@ -1682,11 +1679,13 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
         List<SystemIndexDescriptor> systemIndexDescriptors = new ArrayList<>();
-        systemIndexDescriptors.add(new SystemIndexDescriptor(ALL_AD_RESULTS_INDEX_PATTERN, "Time Series Analytics Results index pattern"));
-        systemIndexDescriptors
-            .add(new SystemIndexDescriptor(ALL_AD_DETECTOR_INDEX_PATTERN, "Time Series Analytics Detector index pattern"));
-        systemIndexDescriptors.add(new SystemIndexDescriptor(CHECKPOINT_INDEX_NAME, "Time Series Analytics Checkpoints index"));
-        systemIndexDescriptors.add(new SystemIndexDescriptor(DETECTION_STATE_INDEX, "Time Series Analytics Detection State index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(CONFIG_INDEX, "Time Series Analytics config index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(ALL_AD_RESULTS_INDEX_PATTERN, "AD result index pattern"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(CHECKPOINT_INDEX_NAME, "AD Checkpoints index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(DETECTION_STATE_INDEX, "AD State index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(FORECAST_CHECKPOINT_INDEX_NAME, "Forecast Checkpoints index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(FORECAST_STATE_INDEX, "Forecast state index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(JOB_INDEX, "Time Series Analytics job index"));
         return systemIndexDescriptors;
     }
 
@@ -1697,7 +1696,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
 
     @Override
     public String getJobIndex() {
-        return CommonName.JOB_INDEX;
+        return JOB_INDEX;
     }
 
     @Override

--- a/src/main/java/org/opensearch/timeseries/constant/CommonName.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonName.java
@@ -33,7 +33,6 @@ public class CommonName {
     // ======================================
     // Index name
     // ======================================
-
     // config index. We are reusing ad detector index.
     public static final String CONFIG_INDEX = ".opendistro-anomaly-detectors";
 

--- a/src/main/java/org/opensearch/timeseries/constant/CommonName.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonName.java
@@ -33,6 +33,9 @@ public class CommonName {
     // ======================================
     // Index name
     // ======================================
+
+    public static final String ALL_AD_DETECTOR_INDEX_PATTERN = ".opendistro-anomaly-detectors*";
+
     // config index. We are reusing ad detector index.
     public static final String CONFIG_INDEX = ".opendistro-anomaly-detectors";
 

--- a/src/main/java/org/opensearch/timeseries/constant/CommonName.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonName.java
@@ -34,8 +34,6 @@ public class CommonName {
     // Index name
     // ======================================
 
-    public static final String ALL_AD_DETECTOR_INDEX_PATTERN = ".opendistro-anomaly-detectors*";
-
     // config index. We are reusing ad detector index.
     public static final String CONFIG_INDEX = ".opendistro-anomaly-detectors";
 


### PR DESCRIPTION
### Description

This PR registers the system indices in this plugin through the SystemIndexPlugin extension point in core. These indices will not be functionally different than they are today, its just a formal registration as a system index.

### Issues Resolved

Related to https://github.com/opensearch-project/security/issues/4439

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
