### PR TITLE
Add flatten_result_index_mapping field to Config

### DIFF
--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -344,7 +344,8 @@ public class ADTask extends TimeSeriesTask {
                 detector.getRules(),
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
-                detector.getCustomResultIndexTTL()
+                detector.getCustomResultIndexTTL(),
+                detector.getFlattenResultIndexMapping()
             );
         return new Builder()
             .taskId(parsedTaskId)

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -150,6 +150,7 @@ public class AnomalyDetector extends Config {
      * @param customResultIndexMinSize custom result index lifecycle management min size condition
      * @param customResultIndexMinAge custom result index lifecycle management min age condition
      * @param customResultIndexTTL custom result index lifecycle management ttl
+     * @param flattenResultIndexMapping flag to indicate whether to flatten result index mapping or not
      */
     public AnomalyDetector(
         String detectorId,
@@ -176,7 +177,8 @@ public class AnomalyDetector extends Config {
         List<Rule> rules,
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
-        Integer customResultIndexTTL
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping
     ) {
         super(
             detectorId,
@@ -203,7 +205,8 @@ public class AnomalyDetector extends Config {
             historyIntervals,
             customResultIndexMinSize,
             customResultIndexMinAge,
-            customResultIndexTTL
+            customResultIndexTTL,
+            flattenResultIndexMapping
         );
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
@@ -280,6 +283,7 @@ public class AnomalyDetector extends Config {
         this.customResultIndexMinSize = input.readOptionalInt();
         this.customResultIndexMinAge = input.readOptionalInt();
         this.customResultIndexTTL = input.readOptionalInt();
+        this.flattenResultIndexMapping = input.readOptionalBoolean();
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -345,6 +349,7 @@ public class AnomalyDetector extends Config {
         output.writeOptionalInt(customResultIndexMinSize);
         output.writeOptionalInt(customResultIndexMinAge);
         output.writeOptionalInt(customResultIndexTTL);
+        output.writeOptionalBoolean(flattenResultIndexMapping);
     }
 
     @Override
@@ -441,6 +446,7 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinSize = null;
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
+        Boolean flattenResultIndexMapping = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -575,6 +581,9 @@ public class AnomalyDetector extends Config {
                 case RESULT_INDEX_FIELD_TTL:
                     customResultIndexTTL = onlyParseNumberValue(parser);
                     break;
+                case FLATTEN_RESULT_INDEX_MAPPING:
+                    flattenResultIndexMapping = onlyParseBooleanValue(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -605,7 +614,8 @@ public class AnomalyDetector extends Config {
             rules,
             customResultIndexMinSize,
             customResultIndexMinAge,
-            customResultIndexTTL
+            customResultIndexTTL,
+            flattenResultIndexMapping
         );
         detector.setDetectionDateRange(detectionDateRange);
         return detector;
@@ -689,6 +699,13 @@ public class AnomalyDetector extends Config {
     private static Integer onlyParseNumberValue(XContentParser parser) throws IOException {
         if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
             return parser.intValue();
+        }
+        return null;
+    }
+
+    private static Boolean onlyParseBooleanValue(XContentParser parser) throws IOException {
+        if (parser.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
+            return parser.booleanValue();
         }
         return null;
     }

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -239,7 +239,8 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             detector.getRules(),
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
-            config.getCustomResultIndexTTL()
+            config.getCustomResultIndexTTL(),
+            config.getFlattenResultIndexMapping()
         );
     }
 

--- a/src/main/java/org/opensearch/forecast/model/ForecastTask.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastTask.java
@@ -342,7 +342,8 @@ public class ForecastTask extends TimeSeriesTask {
                 forecaster.getHistoryIntervals(),
                 forecaster.getCustomResultIndexMinSize(),
                 forecaster.getCustomResultIndexMinAge(),
-                forecaster.getCustomResultIndexTTL()
+                forecaster.getCustomResultIndexTTL(),
+                forecaster.getFlattenResultIndexMapping()
             );
         return new Builder()
             .taskId(parsedTaskId)

--- a/src/main/java/org/opensearch/forecast/model/Forecaster.java
+++ b/src/main/java/org/opensearch/forecast/model/Forecaster.java
@@ -134,7 +134,8 @@ public class Forecaster extends Config {
         Integer historyIntervals,
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
-        Integer customResultIndexTTL
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping
     ) {
         super(
             forecasterId,
@@ -161,7 +162,8 @@ public class Forecaster extends Config {
             historyIntervals,
             customResultIndexMinSize,
             customResultIndexMinAge,
-            customResultIndexTTL
+            customResultIndexTTL,
+            flattenResultIndexMapping
         );
 
         checkAndThrowValidationErrors(ValidationAspect.FORECASTER);
@@ -303,6 +305,7 @@ public class Forecaster extends Config {
         Integer customResultIndexMinSize = null;
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
+        Boolean flattenResultIndexMapping = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -431,6 +434,9 @@ public class Forecaster extends Config {
                 case RESULT_INDEX_FIELD_TTL:
                     customResultIndexTTL = parser.intValue();
                     break;
+                case FLATTEN_RESULT_INDEX_MAPPING:
+                    flattenResultIndexMapping = parser.booleanValue();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -461,7 +467,8 @@ public class Forecaster extends Config {
             historyIntervals,
             customResultIndexMinSize,
             customResultIndexMinAge,
-            customResultIndexTTL
+            customResultIndexTTL,
+            flattenResultIndexMapping
         );
         return forecaster;
     }

--- a/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
+++ b/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
@@ -257,7 +257,8 @@ public abstract class AbstractForecasterActionHandler<T extends ActionResponse> 
             config.getHistoryIntervals(),
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
-            config.getCustomResultIndexTTL()
+            config.getCustomResultIndexTTL(),
+            config.getFlattenResultIndexMapping()
         );
     }
 

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -79,6 +79,7 @@ public abstract class Config implements Writeable, ToXContentObject {
     public static final String RESULT_INDEX_FIELD_MIN_SIZE = "result_index_min_size";
     public static final String RESULT_INDEX_FIELD_MIN_AGE = "result_index_min_age";
     public static final String RESULT_INDEX_FIELD_TTL = "result_index_ttl";
+    public static final String FLATTEN_RESULT_INDEX_MAPPING = "flatten_result_index_mapping";
 
     protected String id;
     protected Long version;
@@ -118,6 +119,7 @@ public abstract class Config implements Writeable, ToXContentObject {
     protected Integer customResultIndexMinSize;
     protected Integer customResultIndexMinAge;
     protected Integer customResultIndexTTL;
+    protected Boolean flattenResultIndexMapping;
 
     public static String INVALID_RESULT_INDEX_NAME_SIZE = "Result index name size must contains less than "
         + MAX_RESULT_INDEX_NAME_SIZE
@@ -148,7 +150,8 @@ public abstract class Config implements Writeable, ToXContentObject {
         Integer historyIntervals,
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
-        Integer customResultIndexTTL
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping
     ) {
         if (Strings.isBlank(name)) {
             errorMessage = CommonMessages.EMPTY_NAME;
@@ -267,6 +270,7 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.customResultIndexMinSize = Strings.trimToNull(resultIndex) == null ? null : customResultIndexMinSize;
         this.customResultIndexMinAge = Strings.trimToNull(resultIndex) == null ? null : customResultIndexMinAge;
         this.customResultIndexTTL = Strings.trimToNull(resultIndex) == null ? null : customResultIndexTTL;
+        this.flattenResultIndexMapping = Strings.trimToNull(resultIndex) == null ? null : flattenResultIndexMapping;
     }
 
     public int suggestHistory() {
@@ -310,6 +314,7 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.customResultIndexMinSize = input.readOptionalInt();
         this.customResultIndexMinAge = input.readOptionalInt();
         this.customResultIndexTTL = input.readOptionalInt();
+        this.flattenResultIndexMapping = input.readOptionalBoolean();
     }
 
     /*
@@ -362,6 +367,7 @@ public abstract class Config implements Writeable, ToXContentObject {
         output.writeOptionalInt(customResultIndexMinSize);
         output.writeOptionalInt(customResultIndexMinAge);
         output.writeOptionalInt(customResultIndexTTL);
+        output.writeOptionalBoolean(flattenResultIndexMapping);
     }
 
     public boolean invalidShingleSizeRange(Integer shingleSizeToTest) {
@@ -418,7 +424,8 @@ public abstract class Config implements Writeable, ToXContentObject {
             && Objects.equal(historyIntervals, config.historyIntervals)
             && Objects.equal(customResultIndexMinSize, config.customResultIndexMinSize)
             && Objects.equal(customResultIndexMinAge, config.customResultIndexMinAge)
-            && Objects.equal(customResultIndexTTL, config.customResultIndexTTL);
+            && Objects.equal(customResultIndexTTL, config.customResultIndexTTL)
+            && Objects.equal(flattenResultIndexMapping, config.flattenResultIndexMapping);
     }
 
     @Generated
@@ -445,7 +452,8 @@ public abstract class Config implements Writeable, ToXContentObject {
                 historyIntervals,
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
     }
 
@@ -493,6 +501,9 @@ public abstract class Config implements Writeable, ToXContentObject {
         }
         if (customResultIndexTTL != null) {
             builder.field(RESULT_INDEX_FIELD_TTL, customResultIndexTTL);
+        }
+        if (flattenResultIndexMapping != null) {
+            builder.field(FLATTEN_RESULT_INDEX_MAPPING, flattenResultIndexMapping);
         }
         return builder;
     }
@@ -702,6 +713,10 @@ public abstract class Config implements Writeable, ToXContentObject {
         return customResultIndexTTL;
     }
 
+    public Boolean getFlattenResultIndexMapping() {
+        return flattenResultIndexMapping;
+    }
+
     /**
      * Identifies redundant feature names.
      *
@@ -756,6 +771,7 @@ public abstract class Config implements Writeable, ToXContentObject {
                 .append("customResultIndexMinSize", customResultIndexMinSize)
                 .append("customResultIndexMinAge", customResultIndexMinAge)
                 .append("customResultIndexTTL", customResultIndexTTL)
+                .append("flattenResultIndexMapping", flattenResultIndexMapping)
                 .toString();
     }
 }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -314,7 +314,8 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 null,
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
-                detector.getCustomResultIndexTTL()
+                detector.getCustomResultIndexTTL(),
+                detector.getFlattenResultIndexMapping()
             ),
             detectorJob,
             historicalAdTask,
@@ -640,7 +641,8 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             null,
             anomalyDetector.getCustomResultIndexMinSize(),
             anomalyDetector.getCustomResultIndexMinAge(),
-            anomalyDetector.getCustomResultIndexTTL()
+            anomalyDetector.getCustomResultIndexTTL(),
+            anomalyDetector.getFlattenResultIndexMapping()
         );
         return detector;
     }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -339,6 +339,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
+                    null,
                     null
                 )
             );
@@ -371,6 +372,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     randomIntBetween(1, 10000),
                     randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                     randomIntBetween(1, 1000),
+                    null,
                     null,
                     null,
                     null,
@@ -409,6 +411,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
+                    null,
                     null
                 )
             );
@@ -441,6 +444,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     randomIntBetween(1, 10000),
                     randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                     randomIntBetween(1, 1000),
+                    null,
                     null,
                     null,
                     null,
@@ -479,6 +483,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
+                    null,
                     null
                 )
             );
@@ -511,6 +516,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     randomIntBetween(1, 10000),
                     randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                     randomIntBetween(1, 1000),
+                    null,
                     null,
                     null,
                     null,
@@ -549,6 +555,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
+                    null,
                     null
                 )
             );
@@ -580,6 +587,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 -1,
                 randomIntBetween(1, 256),
                 randomIntBetween(1, 1000),
+                null,
                 null,
                 null,
                 null,
@@ -618,6 +626,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
+                null,
                 null
             )
         );
@@ -650,6 +659,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null, // emphasis is not customized
                 randomIntBetween(1, 256),
                 randomIntBetween(1, 1000),
+                null,
                 null,
                 null,
                 null,
@@ -701,6 +711,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
+            null,
             null
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
@@ -734,6 +745,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
+            null,
             null
         );
         // seasonalityIntervals is not null and custom shingle size is null, use seasonalityIntervals to deterine shingle size
@@ -761,6 +773,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -796,6 +809,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
+            null,
             null
         );
         assertNotNull(anomalyDetector.getFeatureAttributes());
@@ -825,6 +839,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             randomIntBetween(1, 10000),
             randomIntBetween(1, TimeSeriesSettings.MAX_SHINGLE_SIZE * TimeSeriesSettings.SEASONALITY_TO_SHINGLE_RATIO),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -914,6 +929,21 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[],\"result_index_ttl\":30}";
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
         assertEquals(30, (int) parsedDetector.getCustomResultIndexTTL());
+    }
+
+    public void testParseAnomalyDetector_withCustomIndex_withFlattenResultIndexMapping() throws IOException {
+        String detectorString = "{\"name\":\"AhtYYGWTgqkzairTchcs\",\"description\":\"iIiAVPMyFgnFlEniLbMyfJxyoGvJAl\","
+                + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
+                + "{\"field\":\"value\",\"boost\":1}}],\"adjust_pure_negative\":true,\"boost\":1}},\"window_delay\":"
+                + "{\"period\":{\"interval\":2,\"unit\":\"Minutes\"}},\"shingle_size\":8,\"schema_version\":-512063255,"
+                + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":false,"
+                + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
+                + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"result_index\":"
+                + "\"opensearch-ad-plugin-result-test\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"defaultFill\""
+                + ":[],\"integerSensitive\":false},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
+                + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[],\"flatten_result_index_mapping\":true}";
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
+        assertEquals(true, (boolean) parsedDetector.getFlattenResultIndexMapping());
     }
 
     public void testSerializeAndDeserializeAnomalyDetector() throws IOException {

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -933,15 +933,15 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
 
     public void testParseAnomalyDetector_withCustomIndex_withFlattenResultIndexMapping() throws IOException {
         String detectorString = "{\"name\":\"AhtYYGWTgqkzairTchcs\",\"description\":\"iIiAVPMyFgnFlEniLbMyfJxyoGvJAl\","
-                + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
-                + "{\"field\":\"value\",\"boost\":1}}],\"adjust_pure_negative\":true,\"boost\":1}},\"window_delay\":"
-                + "{\"period\":{\"interval\":2,\"unit\":\"Minutes\"}},\"shingle_size\":8,\"schema_version\":-512063255,"
-                + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":false,"
-                + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
-                + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"result_index\":"
-                + "\"opensearch-ad-plugin-result-test\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"defaultFill\""
-                + ":[],\"integerSensitive\":false},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
-                + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[],\"flatten_result_index_mapping\":true}";
+            + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
+            + "{\"field\":\"value\",\"boost\":1}}],\"adjust_pure_negative\":true,\"boost\":1}},\"window_delay\":"
+            + "{\"period\":{\"interval\":2,\"unit\":\"Minutes\"}},\"shingle_size\":8,\"schema_version\":-512063255,"
+            + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":false,"
+            + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
+            + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"result_index\":"
+            + "\"opensearch-ad-plugin-result-test\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"defaultFill\""
+            + ":[],\"integerSensitive\":false},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
+            + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[],\"flatten_result_index_mapping\":true}";
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
         assertEquals(true, (boolean) parsedDetector.getFlattenResultIndexMapping());
     }

--- a/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
+++ b/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
@@ -222,6 +222,7 @@ public class ADRestTestUtils {
             null,
             null,
             null,
+            null,
             null
         );
 

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -157,6 +157,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -268,6 +269,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         Exception ex = expectThrows(
@@ -331,6 +333,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -405,6 +408,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -450,6 +454,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -504,6 +509,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -875,6 +881,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
@@ -345,7 +345,8 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
             null,
             detector.getCustomResultIndexMinSize(),
             detector.getCustomResultIndexMinAge(),
-            detector.getCustomResultIndexTTL()
+            detector.getCustomResultIndexTTL(),
+            detector.getFlattenResultIndexMapping()
         );
     }
 

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -293,6 +293,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         // User client has admin all access, and has "opensearch" backend role so client should be able to update detector
@@ -344,6 +345,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -226,6 +226,7 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -253,6 +254,7 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
@@ -85,6 +85,7 @@ public class ForwardADTaskRequestTests extends OpenSearchSingleNodeTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         ForwardADTaskRequest request = new ForwardADTaskRequest(detector, null, null, null, null, Version.V_2_1_0);

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -402,6 +402,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             null,
             null,
+            null,
             null
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
@@ -446,6 +447,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
+++ b/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
@@ -477,24 +477,18 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
     }
 
     public void testParseNullCustomResultIndex_nullFlattenResultIndexMapping() throws IOException {
-        Forecaster forecaster = TestHelpers.ForecasterBuilder
-                .newInstance()
-                .setFlattenResultIndexMapping(null)
-                .build();
+        Forecaster forecaster = TestHelpers.ForecasterBuilder.newInstance().setFlattenResultIndexMapping(null).build();
         String forecasterString = TestHelpers
-                .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+            .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         LOG.info(forecasterString);
         Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
         assertEquals(forecaster, parsedForecaster);
     }
 
     public void testValidCustomResultIndex_withFlattenResultIndexMapping() throws IOException {
-        Forecaster forecaster = TestHelpers.ForecasterBuilder
-                .newInstance()
-                .setFlattenResultIndexMapping(true)
-                .build();
+        Forecaster forecaster = TestHelpers.ForecasterBuilder.newInstance().setFlattenResultIndexMapping(true).build();
         String forecasterString = TestHelpers
-                .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+            .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         LOG.info(forecasterString);
         Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
         assertEquals(forecaster, parsedForecaster);

--- a/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
+++ b/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
@@ -59,6 +59,7 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
     Integer customResultIndexMinSize = null;
     Integer customResultIndexMinAge = null;
     Integer customResultIndexTTL = null;
+    Boolean flattenResultIndexMapping = null;
 
     public void testForecasterConstructor() {
         ImputationOption imputationOption = TestHelpers.randomImputationOption(0);
@@ -88,7 +89,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             randomIntBetween(1, 1000),
             customResultIndexMinSize,
             customResultIndexMinAge,
-            customResultIndexTTL
+            customResultIndexTTL,
+            flattenResultIndexMapping
         );
 
         assertEquals(forecasterId, forecaster.getId());
@@ -141,7 +143,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         });
 
@@ -179,7 +182,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         });
 
@@ -217,7 +221,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         });
 
@@ -255,7 +260,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         });
 
@@ -293,7 +299,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         });
 
@@ -330,7 +337,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             randomIntBetween(1, 1000),
             customResultIndexMinSize,
             customResultIndexMinAge,
-            customResultIndexTTL
+            customResultIndexTTL,
+            flattenResultIndexMapping
         );
 
         assertEquals(resultIndex, forecaster.getCustomResultIndexOrAlias());
@@ -365,7 +373,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         });
 
@@ -462,6 +471,30 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             .build();
         String forecasterString = TestHelpers
             .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        LOG.info(forecasterString);
+        Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
+        assertEquals(forecaster, parsedForecaster);
+    }
+
+    public void testParseNullCustomResultIndex_nullFlattenResultIndexMapping() throws IOException {
+        Forecaster forecaster = TestHelpers.ForecasterBuilder
+                .newInstance()
+                .setFlattenResultIndexMapping(null)
+                .build();
+        String forecasterString = TestHelpers
+                .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        LOG.info(forecasterString);
+        Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
+        assertEquals(forecaster, parsedForecaster);
+    }
+
+    public void testValidCustomResultIndex_withFlattenResultIndexMapping() throws IOException {
+        Forecaster forecaster = TestHelpers.ForecasterBuilder
+                .newInstance()
+                .setFlattenResultIndexMapping(true)
+                .build();
+        String forecasterString = TestHelpers
+                .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         LOG.info(forecasterString);
         Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
         assertEquals(forecaster, parsedForecaster);

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -339,6 +339,7 @@ public class TestHelpers {
             new ArrayList<Rule>(),
             null,
             null,
+            null,
             null
         );
     }
@@ -388,6 +389,7 @@ public class TestHelpers {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -453,6 +455,7 @@ public class TestHelpers {
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -491,6 +494,7 @@ public class TestHelpers {
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -518,6 +522,7 @@ public class TestHelpers {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -554,6 +559,7 @@ public class TestHelpers {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -727,6 +733,7 @@ public class TestHelpers {
                 null,
                 null,
                 null,
+                null,
                 null
             );
         }
@@ -757,6 +764,7 @@ public class TestHelpers {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null,
@@ -1721,6 +1729,7 @@ public class TestHelpers {
         Integer customResultIndexMinSize;
         Integer customResultIndexMinAge;
         Integer customResultIndexTTL;
+        Boolean flattenResultIndexMapping;
 
         ForecasterBuilder() throws IOException {
             forecasterId = randomAlphaOfLength(10);
@@ -1745,6 +1754,7 @@ public class TestHelpers {
             customResultIndexMinSize = null;
             customResultIndexMinAge = null;
             customResultIndexTTL = null;
+            flattenResultIndexMapping = null;
         }
 
         public static ForecasterBuilder newInstance() throws IOException {
@@ -1851,6 +1861,11 @@ public class TestHelpers {
             return this;
         }
 
+        public ForecasterBuilder setFlattenResultIndexMapping(Boolean flattenResultIndexMapping) {
+            this.flattenResultIndexMapping = flattenResultIndexMapping;
+            return this;
+        }
+
         public ForecasterBuilder setNullImputationOption() {
             this.imputationOption = null;
             return this;
@@ -1887,7 +1902,8 @@ public class TestHelpers {
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL
+                customResultIndexTTL,
+                flattenResultIndexMapping
             );
         }
     }
@@ -1917,6 +1933,7 @@ public class TestHelpers {
             randomIntBetween(1, 1000),
             randomIntBetween(1, 128),
             randomIntBetween(1, 1000),
+            null,
             null,
             null,
             null


### PR DESCRIPTION
### Description
Add flatten_result_index_mapping field to Config

### Related Issues
https://github.com/opensearch-project/anomaly-detection/issues/1213

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
