### PR TITLE
Fix inference logic and standardize config index mapping

### DIFF
--- a/.github/workflows/long_running.yml
+++ b/.github/workflows/long_running.yml
@@ -1,0 +1,60 @@
+name: Run long running tests
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch
+
+  Run-Tests:
+    needs: Get-CI-Image-Tag
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # each test scenario (rule, hc, single_stream) is treated as a separate job.
+        test: [smoke]
+      fail-fast: false
+    concurrency:
+      # The concurrency setting is used to limit the concurrency of each test scenario group to ensure they do not run concurrently on the same machine.
+      group: ${{ github.workflow }}-${{ matrix.test }}
+    name: Run long running tests
+
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: --user root
+
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Checkout AD
+        uses: actions/checkout@v3
+
+      - name: Build and Run Tests
+        run: |
+          chown -R 1000:1000 `pwd`
+          case ${{ matrix.test }} in
+            smoke)
+              su `id -un 1000` -c "./gradlew integTest --tests 'org.opensearch.ad.e2e.SingleStreamSmokeIT' \
+                -Dtests.seed=B4BA12CCF1D9E825 -Dtests.security.manager=false \
+                -Dtests.jvm.argline='-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m' \
+                -Dtests.locale=ar-JO -Dtests.timezone=Asia/Samarkand -Dlong-running=true \
+                -Dtests.timeoutSuite=3600000!  -Dtest.logs=true"
+              ;;
+          esac

--- a/build.gradle
+++ b/build.gradle
@@ -360,6 +360,12 @@ integTest {
         }
     }
 
+    if (System.getProperty("long-running") == null || System.getProperty("long-running") == "false") {
+        filter {
+            excludeTestsMatching "org.opensearch.ad.e2e.SingleStreamSmokeIT"
+        }
+    }
+
     // The 'doFirst' delays till execution time.
     doFirst {
         // Tell the test JVM if the cluster JVM is running under a debugger so that tests can

--- a/src/main/java/org/opensearch/timeseries/dataprocessor/ImputationOption.java
+++ b/src/main/java/org/opensearch/timeseries/dataprocessor/ImputationOption.java
@@ -26,7 +26,7 @@ import org.opensearch.timeseries.model.Feature;
 public class ImputationOption implements Writeable, ToXContent {
     // field name in toXContent
     public static final String METHOD_FIELD = "method";
-    public static final String DEFAULT_FILL_FIELD = "defaultFill";
+    public static final String DEFAULT_FILL_FIELD = "default_fill";
 
     private final ImputationMethod method;
     private final Map<String, Double> defaultFill;
@@ -152,7 +152,7 @@ public class ImputationOption implements Writeable, ToXContent {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append("method", method).append("defaultFill", defaultFill).toString();
+        return new ToStringBuilder(this).append("method", method).append("default_fill", defaultFill).toString();
     }
 
     public ImputationMethod getMethod() {

--- a/src/main/java/org/opensearch/timeseries/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/timeseries/ml/ModelManager.java
@@ -169,6 +169,7 @@ public abstract class ModelManager<RCFModelType extends ThresholdedRandomCutFore
             throw e;
         } finally {
             modelState.setLastUsedTime(clock.instant());
+            modelState.setLastSeenExecutionEndTime(clock.instant());
         }
         return createEmptyResult();
     }

--- a/src/main/java/org/opensearch/timeseries/ml/ModelState.java
+++ b/src/main/java/org/opensearch/timeseries/ml/ModelState.java
@@ -36,6 +36,7 @@ public class ModelState<T> implements org.opensearch.timeseries.ExpiringState {
     // time when the ML model was used last time
     protected Instant lastUsedTime;
     protected Instant lastCheckpointTime;
+    protected Instant lastSeenExecutionEndTime;
     protected Clock clock;
     protected float priority;
     protected Deque<Sample> samples;
@@ -74,6 +75,7 @@ public class ModelState<T> implements org.opensearch.timeseries.ExpiringState {
         this.priority = priority;
         this.entity = entity;
         this.samples = samples;
+        this.lastSeenExecutionEndTime = Instant.MIN;
     }
 
     /**
@@ -248,5 +250,13 @@ public class ModelState<T> implements org.opensearch.timeseries.ExpiringState {
                 }
             }
         };
+    }
+
+    public Instant getLastSeenExecutionEndTime() {
+        return lastSeenExecutionEndTime;
+    }
+
+    public void setLastSeenExecutionEndTime(Instant lastSeenExecutionEndTime) {
+        this.lastSeenExecutionEndTime = lastSeenExecutionEndTime;
     }
 }

--- a/src/main/resources/mappings/config.json
+++ b/src/main/resources/mappings/config.json
@@ -174,7 +174,7 @@
                 "method": {
                     "type": "keyword"
                 },
-                "defaultFill": {
+                "default_fill": {
                     "type": "nested",
                     "properties": {
                         "feature_name": {

--- a/src/test/java/org/opensearch/ad/e2e/AbstractMissingSingleFeatureTestCase.java
+++ b/src/test/java/org/opensearch/ad/e2e/AbstractMissingSingleFeatureTestCase.java
@@ -66,7 +66,7 @@ public abstract class AbstractMissingSingleFeatureTestCase extends MissingIT {
             case FIXED_VALUES:
                 sb
                     .append(
-                        "\"imputation_option\": { \"method\": \"fixed_values\", \"defaultFill\": [{ \"feature_name\" : \"feature 1\", \"data\": 1 }] },"
+                        "\"imputation_option\": { \"method\": \"fixed_values\", \"default_fill\": [{ \"feature_name\" : \"feature 1\", \"data\": 1 }] },"
                     );
                 break;
         }
@@ -212,7 +212,7 @@ public abstract class AbstractMissingSingleFeatureTestCase extends MissingIT {
                 if (realTime) {
                     sourceList = getRealTimeAnomalyResult(detectorId, end, numberOfEntities, client());
                 } else {
-                    sourceList = getAnomalyResult(detectorId, end, numberOfEntities, client(), true, intervalMillis);
+                    sourceList = getAnomalyResultByDataTime(detectorId, end, numberOfEntities, client(), true, intervalMillis);
                 }
 
                 assertTrue(

--- a/src/test/java/org/opensearch/ad/e2e/HistoricalRuleModelPerfIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/HistoricalRuleModelPerfIT.java
@@ -106,7 +106,7 @@ public class HistoricalRuleModelPerfIT extends AbstractRuleModelPerfTestCase {
             Instant begin = Instant.ofEpochMilli(Long.parseLong(beginTimeStampAsString));
             Instant end = begin.plus(intervalMinutes, ChronoUnit.MINUTES);
             try {
-                List<JsonObject> sourceList = getAnomalyResult(detectorId, end, entitySize, client, true, intervalMillis);
+                List<JsonObject> sourceList = getAnomalyResultByDataTime(detectorId, end, entitySize, client, true, intervalMillis);
                 analyzeResults(anomalies, res, foundWindow, beginTimeStampAsString, entitySize, begin, sourceList);
             } catch (Exception e) {
                 errors++;

--- a/src/test/java/org/opensearch/ad/e2e/MissingMultiFeatureIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/MissingMultiFeatureIT.java
@@ -218,7 +218,7 @@ public class MissingMultiFeatureIT extends MissingIT {
             case FIXED_VALUES:
                 sb
                     .append(
-                        "\"imputation_option\": { \"method\": \"fixed_values\", \"defaultFill\": [{ \"feature_name\" : \"feature 1\", \"data\": 1 }, { \"feature_name\" : \"feature 2\", \"data\": 2 }] },"
+                        "\"imputation_option\": { \"method\": \"fixed_values\", \"default_fill\": [{ \"feature_name\" : \"feature 1\", \"data\": 1 }, { \"feature_name\" : \"feature 2\", \"data\": 2 }] },"
                     );
                 break;
         }

--- a/src/test/java/org/opensearch/ad/e2e/SingleStreamModelPerfIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/SingleStreamModelPerfIT.java
@@ -97,7 +97,6 @@ public class SingleStreamModelPerfIT extends AbstractADSyntheticDataTest {
             .from(DateTimeFormatter.ISO_INSTANT.parse(data.get(trainTestSplit - 1).get("timestamp").getAsString()));
         Instant dataEndTime = dataStartTime.plus(intervalMinutes, ChronoUnit.MINUTES);
         Instant trainTime = dataToExecutionTime(dataStartTime, windowDelay);
-        ;
         Instant executionStartTime = trainTime;
         Instant executionEndTime = executionStartTime.plus(intervalMinutes, ChronoUnit.MINUTES);
 
@@ -221,23 +220,5 @@ public class SingleStreamModelPerfIT extends AbstractADSyntheticDataTest {
             );
         Thread.sleep(1_000);
         waitAllSyncheticDataIngested(data.size(), datasetName, client);
-    }
-
-    protected long getWindowDelayMinutes(List<JsonObject> data, int trainTestSplit, String timestamp) {
-        // e.g., "2019-11-02T00:59:00Z"
-        String trainTimeStr = data.get(trainTestSplit - 1).get("timestamp").getAsString();
-        Instant trainTime = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(trainTimeStr));
-        /*
-         * The {@code CompositeRetriever.PageIterator.hasNext()} method checks if a request is expired
-         * relative to the current system time. This method is designed to ensure that the execution time
-         * is set to either the current time or a future time to prevent premature expirations in our tests.
-         *
-         * Also, AD accepts windowDelay in the unit of minutes. Thus, we need to convert the delay in minutes. This will
-         * make it easier to search for results based on data end time. Otherwise, real data time and the converted
-         * data time from request time.
-         * Assume x = real data time. y= real window delay. y'= window delay in minutes. If y and y' are different,
-         * x + y - y' != x.
-         */
-        return Duration.between(trainTime, Instant.now()).toMinutes();
     }
 }

--- a/src/test/java/org/opensearch/ad/e2e/SingleStreamSmokeIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/SingleStreamSmokeIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.e2e;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.ad.AbstractADSyntheticDataTest;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Test that is meant to run with job scheduler to test if we have at least consecutive results generated.
+ *
+ */
+public class SingleStreamSmokeIT extends AbstractADSyntheticDataTest {
+
+    public void testGenerateResult() throws Exception {
+        String datasetName = "synthetic";
+        String dataFileName = String.format(Locale.ROOT, "data/%s.data", datasetName);
+        int intervalsToWait = 3;
+
+        List<JsonObject> data = getData(dataFileName);
+
+        String mapping = "{ \"mappings\": { \"properties\": { \"timestamp\": { \"type\": \"date\"},"
+            + " \"Feature1\": { \"type\": \"double\" }, \"Feature2\": { \"type\": \"double\" } } } }";
+        int trainTestSplit = 1500;
+        // train data plus a few data points for real time inference
+        bulkIndexTrainData(datasetName, data, trainTestSplit + intervalsToWait + 3, client(), mapping);
+
+        long windowDelayMinutes = getWindowDelayMinutes(data, trainTestSplit - 1, "timestamp");
+        int intervalMinutes = 1;
+
+        // single-stream detector can use window delay 0 here because we give the run api the actual data time
+        String detector = String
+            .format(
+                Locale.ROOT,
+                "{ \"name\": \"test\", \"description\": \"test\", \"time_field\": \"timestamp\""
+                    + ", \"indices\": [\"%s\"], \"feature_attributes\": [{ \"feature_name\": \"feature 1\", \"feature_enabled\": "
+                    + "\"true\", \"aggregation_query\": { \"Feature1\": { \"sum\": { \"field\": \"Feature1\" } } } }, { \"feature_name\""
+                    + ": \"feature 2\", \"feature_enabled\": \"true\", \"aggregation_query\": { \"Feature2\": { \"sum\": { \"field\": "
+                    + "\"Feature2\" } } } }], \"detection_interval\": { \"period\": { \"interval\": %d, \"unit\": \"Minutes\" } }, "
+                    + "\"window_delay\": { \"period\": {\"interval\": %d, \"unit\": \"MINUTES\"}},"
+                    + "\"schema_version\": 0 }",
+                datasetName,
+                intervalMinutes,
+                windowDelayMinutes
+            );
+        String detectorId = createDetector(client(), detector);
+
+        startDetector(detectorId, client());
+
+        long waitMinutes = intervalMinutes * (intervalsToWait + 1);
+        // wait for scheduler to trigger AD
+        Thread.sleep(Duration.ofMinutes(waitMinutes));
+
+        List<JsonObject> results = getAnomalyResultByExecutionTime(
+            detectorId,
+            Instant.now(),
+            1,
+            client(),
+            true,
+            waitMinutes * 60000,
+            intervalsToWait
+        );
+
+        assertTrue(
+            String.format(Locale.ROOT, "Expect at least %d but got %d", intervalsToWait, results.size()),
+            results.size() >= intervalsToWait
+        );
+    }
+
+}

--- a/src/test/java/org/opensearch/ad/indices/RolloverTests.java
+++ b/src/test/java/org/opensearch/ad/indices/RolloverTests.java
@@ -304,7 +304,7 @@ public class RolloverTests extends AbstractTimeSeriesTest {
             + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":false,"
             + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
             + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"customResultIndexOrAlias\":"
-            + "\"\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"defaultFill\""
+            + "\"\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"default_fill\""
             + ":[],\"integerSensitive\":false},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
             + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[]}";
 

--- a/src/test/java/org/opensearch/timeseries/dataprocessor/ImputationOptionTests.java
+++ b/src/test/java/org/opensearch/timeseries/dataprocessor/ImputationOptionTests.java
@@ -41,7 +41,7 @@ public class ImputationOptionTests extends OpenSearchTestCase {
 
         xContent = "{"
             + "\"method\":\"FIXED_VALUES\","
-            + "\"defaultFill\":[{\"feature_name\":\"a\", \"data\":1.0},{\"feature_name\":\"b\", \"data\":2.0},{\"feature_name\":\"c\", \"data\":3.0}]}";
+            + "\"default_fill\":[{\"feature_name\":\"a\", \"data\":1.0},{\"feature_name\":\"b\", \"data\":2.0},{\"feature_name\":\"c\", \"data\":3.0}]}";
     }
 
     private Map<String, Double> randomMap(double[] defaultFill) {


### PR DESCRIPTION
### Description
This commit addresses several issues and improvements in the inference logic and config index mapping:

1. Fixes in RealTimeInferencer:

* Previously, we checked if the last update time of the model state was within the current interval and skipped inference if it was. However, this led to excessive skipping of inference because the last update time was updated when retrieving the model state from the cache.
* Introduced lastSeenExecutionEndTime in the model state, which specifically tracks the last time a sample was processed during inference (not training). This ensures more accurate control over when inference should be skipped.

2. Consistent Naming in Config Index Mapping:

* To maintain consistency across the codebase, changed defaultFill to default_fill in the Config index mapping, following the underscore naming convention used elsewhere.

3. Additional Null Checks:

* Added more null checks for the defaultFill field in the Config constructor to improve robustness.

Testing:
* Added a smoke test to allow the job scheduler to trigger anomaly detection inferencing, successfully reproducing and verifying the fix for item 1.
* added unit tests for item 3.

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
