### PR TITLE
Prevent resetting latest flag of real-time when starting historical analysis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -732,6 +732,8 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.task.ADBatchTaskCache',
         'org.opensearch.timeseries.ratelimit.RateLimitedRequestWorker',
         'org.opensearch.timeseries.util.TimeUtil',
+        'org.opensearch.ad.transport.ADHCImputeTransportAction',
+        'org.opensearch.timeseries.ml.RealTimeInferencer',
 ]
 
 

--- a/src/main/java/org/opensearch/forecast/task/ForecastTaskManager.java
+++ b/src/main/java/org/opensearch/forecast/task/ForecastTaskManager.java
@@ -459,7 +459,7 @@ public class ForecastTaskManager extends
     }
 
     @Override
-    public List<ForecastTaskType> getTaskTypes(DateRange dateRange, boolean resetLatestTaskStateFlag, boolean runOnce) {
+    public List<ForecastTaskType> getTaskTypes(DateRange dateRange, boolean runOnce) {
         if (runOnce) {
             return ForecastTaskType.RUN_ONCE_TASK_TYPES;
         } else {

--- a/src/main/java/org/opensearch/timeseries/ml/RealTimeInferencer.java
+++ b/src/main/java/org/opensearch/timeseries/ml/RealTimeInferencer.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.timeseries.ml;
 
-import java.time.Instant;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -135,16 +134,6 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
     }
 
     private boolean tryProcess(Sample sample, ModelState<RCFModelType> modelState, Config config, String taskId, long curExecutionEnd) {
-        // execution end time (when job starts execution in this interval) >= last seen execution end time => the model state is updated in
-        // previous intervals
-        // This branch being true can happen while scheduled to waiting some other threads have already scored the same interval
-        // (e.g., during tests when everything happens fast)
-        // We cannot use last used time as it will be updated whenever we update its priority in CacheBuffer.update when there is a
-        // PriorityCache.get.
-        if (modelState.getLastSeenExecutionEndTime() != Instant.MIN
-            && curExecutionEnd < modelState.getLastSeenExecutionEndTime().toEpochMilli()) {
-            return false;
-        }
         String modelId = modelState.getModelId();
         try {
             RCFResultType result = modelManager.getResult(sample, modelState, modelId, config, taskId);

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -193,9 +193,9 @@ public abstract class Config implements Writeable, ToXContentObject {
             return;
         }
 
-        if (recencyEmphasis != null && (recencyEmphasis <= 0)) {
+        if (recencyEmphasis != null && recencyEmphasis <= 1) {
             issueType = ValidationIssueType.RECENCY_EMPHASIS;
-            errorMessage = "recency emphasis has to be a positive integer";
+            errorMessage = "Recency emphasis must be an integer greater than 1.";
             return;
         }
 

--- a/src/test/java/org/opensearch/ad/e2e/AbstractRuleTestCase.java
+++ b/src/test/java/org/opensearch/ad/e2e/AbstractRuleTestCase.java
@@ -148,7 +148,7 @@ public abstract class AbstractRuleTestCase extends AbstractADSyntheticDataTest {
         long windowDelayMinutes = Duration.between(trainTime, Instant.now()).toMinutes();
 
         Duration windowDelay = Duration.ofMinutes(windowDelayMinutes);
-        return new TrainResult(null, data, rawDataTrainTestSplit, windowDelay, trainTime);
+        return new TrainResult(null, data, rawDataTrainTestSplit, windowDelay, trainTime, "timestamp");
     }
 
     public Map<String, List<Entry<Instant, Instant>>> getAnomalyWindowsMap(String labelFileName) throws Exception {

--- a/src/test/java/org/opensearch/ad/e2e/MissingIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/MissingIT.java
@@ -126,7 +126,7 @@ public abstract class MissingIT extends AbstractADSyntheticDataTest {
         String detectorId = createDetector(client, detector);
         LOG.info("Created detector {}", detectorId);
 
-        return new TrainResult(detectorId, data, trainTestSplit * numberOfEntities, windowDelay, trainTime);
+        return new TrainResult(detectorId, data, trainTestSplit * numberOfEntities, windowDelay, trainTime, "timestamp");
     }
 
     protected Duration getWindowDelay(long trainTimeMillis) {

--- a/src/test/java/org/opensearch/ad/e2e/MixedRealtimeHistoricalIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/MixedRealtimeHistoricalIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.e2e;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.ad.AbstractADSyntheticDataTest;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Test if real time and historical run together, historical won't reset real time's latest flag
+ *
+ */
+public class MixedRealtimeHistoricalIT extends AbstractADSyntheticDataTest {
+
+    public void testMixed() throws Exception {
+        String datasetName = "synthetic";
+        String dataFileName = String.format(Locale.ROOT, "data/%s.data", datasetName);
+        int intervalsToWait = 3;
+
+        List<JsonObject> data = getData(dataFileName);
+
+        String mapping = "{ \"mappings\": { \"properties\": { \"timestamp\": { \"type\": \"date\"},"
+            + " \"Feature1\": { \"type\": \"double\" }, \"Feature2\": { \"type\": \"double\" } } } }";
+        int trainTestSplit = 1500;
+        // train data plus a few data points for real time inference
+        int totalDataToIngest = trainTestSplit + intervalsToWait + 3;
+        bulkIndexTrainData(datasetName, data, totalDataToIngest, client(), mapping);
+
+        long windowDelayMinutes = getWindowDelayMinutes(data, trainTestSplit - 1, "timestamp");
+        int intervalMinutes = 1;
+
+        // single-stream detector can use window delay 0 here because we give the run api the actual data time
+        String detector = String
+            .format(
+                Locale.ROOT,
+                "{ \"name\": \"test\", \"description\": \"test\", \"time_field\": \"timestamp\""
+                    + ", \"indices\": [\"%s\"], \"feature_attributes\": [{ \"feature_name\": \"feature 1\", \"feature_enabled\": "
+                    + "\"true\", \"aggregation_query\": { \"Feature1\": { \"sum\": { \"field\": \"Feature1\" } } } }, { \"feature_name\""
+                    + ": \"feature 2\", \"feature_enabled\": \"true\", \"aggregation_query\": { \"Feature2\": { \"sum\": { \"field\": "
+                    + "\"Feature2\" } } } }], \"detection_interval\": { \"period\": { \"interval\": %d, \"unit\": \"Minutes\" } }, "
+                    + "\"window_delay\": { \"period\": {\"interval\": %d, \"unit\": \"MINUTES\"}},"
+                    + "\"schema_version\": 0 }",
+                datasetName,
+                intervalMinutes,
+                windowDelayMinutes
+            );
+        String detectorId = createDetector(client(), detector);
+
+        startDetector(detectorId, client());
+
+        startHistorical(
+            detectorId,
+            getDataTimeofISOFormat("timestamp", data, 0),
+            getDataTimeofISOFormat("timestamp", data, totalDataToIngest),
+            client(),
+            1
+        );
+
+        int size = 2;
+        List<JsonObject> results = getTasks(detectorId, size, (h, eSize) -> h.size() >= eSize, client());
+
+        assertEquals(String.format(Locale.ROOT, "Expected %d, but got %d", size, results.size()), size, results.size());
+        for (int i = 0; i < size; i++) {
+            assert (getLatest(results, i));
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -605,7 +605,7 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null
             )
         );
-        assertEquals("recency emphasis has to be a positive integer", exception.getMessage());
+        assertEquals("Recency emphasis must be an integer greater than 1.", exception.getMessage());
     }
 
     public void testInvalidDetectionInterval() {

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -331,7 +331,9 @@ public class TestHelpers {
             user,
             null,
             TestHelpers.randomImputationOption(features),
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomIntBetween(1, TimeSeriesSettings.MAX_SHINGLE_SIZE * 2),
             randomIntBetween(1, 1000),
             new ArrayList<Rule>(),
@@ -384,7 +386,9 @@ public class TestHelpers {
             null,
             resultIndex,
             TestHelpers.randomImputationOption(features),
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
             null,
@@ -448,7 +452,9 @@ public class TestHelpers {
             randomUser(),
             resultIndex,
             TestHelpers.randomImputationOption(features),
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
             null,
@@ -487,7 +493,9 @@ public class TestHelpers {
             randomUser(),
             null,
             TestHelpers.randomImputationOption(features),
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
             null,
@@ -518,7 +526,9 @@ public class TestHelpers {
             randomUser(),
             null,
             null,
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
             null,
@@ -556,7 +566,9 @@ public class TestHelpers {
             randomUser(),
             null,
             TestHelpers.randomImputationOption(featureList),
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
             null,
@@ -769,7 +781,9 @@ public class TestHelpers {
             randomUser(),
             null,
             TestHelpers.randomImputationOption(features),
-            randomIntBetween(1, 10000),
+            // timeDecay (reverse of recencyEmphasis) should be less than 1.
+            // so we start with 2.
+            randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
             null,


### PR DESCRIPTION
### Description
This PR addresses a bug where starting a historical analysis after a real-time analysis on the same detector caused the real-time task’s latest flag to be incorrectly reset to false by the historical run.

The fix ensures that only the latest flags of the same analysis type are reset:
* Real-time analysis will only reset the latest flag of previous real-time analyses.
* Historical analysis will only reset the latest flag of previous historical analyses.

Additional Changes:
* Set a minimum recencyEmphasis value of 2 to align with RCF requirements.
* Updated imputation logic to execute only when the entity maps to the local node ID in the hash ring, reducing errors when models of the same entity exist on multiple nodes.

Testing:
- Added an integration test to reproduce the bug and verified the fix.

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
