### PR TITLE
Adding remote index and multi-index checks in validation

### DIFF
--- a/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
@@ -76,7 +76,7 @@ public class CommonMessages {
     public static final String INDEX_NOT_FOUND = "index does not exist";
     public static final String FAIL_TO_GET_MAPPING_MSG = "Fail to get the index mapping of %s";
     public static final String FAIL_TO_GET_MAPPING = "Fail to get the index mapping";
-    public static final String TIMESTAMP_VALIDATION_FAILED = "Validation failed for timefield of %s ";
+    public static final String TIMESTAMP_VALIDATION_FAILED = "Validation failed for timefield of %s, ";
 
     public static final String FAIL_TO_GET_CONFIG_MSG = "Fail to get config";
 

--- a/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
+++ b/src/main/java/org/opensearch/timeseries/constant/CommonMessages.java
@@ -37,6 +37,7 @@ public class CommonMessages {
         "Result index name has invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore)";
     public static String FAIL_TO_VALIDATE = "failed to validate";
     public static String INVALID_TIMESTAMP = "Timestamp field: (%s) must be of type date";
+    public static String NON_EXISTENT_TIMESTAMP_IN_INDEX = "Timestamp field: (%s) is not found in the (%s) index mapping";
     public static String NON_EXISTENT_TIMESTAMP = "Timestamp field: (%s) is not found in index mapping";
     public static String INVALID_NAME = "Valid characters for name are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period)";
     // change this error message to make it compatible with old version's integration(nexus) test
@@ -74,6 +75,9 @@ public class CommonMessages {
         + " characters.";
     public static final String INDEX_NOT_FOUND = "index does not exist";
     public static final String FAIL_TO_GET_MAPPING_MSG = "Fail to get the index mapping of %s";
+    public static final String FAIL_TO_GET_MAPPING = "Fail to get the index mapping";
+    public static final String TIMESTAMP_VALIDATION_FAILED = "Validation failed for timefield of %s ";
+
     public static final String FAIL_TO_GET_CONFIG_MSG = "Fail to get config";
 
     // ======================================

--- a/src/main/java/org/opensearch/timeseries/rest/RestValidateAction.java
+++ b/src/main/java/org/opensearch/timeseries/rest/RestValidateAction.java
@@ -84,7 +84,6 @@ public class RestValidateAction {
     public ValidateConfigRequest prepareRequest(RestRequest request, NodeClient client, String typesStr) throws IOException {
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-
         // if type param isn't blank and isn't a part of possible validation types throws exception
         if (!StringUtils.isBlank(typesStr)) {
             if (!validationTypesAreAccepted(typesStr)) {

--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -377,15 +377,11 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
                 }
 
                 multiGetMappingResponseListener
-                    .onResponse(
-                        new MergeableList<Optional<double[]>>(
-                            new ArrayList<Optional<double[]>>(Collections.singletonList(Optional.empty()))
-                        )
-                    );
+                    .onResponse(new MergeableList<>(new ArrayList<>(Collections.singletonList(Optional.empty()))));
             }, e -> {
                 String errorMessage = String.format(Locale.ROOT, "Fail to get the index mapping of %s", clusterIndicesEntry.getValue());
                 logger.error(errorMessage, e);
-                multiGetMappingResponseListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.BAD_REQUEST, e));
+                multiGetMappingResponseListener.onFailure(new IllegalArgumentException(errorMessage, e));
             });
             clientUtil
                 .executeWithInjectedSecurity(

--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -7,21 +7,14 @@ package org.opensearch.timeseries.rest.handler;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.timeseries.constant.CommonMessages.CATEGORICAL_FIELD_TYPE_ERR_MSG;
+import static org.opensearch.timeseries.constant.CommonMessages.TIMESTAMP_VALIDATION_FAILED;
 import static org.opensearch.timeseries.util.ParseUtils.parseAggregators;
 import static org.opensearch.timeseries.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static org.opensearch.timeseries.util.RestHandlerUtils.isExceptionCausedByInvalidQuery;
 
 import java.io.IOException;
 import java.time.Clock;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
@@ -76,10 +69,7 @@ import org.opensearch.timeseries.model.ValidationAspect;
 import org.opensearch.timeseries.model.ValidationIssueType;
 import org.opensearch.timeseries.task.TaskCacheManager;
 import org.opensearch.timeseries.task.TaskManager;
-import org.opensearch.timeseries.util.MultiResponsesDelegateActionListener;
-import org.opensearch.timeseries.util.ParseUtils;
-import org.opensearch.timeseries.util.RestHandlerUtils;
-import org.opensearch.timeseries.util.SecurityClientUtil;
+import org.opensearch.timeseries.util.*;
 import org.opensearch.transport.TransportService;
 
 import com.google.common.collect.Sets;
@@ -241,7 +231,6 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             createOrUpdateConfig(listener);
             return;
         }
-
         if (this.isDryRun) {
             if (timeSeriesIndices.doesIndexExist(resultIndexOrAlias) || timeSeriesIndices.doesAliasExist(resultIndexOrAlias)) {
                 timeSeriesIndices
@@ -304,64 +293,110 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
 
     protected void validateTimeField(boolean indexingDryRun, ActionListener<T> listener) {
         String givenTimeField = config.getTimeField();
-        GetFieldMappingsRequest getMappingsRequest = new GetFieldMappingsRequest();
-        getMappingsRequest.indices(config.getIndices().toArray(new String[0])).fields(givenTimeField);
-        getMappingsRequest.indicesOptions(IndicesOptions.strictExpand());
+        HashMap<String, List<String>> clusterIndicesMap = CrossClusterConfigUtils
+            .separateClusterIndexes(config.getIndices(), clusterService);
 
-        // comments explaining fieldMappingResponse parsing can be found inside validateCategoricalField(String, boolean)
-        ActionListener<GetFieldMappingsResponse> mappingsListener = ActionListener.wrap(getMappingsResponse -> {
-            boolean foundField = false;
-            Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByIndex = getMappingsResponse.mappings();
+        ActionListener<MergeableList<Optional<double[]>>> validateGetMappingForTimeFieldListener = ActionListener.wrap(response -> {
+            prepareConfigIndexing(indexingDryRun, listener);
+        }, exception -> { listener.onFailure(createValidationException(exception.getMessage(), ValidationIssueType.TIMEFIELD_FIELD)); });
+        MultiResponsesDelegateActionListener<MergeableList<Optional<double[]>>> multiGetMappingResponseListener =
+            new MultiResponsesDelegateActionListener<>(
+                validateGetMappingForTimeFieldListener,
+                clusterIndicesMap.entrySet().size(),
+                String.format(Locale.ROOT, TIMESTAMP_VALIDATION_FAILED, config.getName()),
+                false
+            );
 
-            for (Map<String, GetFieldMappingsResponse.FieldMappingMetadata> mappingsByField : mappingsByIndex.values()) {
-                for (Map.Entry<String, GetFieldMappingsResponse.FieldMappingMetadata> field2Metadata : mappingsByField.entrySet()) {
-
-                    GetFieldMappingsResponse.FieldMappingMetadata fieldMetadata = field2Metadata.getValue();
-                    if (fieldMetadata != null) {
-                        // sourceAsMap returns sth like {host2={type=keyword}} with host2 being a nested field
-                        Map<String, Object> fieldMap = fieldMetadata.sourceAsMap();
-                        if (fieldMap != null) {
-                            for (Object type : fieldMap.values()) {
-                                if (type instanceof Map) {
-                                    foundField = true;
-                                    Map<String, Object> metadataMap = (Map<String, Object>) type;
-                                    String typeName = (String) metadataMap.get(CommonName.TYPE);
-                                    if (!typeName.equals(CommonName.DATE_TYPE) && !typeName.equals(CommonName.DATE_NANOS_TYPE)) {
-                                        listener
-                                            .onFailure(
-                                                new ValidationException(
-                                                    String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, givenTimeField),
-                                                    ValidationIssueType.TIMEFIELD_FIELD,
-                                                    configValidationAspect
-                                                )
-                                            );
-                                        return;
+        for (Map.Entry<String, List<String>> clusterIndicesEntry : clusterIndicesMap.entrySet()) {
+            GetFieldMappingsRequest getMappingsRequestForIndex = new GetFieldMappingsRequest();
+            getMappingsRequestForIndex.indices((clusterIndicesEntry.getValue().toArray(new String[0]))).fields(givenTimeField);
+            getMappingsRequestForIndex.indicesOptions(IndicesOptions.strictExpand());
+            Client targetClusterClient = CrossClusterConfigUtils.getClientForCluster(clusterIndicesEntry.getKey(), client, clusterService);
+            ActionListener<GetFieldMappingsResponse> getMappingResponseListener = ActionListener.wrap(getMappingsResponse -> {
+                boolean foundField = false;
+                Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByIndex = getMappingsResponse.mappings();
+                for (Map.Entry<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> mappingsByField : mappingsByIndex
+                    .entrySet()) {
+                    if (mappingsByField.getValue().isEmpty()) {
+                        multiGetMappingResponseListener
+                            .onFailure(
+                                new ValidationException(
+                                    String
+                                        .format(
+                                            Locale.ROOT,
+                                            CommonMessages.NON_EXISTENT_TIMESTAMP_IN_INDEX,
+                                            givenTimeField,
+                                            mappingsByField.getKey()
+                                        ),
+                                    ValidationIssueType.TIMEFIELD_FIELD,
+                                    configValidationAspect
+                                )
+                            );
+                        return;
+                    }
+                    for (Map.Entry<String, GetFieldMappingsResponse.FieldMappingMetadata> field2Metadata : mappingsByField
+                        .getValue()
+                        .entrySet()) {
+                        GetFieldMappingsResponse.FieldMappingMetadata fieldMetadata = field2Metadata.getValue();
+                        if (fieldMetadata != null) {
+                            // sourceAsMap returns sth like {host2={type=keyword}} with host2 being a nested field
+                            Map<String, Object> fieldMap = fieldMetadata.sourceAsMap();
+                            if (fieldMap != null) {
+                                for (Object type : fieldMap.values()) {
+                                    if (type instanceof Map) {
+                                        foundField = true;
+                                        Map<String, Object> metadataMap = (Map<String, Object>) type;
+                                        String typeName = (String) metadataMap.get(CommonName.TYPE);
+                                        if (!typeName.equals(CommonName.DATE_TYPE) && !typeName.equals(CommonName.DATE_NANOS_TYPE)) {
+                                            multiGetMappingResponseListener
+                                                .onFailure(
+                                                    new ValidationException(
+                                                        String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, givenTimeField),
+                                                        ValidationIssueType.TIMEFIELD_FIELD,
+                                                        configValidationAspect
+                                                    )
+                                                );
+                                            return;
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                 }
-            }
-            if (!foundField) {
-                listener
-                    .onFailure(
-                        new ValidationException(
-                            String.format(Locale.ROOT, CommonMessages.NON_EXISTENT_TIMESTAMP, givenTimeField),
-                            ValidationIssueType.TIMEFIELD_FIELD,
-                            configValidationAspect
+                if (!foundField) {
+                    multiGetMappingResponseListener
+                        .onFailure(
+                            new ValidationException(
+                                String.format(Locale.ROOT, CommonMessages.NON_EXISTENT_TIMESTAMP, givenTimeField),
+                                ValidationIssueType.TIMEFIELD_FIELD,
+                                configValidationAspect
+                            )
+                        );
+                    return;
+                }
+
+                multiGetMappingResponseListener
+                    .onResponse(
+                        new MergeableList<Optional<double[]>>(
+                            new ArrayList<Optional<double[]>>(Collections.singletonList(Optional.empty()))
                         )
                     );
-                return;
-            }
-            prepareConfigIndexing(indexingDryRun, listener);
-        }, error -> {
-            String message = String.format(Locale.ROOT, "Fail to get the index mapping of %s", config.getIndices());
-            logger.error(message, error);
-            listener.onFailure(new IllegalArgumentException(message));
-        });
-        clientUtil
-            .executeWithInjectedSecurity(GetFieldMappingsAction.INSTANCE, getMappingsRequest, user, client, context, mappingsListener);
+            }, e -> {
+                String errorMessage = String.format(Locale.ROOT, "Fail to get the index mapping of %s", clusterIndicesEntry.getValue());
+                logger.error(errorMessage, e);
+                multiGetMappingResponseListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.BAD_REQUEST, e));
+            });
+            clientUtil
+                .executeWithInjectedSecurity(
+                    GetFieldMappingsAction.INSTANCE,
+                    getMappingsRequestForIndex,
+                    user,
+                    targetClusterClient,
+                    context,
+                    getMappingResponseListener
+                );
+        }
     }
 
     /**
@@ -448,7 +483,6 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             QueryBuilder query = QueryBuilders.boolQuery().filter(QueryBuilders.existsQuery(Config.CATEGORY_FIELD));
 
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query).size(0).timeout(requestTimeout);
-
             SearchRequest searchRequest = new SearchRequest(CommonName.CONFIG_INDEX).source(searchSourceBuilder);
             client
                 .search(
@@ -460,7 +494,7 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
                         )
                 );
         } else {
-            validateCategoricalField(configId, indexingDryRun, listener);
+            validateCategoricalFieldsInAllIndices(configId, indexingDryRun, listener);
         }
 
     }
@@ -522,12 +556,33 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             }
             listener.onFailure(new IllegalArgumentException(errorMsg));
         } else {
-            validateCategoricalField(detectorId, indexingDryRun, listener);
+            validateCategoricalFieldsInAllIndices(detectorId, indexingDryRun, listener);
         }
     }
 
-    @SuppressWarnings("unchecked")
-    protected void validateCategoricalField(String configId, boolean indexingDryRun, ActionListener<T> listener) {
+    protected void validateCategoricalFieldsInAllIndices(String configId, boolean indexingDryRun, ActionListener<T> listener) {
+        HashMap<String, List<String>> clusterIndicesMap = CrossClusterConfigUtils
+            .separateClusterIndexes(config.getIndices(), clusterService);
+
+        Iterator<Map.Entry<String, List<String>>> iterator = clusterIndicesMap.entrySet().iterator();
+
+        validateCategoricalFieldRecursive(iterator, configId, indexingDryRun, listener);
+
+    }
+
+    protected void validateCategoricalFieldRecursive(
+        Iterator<Map.Entry<String, List<String>>> iterator,
+        String configId,
+        boolean indexingDryRun,
+        ActionListener<T> listener
+    ) {
+        if (!iterator.hasNext()) {
+            searchConfigInputIndices(configId, indexingDryRun, listener); // Call after all indices are validated
+            return;
+        }
+
+        // Get the next cluster indices entry
+        Map.Entry<String, List<String>> clusterIndicesEntry = iterator.next();
         List<String> categoryField = config.getCategoryFields();
 
         // categoryField should have at least 1 element. Otherwise, we won't reach here.
@@ -537,12 +592,16 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
         // throws validation exception before reaching here
 
         String categoryField0 = categoryField.get(0);
+        Client targetClusterClient = CrossClusterConfigUtils.getClientForCluster(clusterIndicesEntry.getKey(), client, clusterService);
+        // Create the GetFieldMappingsRequest for each index
+        GetFieldMappingsRequest getMappingsRequestForIndex = new GetFieldMappingsRequest();
+        getMappingsRequestForIndex
+            .indices(clusterIndicesEntry.getValue().toArray(new String[0]))
+            .fields(categoryField.toArray(new String[0]));
+        getMappingsRequestForIndex.indicesOptions(IndicesOptions.strictExpand());
 
-        GetFieldMappingsRequest getMappingsRequest = new GetFieldMappingsRequest();
-        getMappingsRequest.indices(config.getIndices().toArray(new String[0])).fields(categoryField.toArray(new String[0]));
-        getMappingsRequest.indicesOptions(IndicesOptions.strictExpand());
-
-        ActionListener<GetFieldMappingsResponse> mappingsListener = ActionListener.wrap(getMappingsResponse -> {
+        // Define the listener for each getMapping request
+        ActionListener<GetFieldMappingsResponse> getMappingsListener = ActionListener.wrap(getMappingsResponse -> {
             // example getMappingsResponse:
             // GetFieldMappingsResponse{mappings={server-metrics={_doc={service=FieldMappingMetadata{fullName='service',
             // source=org.opensearch.core.common.bytes.BytesArray@7ba87dbd}}}}}
@@ -596,18 +655,25 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
                     );
                 return;
             }
+            validateCategoricalFieldRecursive(iterator, configId, indexingDryRun, listener);
 
-            searchConfigInputIndices(configId, indexingDryRun, listener);
         }, error -> {
             String message = String.format(Locale.ROOT, CommonMessages.FAIL_TO_GET_MAPPING_MSG, config.getIndices());
             logger.error(message, error);
             listener.onFailure(new IllegalArgumentException(message));
         });
-
         clientUtil
-            .executeWithInjectedSecurity(GetFieldMappingsAction.INSTANCE, getMappingsRequest, user, client, context, mappingsListener);
+            .executeWithInjectedSecurity(
+                GetFieldMappingsAction.INSTANCE,
+                getMappingsRequestForIndex,
+                user,
+                targetClusterClient,
+                context,
+                getMappingsListener
+            );
     }
 
+    @SuppressWarnings("unchecked")
     protected void searchConfigInputIndices(String configId, boolean indexingDryRun, ActionListener<T> listener) {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
             .query(QueryBuilders.matchAllQuery())

--- a/src/main/java/org/opensearch/timeseries/transport/BaseValidateConfigTransportAction.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BaseValidateConfigTransportAction.java
@@ -8,10 +8,7 @@ package org.opensearch.timeseries.transport;
 import static org.opensearch.timeseries.util.ParseUtils.checkFilterByBackendRoles;
 
 import java.time.Clock;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -205,7 +202,6 @@ public abstract class BaseValidateConfigTransportAction<IndexType extends Enum<I
         storedContext.restore();
         Config config = request.getConfig();
         ActionListener<ValidateConfigResponse> validateListener = ActionListener.wrap(response -> {
-            logger.debug("Result of validation process " + response);
             // forcing response to be empty
             listener.onResponse(new ValidateConfigResponse((ConfigValidationIssue) null));
         }, exception -> {

--- a/src/main/java/org/opensearch/timeseries/util/CrossClusterConfigUtils.java
+++ b/src/main/java/org/opensearch/timeseries/util/CrossClusterConfigUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.timeseries.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+
+public class CrossClusterConfigUtils {
+    private static final Logger logger = LogManager.getLogger(ParseUtils.class);
+
+    /**
+     * Uses the clusterName to determine whether the target client is the local or a remote client,
+     * and returns the appropriate client.
+     * @param clusterName The name of the cluster to evaluate.
+     * @param client The local {@link NodeClient}.
+     * @param localClusterName The name of the local cluster.
+     * @return The local {@link NodeClient} for the local cluster, or a remote client for a remote cluster.
+     */
+    public static Client getClientForCluster(String clusterName, Client client, String localClusterName) {
+        return clusterName.equals(localClusterName) ? client : client.getRemoteClusterClient(clusterName);
+    }
+
+    /**
+     * Uses the clusterName to determine whether the target client is the local or a remote client,
+     * and returns the appropriate client.
+     * @param clusterName The name of the cluster to evaluate.
+     * @param client The local {@link NodeClient}.
+     * @param clusterService Used to retrieve the name of the local cluster.
+     * @return The local {@link NodeClient} for the local cluster, or a remote client for a remote cluster.
+     */
+    public static Client getClientForCluster(String clusterName, Client client, ClusterService clusterService) {
+        logger.info("clusterName1: " + clusterName);
+        logger.info("clusterService.getClusterName().value(): " + clusterService.getClusterName().value());
+
+        return getClientForCluster(clusterName, client, clusterService.getClusterName().value());
+    }
+
+    /**
+     * Parses the list of indexes into a map of cluster_name to List of index names
+     * @param indexes A list of index names in cluster_name:index_name format.
+     *      Local indexes can also be in index_name format.
+     * @param clusterService Used to retrieve the name of the local cluster.
+     * @return A map of cluster_name:index names
+     */
+    public static HashMap<String, List<String>> separateClusterIndexes(List<String> indexes, ClusterService clusterService) {
+        return separateClusterIndexes(indexes, clusterService.getClusterName().value());
+    }
+
+    /**
+     * Parses the list of indexes into a map of cluster_name to list of index_name
+     * @param indexes A list of index names in cluster_name:index_name format.
+     * @param localClusterName The name of the local cluster.
+     * @return A map of cluster_name to List index_name
+     */
+    public static HashMap<String, List<String>> separateClusterIndexes(List<String> indexes, String localClusterName) {
+        HashMap<String, List<String>> output = new HashMap<>();
+        for (String index : indexes) {
+            String clusterName = parseClusterName(index);
+            String indexName = parseIndexName(index);
+
+            // If the index entry does not have a cluster_name, it indicates the index is on the local cluster.
+            if (clusterName.isEmpty()) {
+                clusterName = localClusterName;
+            }
+            output.computeIfAbsent(clusterName, k -> new ArrayList<>()).add(indexName);
+        }
+        return output;
+    }
+
+    /**
+     * @param index The name of the index to evaluate.
+     *      Can be in either cluster_name:index_name or index_name format.
+     * @return The index name.
+     */
+    public static String parseIndexName(String index) {
+        if (index.contains(":")) {
+            String[] parts = index.split(":");
+            return parts.length > 1 ? parts[1] : index;
+        } else {
+            return index;
+        }
+    }
+
+    /**
+     * @param index The name of the index to evaluate.
+     *      Can be in either cluster_name:index_name or index_name format.
+     * @return The index name.
+     */
+    public static String parseClusterName(String index) {
+        return index.contains(":") ? index.substring(0, index.indexOf(':')) : "";
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/util/MultiResponsesDelegateActionListener.java
+++ b/src/main/java/org/opensearch/timeseries/util/MultiResponsesDelegateActionListener.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.timeseries.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/main/java/org/opensearch/timeseries/util/MultiResponsesDelegateActionListener.java
+++ b/src/main/java/org/opensearch/timeseries/util/MultiResponsesDelegateActionListener.java
@@ -11,8 +11,6 @@
 
 package org.opensearch.timeseries.util;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/AbstractForecasterActionHandlerTestCase.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/AbstractForecasterActionHandlerTestCase.java
@@ -73,6 +73,8 @@ public class AbstractForecasterActionHandlerTestCase extends AbstractTimeSeriesT
     protected ThreadContext threadContext;
     protected SecurityClientUtil clientUtil;
     protected String categoricalField;
+    // @Mock
+    protected ClusterName clusterName;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -85,6 +87,9 @@ public class AbstractForecasterActionHandlerTestCase extends AbstractTimeSeriesT
 
         clusterService = mock(ClusterService.class);
         ClusterName clusterName = new ClusterName("test");
+        clusterName = mock(ClusterName.class);
+        when(clusterService.getClusterName()).thenReturn(clusterName);
+        when(clusterName.value()).thenReturn("test");
         ClusterState clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().build()).build();
         when(clusterService.state()).thenReturn(clusterState);
 

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -100,6 +100,7 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractTimeSeriesTe
     private RestRequest.Method method;
     private ADTaskManager adTaskManager;
     private SearchFeatureDao searchFeatureDao;
+    private ClusterName clusterName;
 
     @BeforeClass
     public static void beforeClass() {
@@ -156,6 +157,10 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractTimeSeriesTe
         adTaskManager = mock(ADTaskManager.class);
 
         searchFeatureDao = mock(SearchFeatureDao.class);
+
+        clusterName = mock(ClusterName.class);
+        when(clusterService.getClusterName()).thenReturn(clusterName);
+        when(clusterName.value()).thenReturn("test");
 
         handler = new IndexAnomalyDetectorActionHandler(
             clusterService,

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexForecasterActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexForecasterActionHandlerTests.java
@@ -40,6 +40,7 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.routing.AllocationId;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
@@ -240,7 +241,7 @@ public class IndexForecasterActionHandlerTests extends AbstractForecasterActionH
         verify(clientSpy, times(1)).execute(eq(GetAction.INSTANCE), any(), any());
     }
 
-    public void testFaiToParse() throws InterruptedException {
+    public void testFailToParse() throws InterruptedException {
         NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -273,6 +274,9 @@ public class IndexForecasterActionHandlerTests extends AbstractForecasterActionH
             }
         };
         NodeClient clientSpy = spy(client);
+        clusterName = mock(ClusterName.class);
+        when(clusterService.getClusterName()).thenReturn(clusterName);
+        when(clusterName.value()).thenReturn("test");
 
         method = RestRequest.Method.PUT;
 
@@ -508,6 +512,9 @@ public class IndexForecasterActionHandlerTests extends AbstractForecasterActionH
             }
         };
         NodeClient clientSpy = spy(client);
+        clusterName = mock(ClusterName.class);
+        when(clusterService.getClusterName()).thenReturn(clusterName);
+        when(clusterName.value()).thenReturn("test");
 
         method = RestRequest.Method.POST;
 

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateAnomalyDetectorActionHandlerTests.java
@@ -43,6 +43,7 @@ import org.opensearch.ad.task.ADTaskCacheManager;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -91,6 +92,7 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractTimeSerie
     @Mock
     protected ThreadPool threadPool;
     protected ThreadContext threadContext;
+    protected ClusterName mockClusterName;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -106,7 +108,9 @@ public class ValidateAnomalyDetectorActionHandlerTests extends AbstractTimeSerie
 
         anomalyDetectionIndices = mock(ADIndexManagement.class);
         when(anomalyDetectionIndices.doesConfigIndexExist()).thenReturn(true);
-
+        mockClusterName = mock(ClusterName.class);
+        when(clusterService.getClusterName()).thenReturn(mockClusterName);
+        when(mockClusterName.value()).thenReturn("test");
         detectorId = "123";
         seqNo = 0L;
         primaryTerm = 0L;

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateForecasterActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/ValidateForecasterActionHandlerTests.java
@@ -22,6 +22,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.forecast.rest.handler.ValidateForecasterActionHandler;
+import org.opensearch.timeseries.common.exception.ValidationException;
 import org.opensearch.timeseries.model.ValidationAspect;
 
 public class ValidateForecasterActionHandlerTests extends AbstractForecasterActionHandlerTestCase {
@@ -100,7 +101,7 @@ public class ValidateForecasterActionHandlerTests extends AbstractForecasterActi
             assertTrue("should not reach here", false);
             inProgressLatch.countDown();
         }, e -> {
-            assertTrue(e instanceof IllegalArgumentException);
+            assertTrue(e instanceof ValidationException);
             inProgressLatch.countDown();
         }));
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -490,9 +490,11 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         ValidateConfigResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
         assertEquals(ValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertEquals(
-            String.format(Locale.ROOT, CommonMessages.NON_EXISTENT_TIMESTAMP, anomalyDetector.getTimeField()),
-            response.getIssue().getMessage()
+        assertTrue(
+            response
+                .getIssue()
+                .getMessage()
+                .contains(String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()))
         );
     }
 
@@ -513,9 +515,11 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         ValidateConfigResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
         assertEquals(ValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
-        assertEquals(
-            String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()),
-            response.getIssue().getMessage()
+        assertTrue(
+            response
+                .getIssue()
+                .getMessage()
+                .contains(String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()))
         );
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -491,10 +491,7 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertEquals(ValidationIssueType.TIMEFIELD_FIELD, response.getIssue().getType());
         assertEquals(ValidationAspect.DETECTOR, response.getIssue().getAspect());
         assertTrue(
-            response
-                .getIssue()
-                .getMessage()
-                .contains(String.format(Locale.ROOT, CommonMessages.INVALID_TIMESTAMP, anomalyDetector.getTimeField()))
+            response.getIssue().getMessage().contains("Timestamp field: (" + anomalyDetector.getTimeField() + ") is not found in the")
         );
     }
 

--- a/src/test/java/org/opensearch/timeseries/util/CrossClusterConfigUtilsTests.java
+++ b/src/test/java/org/opensearch/timeseries/util/CrossClusterConfigUtilsTests.java
@@ -1,14 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.timeseries.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import org.mockito.Mock;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
 import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterName;
@@ -17,50 +26,50 @@ import org.opensearch.test.OpenSearchTestCase;
 
 public class CrossClusterConfigUtilsTests extends OpenSearchTestCase {
 
-    @Mock
-    private Client clientMock;
+    private Client mockClient;
+    private String remoteClusterName;
+    private String localClusterName;
+
+    @Before
+    public void setup() {
+        // Initialize the mock clients
+        mockClient = mock(NodeClient.class);
+        localClusterName = "localCluster";
+        remoteClusterName = "remoteCluster";
+    }
 
     public void testGetClientForClusterLocalCluster() {
-        String clusterName = "localCluster";
-        Client mockClient = mock(NodeClient.class);
-        String localClusterName = "localCluster";
-
-        Client result = CrossClusterConfigUtils.getClientForCluster(clusterName, mockClient, localClusterName);
-
+        Client result = CrossClusterConfigUtils.getClientForCluster(localClusterName, mockClient, localClusterName);
         assertEquals(mockClient, result);
+        verify(mockClient, never()).getRemoteClusterClient(anyString());
     }
 
     public void testGetClientForClusterRemoteCluster() {
-        String clusterName = "remoteCluster";
         Client mockClient = mock(NodeClient.class);
-        // Client mockRemoteClient = mock(Client.class);
+        CrossClusterConfigUtils.getClientForCluster(remoteClusterName, mockClient, localClusterName);
 
-        when(mockClient.getRemoteClusterClient(clusterName)).thenReturn(mockClient);
-
-        Client result = CrossClusterConfigUtils.getClientForCluster(clusterName, mockClient, "localCluster");
-
-        assertEquals(mockClient, result);
+        // Verify that getRemoteClusterClient was called once with the correct cluster name
+        verify(mockClient, times(1)).getRemoteClusterClient("remoteCluster");
+        when(mockClient.getRemoteClusterClient(remoteClusterName)).thenReturn(mockClient);
     }
 
     public void testSeparateClusterIndexesRemoteCluster() {
-        List<String> indexes = Arrays.asList("remoteCluster:index1", "index2");
+        List<String> indexes = Arrays.asList("remoteCluster:index1", "index2", "remoteCluster2:index2");
         ClusterService mockClusterService = mock(ClusterService.class);
         when(mockClusterService.getClusterName()).thenReturn(new ClusterName("localCluster"));
 
         HashMap<String, List<String>> result = CrossClusterConfigUtils.separateClusterIndexes(indexes, mockClusterService);
 
-        assertEquals(2, result.size());
+        assertEquals(3, result.size());
         assertEquals(Arrays.asList("index1"), result.get("remoteCluster"));
         assertEquals(Arrays.asList("index2"), result.get("localCluster"));
+        assertEquals(Arrays.asList("index2"), result.get("remoteCluster2"));
     }
 
-    public void testParseIndexName() {
-        assertEquals("index1", CrossClusterConfigUtils.parseIndexName("remoteCluster:index1"));
-        assertEquals("index2", CrossClusterConfigUtils.parseIndexName("index2"));
-    }
-
-    public void testParseClusterName() {
-        assertEquals("remoteCluster", CrossClusterConfigUtils.parseClusterName("remoteCluster:index1"));
-        assertEquals("", CrossClusterConfigUtils.parseClusterName("index2"));
+    public void testParseClusterAndIndexName_WithClusterAndIndex() {
+        String input = "clusterA:index1";
+        Pair<String, String> result = CrossClusterConfigUtils.parseClusterAndIndexName(input);
+        assertEquals("clusterA", result.getKey());
+        assertEquals("index1", result.getValue());
     }
 }

--- a/src/test/java/org/opensearch/timeseries/util/CrossClusterConfigUtilsTests.java
+++ b/src/test/java/org/opensearch/timeseries/util/CrossClusterConfigUtilsTests.java
@@ -1,0 +1,66 @@
+package org.opensearch.timeseries.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.mockito.Mock;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class CrossClusterConfigUtilsTests extends OpenSearchTestCase {
+
+    @Mock
+    private Client clientMock;
+
+    public void testGetClientForClusterLocalCluster() {
+        String clusterName = "localCluster";
+        Client mockClient = mock(NodeClient.class);
+        String localClusterName = "localCluster";
+
+        Client result = CrossClusterConfigUtils.getClientForCluster(clusterName, mockClient, localClusterName);
+
+        assertEquals(mockClient, result);
+    }
+
+    public void testGetClientForClusterRemoteCluster() {
+        String clusterName = "remoteCluster";
+        Client mockClient = mock(NodeClient.class);
+        // Client mockRemoteClient = mock(Client.class);
+
+        when(mockClient.getRemoteClusterClient(clusterName)).thenReturn(mockClient);
+
+        Client result = CrossClusterConfigUtils.getClientForCluster(clusterName, mockClient, "localCluster");
+
+        assertEquals(mockClient, result);
+    }
+
+    public void testSeparateClusterIndexesRemoteCluster() {
+        List<String> indexes = Arrays.asList("remoteCluster:index1", "index2");
+        ClusterService mockClusterService = mock(ClusterService.class);
+        when(mockClusterService.getClusterName()).thenReturn(new ClusterName("localCluster"));
+
+        HashMap<String, List<String>> result = CrossClusterConfigUtils.separateClusterIndexes(indexes, mockClusterService);
+
+        assertEquals(2, result.size());
+        assertEquals(Arrays.asList("index1"), result.get("remoteCluster"));
+        assertEquals(Arrays.asList("index2"), result.get("localCluster"));
+    }
+
+    public void testParseIndexName() {
+        assertEquals("index1", CrossClusterConfigUtils.parseIndexName("remoteCluster:index1"));
+        assertEquals("index2", CrossClusterConfigUtils.parseIndexName("index2"));
+    }
+
+    public void testParseClusterName() {
+        assertEquals("remoteCluster", CrossClusterConfigUtils.parseClusterName("remoteCluster:index1"));
+        assertEquals("", CrossClusterConfigUtils.parseClusterName("index2"));
+    }
+}


### PR DESCRIPTION
### Description
Adds ability to validate multiple indices/aliases and remote indices during validation, rest of the remote indexing feature actually works out of the box on any search action that is done. 
1. Validation for timefield works based on the fact that all indices given should have the given timestamp or we fail
2. Validation for categorical field is similar that we required all indices to have the given categorical field

Tasks left over:
- Writing a few more integ tests and fixing one more broken unit tests

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
