### PR TITLE
Passing user to getLatestDataTime call

### DIFF
--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -105,7 +105,7 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
 
     public static final String NAME_REGEX = "[a-zA-Z0-9._-]+";
     public static final Integer MAX_NAME_SIZE = 64;
-    public static final String CATEGORY_NOT_FOUND_ERR_MSG = "Can't find the categorical field %s";
+    public static final String CATEGORY_NOT_FOUND_ERR_MSG = "Can't find the categorical field %s in index %s";
 
     public static String INVALID_NAME_SIZE = "Name should be shortened. The maximum limit is "
         + AbstractTimeSeriesActionHandler.MAX_NAME_SIZE
@@ -562,11 +562,11 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
 
         Iterator<Map.Entry<String, List<String>>> iterator = clusterIndicesMap.entrySet().iterator();
 
-        validateCategoricalFieldRecursive(iterator, configId, indexingDryRun, listener);
+        validateCategoricalField(iterator, configId, indexingDryRun, listener);
 
     }
 
-    protected void validateCategoricalFieldRecursive(
+    protected void validateCategoricalField(
         Iterator<Map.Entry<String, List<String>>> iterator,
         String configId,
         boolean indexingDryRun,
@@ -645,13 +645,19 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
                 listener
                     .onFailure(
                         createValidationException(
-                            String.format(Locale.ROOT, CATEGORY_NOT_FOUND_ERR_MSG, categoryField0),
+                            String
+                                .format(
+                                    Locale.ROOT,
+                                    CATEGORY_NOT_FOUND_ERR_MSG,
+                                    categoryField0,
+                                    Arrays.toString(clusterIndicesEntry.getValue().toArray(new String[0]))
+                                ),
                             ValidationIssueType.CATEGORY
                         )
                     );
                 return;
             }
-            validateCategoricalFieldRecursive(iterator, configId, indexingDryRun, listener);
+            validateCategoricalField(iterator, configId, indexingDryRun, listener);
 
         }, error -> {
             String message = String.format(Locale.ROOT, CommonMessages.FAIL_TO_GET_MAPPING_MSG, config.getIndices());

--- a/src/main/java/org/opensearch/timeseries/rest/handler/IntervalCalculation.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/IntervalCalculation.java
@@ -243,7 +243,6 @@ public class IntervalCalculation {
      * interval can be a practical approach in scenarios where data arrival is irregular and there's
      * a need to balance between capturing data features and avoiding over-sampling.
      *
-     * @param topEntity top entity to use
      * @param timeStampBounds Used to determine start and end date range to search for data
      * @param listener returns minimum interval
      */

--- a/src/main/java/org/opensearch/timeseries/rest/handler/LatestTimeRetriever.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/LatestTimeRetriever.java
@@ -81,7 +81,7 @@ public class LatestTimeRetriever {
      * @param listener to return latest time and entity attributes if the config is HC
      */
     public void checkIfHC(ActionListener<Pair<Optional<Long>, Map<String, Object>>> listener) {
-        searchFeatureDao.getLatestDataTime(config, Optional.empty(), context, ActionListener.wrap(latestTime -> {
+        searchFeatureDao.getLatestDataTime(user, config, Optional.empty(), context, ActionListener.wrap(latestTime -> {
             if (latestTime.isEmpty()) {
                 listener.onResponse(Pair.of(Optional.empty(), Collections.emptyMap()));
             } else if (config.isHighCardinality()) {

--- a/src/main/java/org/opensearch/timeseries/rest/handler/ModelValidationActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/ModelValidationActionHandler.java
@@ -147,8 +147,8 @@ public class ModelValidationActionHandler {
                     latestEntityAttributes.getRight()
                 ),
                 exception -> {
-                    listener.onFailure(exception);
                     logger.error("Failed to create search request for last data point", exception);
+                    listener.onFailure(exception);
                 }
             );
         latestTimeRetriever.checkIfHC(latestTimeListener);

--- a/src/main/java/org/opensearch/timeseries/util/CrossClusterConfigUtils.java
+++ b/src/main/java/org/opensearch/timeseries/util/CrossClusterConfigUtils.java
@@ -67,8 +67,6 @@ public class CrossClusterConfigUtils {
             Pair<String, String> clusterAndIndex = parseClusterAndIndexName(index);
             String clusterName = clusterAndIndex.getKey();
             String indexName = clusterAndIndex.getValue();
-            logger.info("clusterName: " + clusterName);
-            logger.info("indexName: " + indexName);
 
             // If the index entry does not have a cluster_name, it indicates the index is on the local cluster.
             if (clusterName.isEmpty()) {

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1643,7 +1643,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             .extractValue("detector", responseMap);
         assertEquals(
             "non-existing category",
-            String.format(Locale.ROOT, AbstractTimeSeriesActionHandler.CATEGORY_NOT_FOUND_ERR_MSG, "host.keyword"),
+            String.format(Locale.ROOT, AbstractTimeSeriesActionHandler.CATEGORY_NOT_FOUND_ERR_MSG, "host.keyword", "[index-test]"),
             messageMap.get("category_field").get("message")
         );
 

--- a/src/test/java/org/opensearch/forecast/rest/ForecastRestApiIT.java
+++ b/src/test/java/org/opensearch/forecast/rest/ForecastRestApiIT.java
@@ -1709,7 +1709,7 @@ public class ForecastRestApiIT extends AbstractForecastSyntheticDataTest {
         assertEquals("Validate forecaster model failed", RestStatus.OK, TestHelpers.restStatus(response));
         responseMap = entityAsMap(response);
         validations = (Map<String, Object>) ((Map<String, Object>) responseMap.get("forecaster")).get("category_field");
-        assertEquals("Can't find the categorical field 476465", validations.get("message"));
+        assertEquals("Can't find the categorical field 476465 in index [rule]", validations.get("message"));
 
         // case 3: validate data sparsity with one categorical field
         forecasterDef = "{\n"


### PR DESCRIPTION
### Description
Changed getLatestDataTime so we pass the correct user so we have the right user info when querying remote indices, otherwise we get a failure like: 
```
nested: RemoteTransportException[[35692e6c255f][172.22.0.4:9300][indices:data/read/search]]; nested: OpenSearchSecurityException[No user found for indices:data/read/search];
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
