### PR TITLE
Fix Security Tests After Changes to Permissions Requirements

### DIFF
--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -61,6 +61,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
     RestClient lionClient;
     private String indexAllAccessRole = "index_all_access";
     private String indexSearchAccessRole = "index_all_search";
+    String oceanUser = "ocean";
+    RestClient oceanClient;
 
     /**
      * Create an unguessable password. Simple password are weak due to https://tinyurl.com/383em9zk
@@ -156,7 +158,13 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             .setSocketTimeout(60000)
             .build();
 
-        createRoleMapping("anomaly_read_access", new ArrayList<>(Arrays.asList(bobUser)));
+        String oceanPassword = generatePassword(oceanUser);
+        createUser(oceanUser, elkPassword, new ArrayList<>(Arrays.asList("odfe")));
+        oceanClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), oceanUser, oceanPassword)
+            .setSocketTimeout(60000)
+            .build();
+
+        createRoleMapping("anomaly_read_access", new ArrayList<>(Arrays.asList(bobUser, oceanUser)));
         createRoleMapping("anomaly_full_access", new ArrayList<>(Arrays.asList(aliceUser, catUser, dogUser, elkUser, fishUser, goatUser)));
         createRoleMapping(indexAllAccessRole, new ArrayList<>(Arrays.asList(aliceUser, bobUser, catUser, dogUser, fishUser, lionUser)));
         createRoleMapping(indexSearchAccessRole, new ArrayList<>(Arrays.asList(goatUser)));
@@ -172,6 +180,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         fishClient.close();
         goatClient.close();
         lionClient.close();
+        oceanClient.close();
         deleteUser(aliceUser);
         deleteUser(bobUser);
         deleteUser(catUser);
@@ -180,6 +189,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         deleteUser(fishUser);
         deleteUser(goatUser);
         deleteUser(lionUser);
+        deleteUser(oceanUser);
     }
 
     public void testCreateAnomalyDetectorWithWriteAccess() throws IOException {
@@ -416,8 +426,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         AnomalyDetector anomalyDetector = createRandomAnomalyDetector(false, false, aliceClient);
         // User elk has AD full access, but has no read permission of index
         String indexName = anomalyDetector.getIndices().get(0);
-        Exception exception = expectThrows(IOException.class, () -> { createRandomAnomalyDetector(false, false, indexName, elkClient); });
-        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
+        Exception exception = expectThrows(IOException.class, () -> { createRandomAnomalyDetector(false, false, indexName, oceanClient); });
+        Assert.assertTrue("actual: " + exception.getMessage(), exception.getMessage().contains("Unauthorized"));
     }
 
     public void testCreateAnomalyDetectorWithCustomResultIndex() throws IOException {
@@ -496,12 +506,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         );
         enableFilterBy();
         // User elk has no read permission of index
-        Exception exception = expectThrows(Exception.class, () -> { previewAnomalyDetector(aliceDetector.getId(), elkClient, input); });
-        Assert
-            .assertTrue(
-                "actual msg: " + exception.getMessage(),
-                exception.getMessage().contains("no permissions for [indices:data/read/search]")
-            );
+        Exception exception = expectThrows(Exception.class, () -> { previewAnomalyDetector(aliceDetector.getId(), oceanClient, input); });
+        Assert.assertTrue("actual msg: " + exception.getMessage(), exception.getMessage().contains("Unauthorized"));
     }
 
     public void testValidateAnomalyDetectorWithWriteAccess() throws IOException {
@@ -530,8 +536,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null, Instant.now());
         enableFilterBy();
         // User elk has no read permission of index, can't validate detector
-        Exception exception = expectThrows(Exception.class, () -> { validateAnomalyDetector(detector, elkClient); });
-        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
+        Exception exception = expectThrows(Exception.class, () -> { validateAnomalyDetector(detector, oceanClient); });
+        Assert.assertTrue("actual: " + exception.getMessage(), exception.getMessage().contains("Unauthorized"));
     }
 
     public void testValidateAnomalyDetectorWithNoBackendRole() throws IOException {


### PR DESCRIPTION
### Description
This PR addresses errors in security tests caused by recent changes in opensearch-project/security#4719. Previously, users needed both AD full access and source index permissions to fully utilize anomaly detection (AD). AD full access has already included all alias and mapping permissions.  it was inconsistent not to include index search permission, which would otherwise force users to create an additional role. The change in the referenced PR aimed to simplify user management.

Due to this change, existing security tests that relied on a user having AD full access but lacking data search permission would no longer trigger the expected search permission exception. This PR addresses that issue by creating a new user role with only AD read permission (note we didn't change ad read access permission in the referenced PR) and without source index search permission, ensuring the tests correctly validate the lack of search permissions.

Testing Done:
* Verified that previously failing security tests now pass

### Related Issues
https://github.com/opensearch-project/anomaly-detection/issues/1307

```
Suite: Test class org.opensearch.ad.rest.SecureADRestIT

  2> Sep 11, 2024 6:07:48 AM org.apache.lucene.internal.vectorization.VectorizationProvider lookup

  2> WARNING: Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.

  2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.ad.rest.SecureADRestIT.testValidateAnomalyDetectorWithNoReadPermissionOfIndex" -Dtests.seed=92E7F7A66E928896 -Dtests.security.manager=false -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=en-AU -Dtests.timezone=Asia/Novosibirsk -Druntime.java=21

  2> junit.framework.AssertionFailedError: Expected exception Exception but no exception was thrown

        at __randomizedtesting.SeedInfo.seed([92E7F7A66E928896:95DAB14B833EFF1B]:0)

        at org.apache.lucene.tests.util.LuceneTestCase.expectThrows(LuceneTestCase.java:2885)

        at org.apache.lucene.tests.util.LuceneTestCase.expectThrows(LuceneTestCase.java:2871)

        at org.opensearch.ad.rest.SecureADRestIT.testValidateAnomalyDetectorWithNoReadPermissionOfIndex(SecureADRestIT.java:531)

  2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.ad.rest.SecureADRestIT.testPreviewAnomalyDetectorWithNoReadPermissionOfIndex" -Dtests.seed=92E7F7A66E928896 -Dtests.security.manager=false -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=en-AU -Dtests.timezone=Asia/Novosibirsk -Druntime.java=21

  2> junit.framework.AssertionFailedError: Expected exception Exception but no exception was thrown

        at __randomizedtesting.SeedInfo.seed([92E7F7A66E928896:E8BD49915378A3BB]:0)

        at org.apache.lucene.tests.util.LuceneTestCase.expectThrows(LuceneTestCase.java:2885)

        at org.apache.lucene.tests.util.LuceneTestCase.expectThrows(LuceneTestCase.java:2871)

        at org.opensearch.ad.rest.SecureADRestIT.testPreviewAnomalyDetectorWithNoReadPermissionOfIndex(SecureADRestIT.java:497)

  2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.ad.rest.SecureADRestIT.testCreateAnomalyDetectorWithNoReadPermissionOfIndex" -Dtests.seed=92E7F7A66E928896 -Dtests.security.manager=false -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=en-AU -Dtests.timezone=Asia/Novosibirsk -Druntime.java=21

  2> java.lang.AssertionError

        at __randomizedtesting.SeedInfo.seed([92E7F7A66E928896:6E8988EEB6425BF1]:0)

        at org.junit.Assert.fail(Assert.java:87)

        at org.junit.Assert.assertTrue(Assert.java:42)

        at org.junit.Assert.assertTrue(Assert.java:53)

        at org.opensearch.ad.rest.SecureADRestIT.testCreateAnomalyDetectorWithNoReadPermissionOfIndex(SecureADRestIT.java:418)

  2> NOTE: leaving temporary files on disk at: C:\Users\ContainerAdministrator\tmpusmlhzan\anomaly-detection\build\testrun\integTest\temp\org.opensearch.ad.rest.SecureADRestIT_92E7F7A66E928896-002

  2> NOTE: test params are: codec=Asserting(Lucene99), sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=en-AU, timezone=Asia/Novosibirsk

  2> NOTE: Windows 10 10.0 amd64/Eclipse Adoptium 21.0.3 (64-bit)/cpus=16,threads=1,free=308185312,total=536870912

  2> NOTE: All tests run in this JVM: [DetectionResultEvalutationIT, HistoricalMissingSingleFeatureIT, MissingMultiFeatureIT, MissingSingleFeatureIT, MixedRealtimeHistoricalIT, PreviewMissingSingleFeatureIT, PreviewRuleIT, RealTimeRuleIT, AnomalyDetectorRestApiIT, DataDependentADRestApiIT, HistoricalAnalysisRestApiIT, SecureADRestIT]

Sep 11, 2024 6:08:37 AM sun.util.locale.provider.LocaleProviderAdapter <clinit>

WARNING: COMPAT locale provider will be removed in a future release

```

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
