### PR TITLE
Bump BWC Version to 2.18 and Fix Bugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         js_resource_folder = "src/test/resources/job-scheduler"
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
-        bwcVersionShort = "2.17.0"
+        bwcVersionShort = "2.18.0"
         bwcVersion = bwcVersionShort + ".0"
         bwcOpenSearchADDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + bwcVersionShort + '/latest/linux/x64/tar/builds/' +
                 'opensearch/plugins/opensearch-anomaly-detection-' + bwcVersion + '.zip'
@@ -696,9 +696,8 @@ List<String> jacocoExclusions = [
 
         // TODO: add test coverage (kaituo)
         'org.opensearch.forecast.*',
+        'org.opensearch.ad.transport.ADHCImputeNodeResponse',
         'org.opensearch.ad.transport.GetAnomalyDetectorTransportAction',
-        'org.opensearch.ad.ml.ADColdStart',
-        'org.opensearch.ad.transport.ADHCImputeNodesResponse',
         'org.opensearch.timeseries.transport.BooleanNodeResponse',
         'org.opensearch.timeseries.ml.TimeSeriesSingleStreamCheckpointDao',
         'org.opensearch.timeseries.transport.JobRequest',
@@ -713,7 +712,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.timeseries.transport.ResultBulkTransportAction',
         'org.opensearch.timeseries.transport.handler.IndexMemoryPressureAwareResultHandler',
         'org.opensearch.timeseries.transport.handler.ResultIndexingHandler',
-        'org.opensearch.ad.transport.ADHCImputeNodeResponse',
         'org.opensearch.timeseries.ml.Sample',
         'org.opensearch.timeseries.ratelimit.FeatureRequest',
         'org.opensearch.ad.transport.ADHCImputeNodeRequest',

--- a/src/main/java/org/opensearch/ad/model/AnomalyResult.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyResult.java
@@ -446,7 +446,7 @@ public class AnomalyResult extends IndexableResult {
             taskId,
             rcfScore,
             Math.max(0, grade),
-            confidence,
+            Math.min(1, confidence),
             featureData,
             dataStartTime,
             dataEndTime,

--- a/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -86,10 +86,11 @@ public class GetAnomalyDetectorTransportAction extends
     }
 
     @Override
-    protected void fillInHistoricalTaskforBwc(Map<String, ADTask> tasks, Optional<ADTask> historicalAdTask) {
+    protected Optional<ADTask> fillInHistoricalTaskforBwc(Map<String, ADTask> tasks) {
         if (tasks.containsKey(ADTaskType.HISTORICAL.name())) {
-            historicalAdTask = Optional.ofNullable(tasks.get(ADTaskType.HISTORICAL.name()));
+            return Optional.ofNullable(tasks.get(ADTaskType.HISTORICAL.name()));
         }
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/opensearch/forecast/model/ForecastResult.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastResult.java
@@ -188,7 +188,7 @@ public class ForecastResult extends IndexableResult {
                 new ForecastResult(
                     forecasterId,
                     taskId,
-                    dataQuality,
+                    Math.min(1, dataQuality),
                     featureData,
                     dataStartTime,
                     dataEndTime,
@@ -218,7 +218,7 @@ public class ForecastResult extends IndexableResult {
                         new ForecastResult(
                             forecasterId,
                             taskId,
-                            dataQuality,
+                            Math.min(1, dataQuality),
                             null,
                             dataStartTime,
                             dataEndTime,

--- a/src/main/java/org/opensearch/timeseries/transport/BaseGetConfigTransportAction.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BaseGetConfigTransportAction.java
@@ -180,7 +180,7 @@ public abstract class BaseGetConfigTransportAction<GetConfigResponseType extends
         }
     }
 
-    protected void getConfigAndJob(
+    public void getConfigAndJob(
         String configID,
         boolean returnJob,
         boolean returnTask,
@@ -251,7 +251,7 @@ public abstract class BaseGetConfigTransportAction<GetConfigResponseType extends
                             } else {
                                 // AD needs to provides custom behavior for bwc, while forecasting can inherit
                                 // the empty implementation
-                                fillInHistoricalTaskforBwc(tasks, historicalTask);
+                                historicalTask = fillInHistoricalTaskforBwc(tasks);
                             }
                         }
                         getConfigAndJob(configID, returnJob, returnTask, realtimeTask, historicalTask, listener);
@@ -357,7 +357,9 @@ public abstract class BaseGetConfigTransportAction<GetConfigResponseType extends
         };
     }
 
-    protected void fillInHistoricalTaskforBwc(Map<String, TaskClass> tasks, Optional<TaskClass> historicalAdTask) {}
+    protected Optional<TaskClass> fillInHistoricalTaskforBwc(Map<String, TaskClass> tasks) {
+        return Optional.empty();
+    }
 
     protected void getExecuteProfile(
         GetConfigRequest request,

--- a/src/main/java/org/opensearch/timeseries/transport/ResultProcessor.java
+++ b/src/main/java/org/opensearch/timeseries/transport/ResultProcessor.java
@@ -229,8 +229,6 @@ public abstract class ResultProcessor<TransportResultRequestType extends ResultR
                 pageIterator.next(this);
             }
             if (entityFeatures != null && false == entityFeatures.isEmpty()) {
-                sentOutPages.incrementAndGet();
-
                 LOG
                     .info(
                         "Sending an HC request to process data from timestamp {} to {} for config {}",
@@ -285,6 +283,7 @@ public abstract class ResultProcessor<TransportResultRequestType extends ResultR
                         final AtomicReference<Exception> failure = new AtomicReference<>();
 
                         node2Entities.stream().forEach(nodeEntity -> {
+                            sentOutPages.incrementAndGet();
                             DiscoveryNode node = nodeEntity.getKey();
                             transportService
                                 .sendRequest(
@@ -370,7 +369,15 @@ public abstract class ResultProcessor<TransportResultRequestType extends ResultR
                             cancellable.get().cancel();
                         }
                     } else if (Instant.now().toEpochMilli() >= timeoutMillis) {
-                        LOG.warn("Scheduled impute HC task is cancelled due to timeout");
+                        LOG
+                            .warn(
+                                "Scheduled impute HC task is cancelled due to timeout, current epoch {}, timeout epoch {}, dataEndTime {}, sent out {}, receive {}",
+                                Instant.now().toEpochMilli(),
+                                timeoutMillis,
+                                dataEndTime,
+                                sentOutPages.get(),
+                                receivedPages.get()
+                            );
                         if (cancellable != null) {
                             cancellable.get().cancel();
                         }

--- a/src/test/java/org/opensearch/ad/HistoricalAnalysisRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/HistoricalAnalysisRestTestCase.java
@@ -269,6 +269,29 @@ public abstract class HistoricalAnalysisRestTestCase extends AnomalyDetectorRest
         return results;
     }
 
+    protected List<Object> waitUntilTaskReachNumberOfEntities(String detectorId, int categoricalValuesCount) throws InterruptedException {
+        List<Object> results = new ArrayList<>();
+        int i = 0;
+        ADTaskProfile adTaskProfile = null;
+        // Increase retryTimes if some task can't reach done state
+        while ((adTaskProfile == null
+            || adTaskProfile.getTotalEntitiesCount() == null
+            || adTaskProfile.getTotalEntitiesCount().intValue() != categoricalValuesCount) && i < MAX_RETRY_TIMES) {
+            try {
+                adTaskProfile = getADTaskProfile(detectorId);
+            } catch (Exception e) {
+                logger.error("failed to get ADTaskProfile", e);
+            } finally {
+                Thread.sleep(1000);
+            }
+            i++;
+        }
+        assertNotNull(adTaskProfile);
+        results.add(adTaskProfile);
+        results.add(i);
+        return results;
+    }
+
     protected List<Object> waitUntilEntityCountAvailable(String detectorId) throws InterruptedException {
         List<Object> results = new ArrayList<>();
         int i = 0;

--- a/src/test/java/org/opensearch/ad/e2e/PreviewRuleIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/PreviewRuleIT.java
@@ -32,7 +32,7 @@ public class PreviewRuleIT extends AbstractRuleTestCase {
                 (trainTestSplit + 1) * numberOfEntities
             );
 
-            String detector = genDetector(datasetName, intervalMinutes, trainTestSplit, trainResult);
+            String detector = genDetector(datasetName, intervalMinutes, trainTestSplit, trainResult, true);
             Map<String, Object> result = preview(detector, trainResult.firstDataTime, trainResult.finalDataTime, client());
             List<Object> results = (List<Object>) XContentMapValues.extractValue(result, "anomaly_result");
             assertTrue(results.size() > 100);

--- a/src/test/java/org/opensearch/ad/e2e/RealTimeRuleIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/RealTimeRuleIT.java
@@ -15,7 +15,7 @@ import java.util.TreeMap;
 import com.google.gson.JsonObject;
 
 public class RealTimeRuleIT extends AbstractRuleTestCase {
-    public void testRuleWithDateNanos() throws Exception {
+    private void template(boolean reltive) throws Exception {
         // TODO: this test case will run for a much longer time and timeout with security enabled
         if (!isHttps()) {
             disableResourceNotFoundFaultTolerence();
@@ -32,7 +32,8 @@ public class RealTimeRuleIT extends AbstractRuleTestCase {
                 trainTestSplit,
                 true,
                 // ingest just enough for finish the test
-                (trainTestSplit + 1) * numberOfEntities
+                (trainTestSplit + 1) * numberOfEntities,
+                reltive
             );
 
             startRealTimeDetector(trainResult, numberOfEntities, intervalMinutes, false);
@@ -89,5 +90,13 @@ public class RealTimeRuleIT extends AbstractRuleTestCase {
                 }
             }
         }
+    }
+
+    public void testRelativeRule() throws Exception {
+        template(true);
+    }
+
+    public void testAbsoluateRule() throws Exception {
+        template(false);
     }
 }

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -1275,4 +1275,25 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
         checkSemaphoreRelease();
         assertTrue(modelState.getModel().isEmpty());
     }
+
+    public void testTrainModelFromInvalidSamplesNotEnoughSamples() {
+        Deque<Sample> samples = new ArrayDeque<>();
+        // we have at least numMinSamples samples before executing the null check of trainModelFromDataSegments
+        for (int i = 0; i < numMinSamples; i++) {
+            samples.add(new Sample());
+        }
+
+        modelState = new ModelState<ThresholdedRandomCutForest>(
+            null,
+            modelId,
+            detectorId,
+            ModelManager.ModelType.TRCF.getName(),
+            clock,
+            priority,
+            Optional.of(entity),
+            samples
+        );
+        entityColdStarter.trainModelFromExistingSamples(modelState, detector, "123");
+        assertTrue(modelState.getModel().isEmpty());
+    }
 }

--- a/src/test/java/org/opensearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyResultTests.java
@@ -12,10 +12,15 @@
 package org.opensearch.ad.model;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.ToXContent;
@@ -24,6 +29,8 @@ import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.model.Entity;
+import org.opensearch.timeseries.model.FeatureData;
 
 import com.google.common.base.Objects;
 
@@ -151,5 +158,65 @@ public class AnomalyResultTests extends OpenSearchSingleNodeTestCase {
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyResult parsedDetectResult = new AnomalyResult(input);
         assertTrue(parsedDetectResult.equals(detectResult));
+    }
+
+    public void testFromRawTRCFResultWithHighConfidence() {
+        // Set up test parameters
+        String detectorId = "test-detector-id";
+        long intervalMillis = 60000; // Example interval
+        String taskId = "test-task-id";
+        Double rcfScore = 0.5;
+        Double grade = 0.0; // Non-anomalous
+        Double confidence = 1.03; // Confidence greater than 1
+        List<FeatureData> featureData = Collections.emptyList(); // Assuming empty for simplicity
+        Instant dataStartTime = Instant.now();
+        Instant dataEndTime = dataStartTime.plusMillis(intervalMillis);
+        Instant executionStartTime = Instant.now();
+        Instant executionEndTime = executionStartTime.plusMillis(500);
+        String error = null;
+        Optional<Entity> entity = Optional.empty();
+        User user = null; // Replace with actual user if needed
+        Integer schemaVersion = 1;
+        String modelId = "test-model-id";
+        double[] relevantAttribution = null;
+        Integer relativeIndex = null;
+        double[] pastValues = null;
+        double[][] expectedValuesList = null;
+        double[] likelihoodOfValues = null;
+        Double threshold = null;
+        double[] currentData = null;
+        boolean[] featureImputed = null;
+
+        // Invoke the method under test
+        AnomalyResult result = AnomalyResult
+            .fromRawTRCFResult(
+                detectorId,
+                intervalMillis,
+                taskId,
+                rcfScore,
+                grade,
+                confidence,
+                featureData,
+                dataStartTime,
+                dataEndTime,
+                executionStartTime,
+                executionEndTime,
+                error,
+                entity,
+                user,
+                schemaVersion,
+                modelId,
+                relevantAttribution,
+                relativeIndex,
+                pastValues,
+                expectedValuesList,
+                likelihoodOfValues,
+                threshold,
+                currentData,
+                featureImputed
+            );
+
+        // Assert that the confidence is capped at 1.0
+        assertEquals("Confidence should be capped at 1.0", 1.0, result.getConfidence(), 0.00001);
     }
 }

--- a/src/test/java/org/opensearch/ad/model/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/model/GetAnomalyDetectorTransportActionTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.model;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.task.ADTaskManager;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.ad.transport.GetAnomalyDetectorTransportAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.timeseries.AbstractTimeSeriesTest;
+import org.opensearch.timeseries.transport.GetConfigRequest;
+import org.opensearch.transport.TransportService;
+
+public class GetAnomalyDetectorTransportActionTests extends AbstractTimeSeriesTest {
+    @SuppressWarnings("unchecked")
+    public void testRealtimeTaskAssignedWithSingleStreamRealTimeTaskName() throws Exception {
+        // Arrange
+        String configID = "test-config-id";
+
+        // Create a task with singleStreamRealTimeTaskName
+        Map<String, ADTask> tasks = new HashMap<>();
+        ADTask adTask = ADTask.builder().taskType(ADTaskType.HISTORICAL.name()).build();
+        tasks.put(ADTaskType.HISTORICAL.name(), adTask);
+
+        // Mock taskManager to return the tasks
+        ADTaskManager taskManager = mock(ADTaskManager.class);
+        doAnswer(invocation -> {
+            List<ADTask> taskList = new ArrayList<>(tasks.values());
+            ((Consumer<List<ADTask>>) invocation.getArguments()[4]).accept(taskList);
+            return null;
+        }).when(taskManager).getAndExecuteOnLatestTasks(anyString(), any(), any(), any(), any(), any(), anyBoolean(), anyInt(), any());
+
+        // Mock listener
+        ActionListener<GetAnomalyDetectorResponse> listener = mock(ActionListener.class);
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings settings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(settings);
+        GetAnomalyDetectorTransportAction getForecaster = spy(
+            new GetAnomalyDetectorTransportAction(
+                mock(TransportService.class),
+                null,
+                mock(ActionFilters.class),
+                clusterService,
+                null,
+                null,
+                Settings.EMPTY,
+                null,
+                taskManager,
+                null
+            )
+        );
+
+        // Act
+        GetConfigRequest request = new GetConfigRequest(configID, 0L, true, true, "", "", true, null);
+        getForecaster.getExecute(request, listener);
+
+        // Assert
+        // Verify that realtimeTask is assigned using singleStreamRealTimeTaskName
+        // This can be checked by verifying interactions or internal state
+        // For this example, we'll verify that the correct task is passed to getConfigAndJob
+        verify(getForecaster).getConfigAndJob(eq(configID), anyBoolean(), anyBoolean(), any(), eq(Optional.of(adTask)), eq(listener));
+    }
+}

--- a/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
@@ -105,14 +105,17 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
     }
 
     private void checkIfTaskCanFinishCorrectly(String detectorId, String taskId, Set<String> states) throws InterruptedException {
-        List<Object> results = waitUntilTaskDone(detectorId);
+        List<Object> results = waitUntilTaskReachState(detectorId, states);
         TaskProfile<ADTask> endTaskProfile = (TaskProfile<ADTask>) results.get(0);
         Integer retryCount = (Integer) results.get(1);
         ADTask stoppedAdTask = endTaskProfile.getTask();
         assertEquals(taskId, stoppedAdTask.getTaskId());
         if (retryCount < MAX_RETRY_TIMES) {
             // It's possible that historical analysis still running after max retry times
-            assertTrue(states.contains(stoppedAdTask.getState()));
+            assertTrue(
+                "expect: " + stoppedAdTask.getState() + ", but got " + stoppedAdTask.getState(),
+                states.contains(stoppedAdTask.getState())
+            );
         }
     }
 
@@ -133,6 +136,10 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
         if (categoryFieldSize > 0) {
             if (!TaskState.RUNNING.name().equals(adTaskProfile.getTask().getState())) {
                 adTaskProfile = (ADTaskProfile) waitUntilTaskReachState(detectorId, ImmutableSet.of(TaskState.RUNNING.name())).get(0);
+            }
+            if (adTaskProfile == null
+                || (int) Math.pow(categoryFieldDocCount, categoryFieldSize) != adTaskProfile.getTotalEntitiesCount().intValue()) {
+                adTaskProfile = (ADTaskProfile) waitUntilTaskReachNumberOfEntities(detectorId, categoryFieldDocCount).get(0);
             }
             assertEquals((int) Math.pow(categoryFieldDocCount, categoryFieldSize), adTaskProfile.getTotalEntitiesCount().intValue());
             assertTrue(adTaskProfile.getPendingEntitiesCount() > 0);

--- a/src/test/java/org/opensearch/ad/transport/ADHCImputeNodesResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADHCImputeNodesResponseTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.transport;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ADHCImputeNodesResponseTests extends OpenSearchTestCase {
+
+    public void testADHCImputeNodesResponseSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        Exception previousException = new Exception("Test exception message");
+
+        ADHCImputeNodeResponse nodeResponse = new ADHCImputeNodeResponse(node, previousException);
+        List<ADHCImputeNodeResponse> nodes = Collections.singletonList(nodeResponse);
+        List<FailedNodeException> failures = Collections.emptyList();
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        ADHCImputeNodesResponse response = new ADHCImputeNodesResponse(clusterName, nodes, failures);
+
+        // Act: Serialize the response
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+
+        // Deserialize the response
+        StreamInput input = output.bytes().streamInput();
+        ADHCImputeNodesResponse deserializedResponse = new ADHCImputeNodesResponse(input);
+
+        // Assert
+        assertEquals(clusterName, deserializedResponse.getClusterName());
+        assertEquals(response.getNodes().size(), deserializedResponse.getNodes().size());
+        assertEquals(response.failures().size(), deserializedResponse.failures().size());
+
+        // Check the node response
+        ADHCImputeNodeResponse deserializedNodeResponse = deserializedResponse.getNodes().get(0);
+        assertEquals(node, deserializedNodeResponse.getNode());
+        assertNotNull(deserializedNodeResponse.getPreviousException());
+        assertEquals("exception: " + previousException.getMessage(), deserializedNodeResponse.getPreviousException().getMessage());
+    }
+
+    public void testReadNodesFromAndWriteNodesTo() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        Exception previousException = new Exception("Test exception message");
+
+        ADHCImputeNodeResponse nodeResponse = new ADHCImputeNodeResponse(node, previousException);
+        List<ADHCImputeNodeResponse> nodes = Collections.singletonList(nodeResponse);
+        ClusterName clusterName = new ClusterName("test-cluster");
+        ADHCImputeNodesResponse response = new ADHCImputeNodesResponse(clusterName, nodes, Collections.emptyList());
+
+        // Act: Write nodes to output
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeNodesTo(output, nodes);
+
+        // Read nodes from input
+        StreamInput input = output.bytes().streamInput();
+        List<ADHCImputeNodeResponse> readNodes = response.readNodesFrom(input);
+
+        // Assert
+        assertEquals(nodes.size(), readNodes.size());
+        ADHCImputeNodeResponse readNodeResponse = readNodes.get(0);
+        assertEquals(node, readNodeResponse.getNode());
+        assertNotNull(readNodeResponse.getPreviousException());
+        assertEquals("exception: " + previousException.getMessage(), readNodeResponse.getPreviousException().getMessage());
+    }
+
+    public void testADHCImputeNodeResponseSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        Exception previousException = new Exception("Test exception message");
+
+        ADHCImputeNodeResponse nodeResponse = new ADHCImputeNodeResponse(node, previousException);
+
+        // Act: Serialize the node response
+        BytesStreamOutput output = new BytesStreamOutput();
+        nodeResponse.writeTo(output);
+
+        // Deserialize the node response
+        StreamInput input = output.bytes().streamInput();
+        ADHCImputeNodeResponse deserializedNodeResponse = new ADHCImputeNodeResponse(input);
+
+        // Assert
+        assertEquals(node, deserializedNodeResponse.getNode());
+        assertNotNull(deserializedNodeResponse.getPreviousException());
+        assertEquals("exception: " + previousException.getMessage(), deserializedNodeResponse.getPreviousException().getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/forecast/transport/GetForecasterTransportActionTests.java
+++ b/src/test/java/org/opensearch/forecast/transport/GetForecasterTransportActionTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.forecast.transport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.forecast.model.ForecastTask;
+import org.opensearch.forecast.model.ForecastTaskType;
+import org.opensearch.forecast.settings.ForecastSettings;
+import org.opensearch.forecast.task.ForecastTaskManager;
+import org.opensearch.timeseries.AbstractTimeSeriesTest;
+import org.opensearch.timeseries.transport.GetConfigRequest;
+import org.opensearch.transport.TransportService;
+
+public class GetForecasterTransportActionTests extends AbstractTimeSeriesTest {
+    @SuppressWarnings("unchecked")
+    public void testRealtimeTaskAssignedWithSingleStreamRealTimeTaskName() throws Exception {
+        // Arrange
+        String configID = "test-config-id";
+
+        // Create a task with singleStreamRealTimeTaskName
+        Map<String, ForecastTask> tasks = new HashMap<>();
+        ForecastTask forecastTask = ForecastTask.builder().taskType(ForecastTaskType.REALTIME_FORECAST_SINGLE_STREAM.name()).build();
+        tasks.put(ForecastTaskType.REALTIME_FORECAST_SINGLE_STREAM.name(), forecastTask);
+
+        // Mock taskManager to return the tasks
+        ForecastTaskManager taskManager = mock(ForecastTaskManager.class);
+        doAnswer(invocation -> {
+            List<ForecastTask> taskList = new ArrayList<>(tasks.values());
+            ((Consumer<List<ForecastTask>>) invocation.getArguments()[4]).accept(taskList);
+            return null;
+        }).when(taskManager).getAndExecuteOnLatestTasks(anyString(), any(), any(), any(), any(), any(), anyBoolean(), anyInt(), any());
+
+        // Mock listener
+        ActionListener<GetForecasterResponse> listener = mock(ActionListener.class);
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings settings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ForecastSettings.FORECAST_FILTER_BY_BACKEND_ROLES)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(settings);
+        GetForecasterTransportAction getForecaster = spy(
+            new GetForecasterTransportAction(
+                mock(TransportService.class),
+                null,
+                mock(ActionFilters.class),
+                clusterService,
+                null,
+                null,
+                Settings.EMPTY,
+                null,
+                taskManager,
+                null
+            )
+        );
+
+        // Act
+        GetConfigRequest request = new GetConfigRequest(configID, 0L, true, true, "", "", true, null);
+        getForecaster.getExecute(request, listener);
+
+        // Assert
+        // Verify that realtimeTask is assigned using singleStreamRealTimeTaskName
+        // This can be checked by verifying interactions or internal state
+        // For this example, we'll verify that the correct task is passed to getConfigAndJob
+        verify(getForecaster).getConfigAndJob(eq(configID), anyBoolean(), anyBoolean(), eq(Optional.of(forecastTask)), any(), eq(listener));
+    }
+}


### PR DESCRIPTION
### Description
This PR includes the following updates and bug fixes:

* Bump BWC Version to 2.18: Updated BWC version to 2.18 since the 2.17 branch has been cut.
* Fix Confidence Value Exceeding 1 in RCF: Addressed a bug in RCF where the confidence value could exceed 1. Implemented a check to cap the confidence value at 1, preventing invalid confidence scores.
* Correct Parameter Assignment in GetAnomalyDetectorTransportAction: Fixed an issue where parameter assignments within a method did not affect external variables due to Java's pass-by-value nature.
* Fixed a bug in ResultProcessor where we were supposed to check whether the number of sent messages equals the number of received messages before starting imputation. However, the sent message count was mistakenly based on the number of pages rather than the actual number of messages.
* Fixed a bug where we mistakenly used the total reserved memory bytes as the memory size per entity in PriorityCache.

Testing done:
* added test cases for the buggy scenarios
* manual e2e testing

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
