### PR TITLE
Support forecast tasks in profile API; enable index field modifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -696,15 +696,11 @@ List<String> jacocoExclusions = [
 
         // TODO: add test coverage (kaituo)
         'org.opensearch.forecast.*',
-        'org.opensearch.ad.transport.ADHCImputeNodeResponse',
-        'org.opensearch.ad.transport.GetAnomalyDetectorTransportAction',
-        'org.opensearch.timeseries.transport.BooleanNodeResponse',
         'org.opensearch.timeseries.ml.TimeSeriesSingleStreamCheckpointDao',
         'org.opensearch.timeseries.transport.JobRequest',
         'org.opensearch.timeseries.transport.handler.ResultBulkIndexingHandler',
         'org.opensearch.timeseries.ml.Inferencer',
         'org.opensearch.timeseries.transport.SingleStreamResultRequest',
-        'org.opensearch.timeseries.transport.BooleanResponse',
         'org.opensearch.timeseries.rest.handler.IndexJobActionHandler.1',
         'org.opensearch.timeseries.transport.SuggestConfigParamResponse',
         'org.opensearch.timeseries.transport.SuggestConfigParamRequest',

--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -345,7 +345,8 @@ public class ADTask extends TimeSeriesTask {
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
                 detector.getCustomResultIndexTTL(),
-                detector.getFlattenResultIndexMapping()
+                detector.getFlattenResultIndexMapping(),
+                detector.getLastBreakingUIChangeTime()
             );
         return new Builder()
             .taskId(parsedTaskId)

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -151,6 +151,8 @@ public class AnomalyDetector extends Config {
      * @param customResultIndexMinAge custom result index lifecycle management min age condition
      * @param customResultIndexTTL custom result index lifecycle management ttl
      * @param flattenResultIndexMapping flag to indicate whether to flatten result index mapping or not
+     * @param lastBreakingUIChangeTime last update time to configuration that can break UI and we have
+     *  to display updates from the changed time
      */
     public AnomalyDetector(
         String detectorId,
@@ -178,7 +180,8 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime
     ) {
         super(
             detectorId,
@@ -206,7 +209,8 @@ public class AnomalyDetector extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
@@ -284,6 +288,7 @@ public class AnomalyDetector extends Config {
         this.customResultIndexMinAge = input.readOptionalInt();
         this.customResultIndexTTL = input.readOptionalInt();
         this.flattenResultIndexMapping = input.readOptionalBoolean();
+        this.lastUIBreakingChangeTime = input.readOptionalInstant();
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -350,6 +355,7 @@ public class AnomalyDetector extends Config {
         output.writeOptionalInt(customResultIndexMinAge);
         output.writeOptionalInt(customResultIndexTTL);
         output.writeOptionalBoolean(flattenResultIndexMapping);
+        output.writeOptionalInstant(lastUIBreakingChangeTime);
     }
 
     @Override
@@ -447,6 +453,7 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
         Boolean flattenResultIndexMapping = null;
+        Instant lastBreakingUIChangeTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -584,6 +591,9 @@ public class AnomalyDetector extends Config {
                 case FLATTEN_RESULT_INDEX_MAPPING:
                     flattenResultIndexMapping = onlyParseBooleanValue(parser);
                     break;
+                case BREAKING_UI_CHANGE_TIME:
+                    lastBreakingUIChangeTime = ParseUtils.toInstant(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -615,7 +625,8 @@ public class AnomalyDetector extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
         detector.setDetectionDateRange(detectionDateRange);
         return detector;

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -84,6 +84,11 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
             : WriteRequest.RefreshPolicy.IMMEDIATE;
         RestRequest.Method method = request.getHttpRequest().method();
 
+        if (method == RestRequest.Method.POST && detectorId != AnomalyDetector.NO_ID) {
+            // reset detector to empty string detectorId is only meant for updating detector
+            detectorId = AnomalyDetector.NO_ID;
+        }
+
         IndexAnomalyDetectorRequest indexAnomalyDetectorRequest = new IndexAnomalyDetectorRequest(
             detectorId,
             seqNo,

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -245,7 +245,8 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
             config.getCustomResultIndexTTL(),
-            config.getFlattenResultIndexMapping()
+            config.getFlattenResultIndexMapping(),
+            breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime()
         );
     }
 

--- a/src/main/java/org/opensearch/forecast/ForecastTaskProfileRunner.java
+++ b/src/main/java/org/opensearch/forecast/ForecastTaskProfileRunner.java
@@ -14,8 +14,18 @@ public class ForecastTaskProfileRunner implements TaskProfileRunner<ForecastTask
 
     @Override
     public void getTaskProfile(ForecastTask configLevelTask, ActionListener<ForecastTaskProfile> listener) {
-        // return null since forecasting have no in-memory task profiles as AD
-        listener.onResponse(null);
+        // return null in other fields since forecasting have no in-memory task profiles as AD
+        listener
+            .onResponse(
+                new ForecastTaskProfile(
+                    configLevelTask,
+                    null,
+                    null,
+                    null,
+                    configLevelTask == null ? null : configLevelTask.getTaskId(),
+                    null
+                )
+            );
     }
 
 }

--- a/src/main/java/org/opensearch/forecast/model/ForecastTask.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastTask.java
@@ -343,7 +343,8 @@ public class ForecastTask extends TimeSeriesTask {
                 forecaster.getCustomResultIndexMinSize(),
                 forecaster.getCustomResultIndexMinAge(),
                 forecaster.getCustomResultIndexTTL(),
-                forecaster.getFlattenResultIndexMapping()
+                forecaster.getFlattenResultIndexMapping(),
+                forecaster.getLastBreakingUIChangeTime()
             );
         return new Builder()
             .taskId(parsedTaskId)
@@ -375,10 +376,12 @@ public class ForecastTask extends TimeSeriesTask {
     @Generated
     @Override
     public boolean equals(Object other) {
-        if (this == other)
+        if (this == other) {
             return true;
-        if (other == null || getClass() != other.getClass())
+        }
+        if (other == null || getClass() != other.getClass()) {
             return false;
+        }
         ForecastTask that = (ForecastTask) other;
         return super.equals(that)
             && Objects.equal(getForecaster(), that.getForecaster())

--- a/src/main/java/org/opensearch/forecast/model/Forecaster.java
+++ b/src/main/java/org/opensearch/forecast/model/Forecaster.java
@@ -135,7 +135,8 @@ public class Forecaster extends Config {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime
     ) {
         super(
             forecasterId,
@@ -163,7 +164,8 @@ public class Forecaster extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
 
         checkAndThrowValidationErrors(ValidationAspect.FORECASTER);
@@ -306,6 +308,7 @@ public class Forecaster extends Config {
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
         Boolean flattenResultIndexMapping = null;
+        Instant lastBreakingUIChangeTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -437,6 +440,9 @@ public class Forecaster extends Config {
                 case FLATTEN_RESULT_INDEX_MAPPING:
                     flattenResultIndexMapping = parser.booleanValue();
                     break;
+                case BREAKING_UI_CHANGE_TIME:
+                    lastBreakingUIChangeTime = ParseUtils.toInstant(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -468,7 +474,8 @@ public class Forecaster extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
         return forecaster;
     }

--- a/src/main/java/org/opensearch/forecast/rest/RestIndexForecasterAction.java
+++ b/src/main/java/org/opensearch/forecast/rest/RestIndexForecasterAction.java
@@ -87,6 +87,11 @@ public class RestIndexForecasterAction extends AbstractForecasterAction {
                 : WriteRequest.RefreshPolicy.IMMEDIATE;
             RestRequest.Method method = request.getHttpRequest().method();
 
+            if (method == RestRequest.Method.POST && forecasterId != Config.NO_ID) {
+                // reset detector to empty string detectorId is only meant for updating detector
+                forecasterId = Config.NO_ID;
+            }
+
             IndexForecasterRequest indexAnomalyDetectorRequest = new IndexForecasterRequest(
                 forecasterId,
                 seqNo,

--- a/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
+++ b/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
@@ -258,7 +258,8 @@ public abstract class AbstractForecasterActionHandler<T extends ActionResponse> 
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
             config.getCustomResultIndexTTL(),
-            config.getFlattenResultIndexMapping()
+            config.getFlattenResultIndexMapping(),
+            breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime()
         );
     }
 

--- a/src/main/java/org/opensearch/timeseries/transport/BooleanNodeResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BooleanNodeResponse.java
@@ -31,6 +31,7 @@ public class BooleanNodeResponse extends BaseNodeResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
         out.writeBoolean(answer);
     }
 }

--- a/src/main/java/org/opensearch/timeseries/transport/BooleanResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BooleanResponse.java
@@ -37,6 +37,7 @@ public class BooleanResponse extends BaseNodesResponse<BooleanNodeResponse> impl
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
         out.writeBoolean(answer);
     }
 

--- a/src/main/resources/mappings/anomaly-detection-state.json
+++ b/src/main/resources/mappings/anomaly-detection-state.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 4
+    "schema_version": 5
   },
   "properties": {
     "schema_version": {

--- a/src/main/resources/mappings/config.json
+++ b/src/main/resources/mappings/config.json
@@ -1,7 +1,7 @@
 {
     "dynamic": false,
     "_meta": {
-        "schema_version": 6
+        "schema_version": 7
     },
     "properties": {
         "schema_version": {
@@ -232,6 +232,10 @@
         },
         "flatten_result_index_mapping": {
             "type": "boolean"
+        },
+        "last_ui_breaking_change_time" : {
+            "type": "date",
+            "format": "strict_date_time||epoch_millis"
         }
     }
 }

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -859,7 +859,8 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractTimeSeriesTe
                         detector.getCustomResultIndexMinSize(),
                         detector.getCustomResultIndexMinAge(),
                         detector.getCustomResultIndexTTL(),
-                        false
+                        false,
+                        Instant.now()
                     );
                     try {
                         listener.onResponse((Response) TestHelpers.createGetResponse(clone, clone.getId(), CommonName.CONFIG_INDEX));

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -315,7 +315,8 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
                 detector.getCustomResultIndexTTL(),
-                detector.getFlattenResultIndexMapping()
+                detector.getFlattenResultIndexMapping(),
+                detector.getLastBreakingUIChangeTime()
             ),
             detectorJob,
             historicalAdTask,
@@ -642,7 +643,8 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             anomalyDetector.getCustomResultIndexMinSize(),
             anomalyDetector.getCustomResultIndexMinAge(),
             anomalyDetector.getCustomResultIndexTTL(),
-            anomalyDetector.getFlattenResultIndexMapping()
+            anomalyDetector.getFlattenResultIndexMapping(),
+            Instant.now()
         );
         return detector;
     }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -344,7 +344,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -381,7 +382,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -418,7 +420,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -455,7 +458,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -492,7 +496,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -529,7 +534,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -566,7 +572,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -602,7 +609,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Recency emphasis must be an integer greater than 1.", exception.getMessage());
@@ -639,7 +647,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Detection interval must be a positive integer", exception.getMessage());
@@ -676,7 +685,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Interval -1 should be non-negative", exception.getMessage());
@@ -726,7 +736,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
     }
@@ -761,7 +772,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         // seasonalityIntervals is not null and custom shingle size is null, use seasonalityIntervals to deterine shingle size
         assertEquals(seasonalityIntervals / TimeSeriesSettings.SEASONALITY_TO_SHINGLE_RATIO, (int) anomalyDetector.getShingleSize());
@@ -792,7 +804,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         // seasonalityIntervals is null and custom shingle size is null, use default shingle size
         assertEquals(TimeSeriesSettings.DEFAULT_SHINGLE_SIZE, (int) anomalyDetector.getShingleSize());
@@ -825,7 +838,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         assertNotNull(anomalyDetector.getFeatureAttributes());
         assertEquals(0, anomalyDetector.getFeatureAttributes().size());
@@ -858,7 +872,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         String errorMessage = anomalyDetector.validateCustomResultIndex("abc");
         assertEquals(ADCommonMessages.INVALID_RESULT_INDEX_PREFIX, errorMessage);
@@ -1024,7 +1039,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Got: " + e.getMessage(), "Enabled features are present, but no default fill values are provided.", e.getMessage());

--- a/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
+++ b/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
@@ -227,7 +227,8 @@ public class ADRestTestUtils {
             null,
             null,
             null,
-            null
+            null,
+            now
         );
 
         if (historical) {
@@ -317,7 +318,6 @@ public class ADRestTestUtils {
                 TestHelpers.LEGACY_OPENDISTRO_AD_BASE_DETECTORS_URI + "/results/_search",
                 ImmutableMap.of(),
                 TestHelpers.toHttpEntity(query),
-
                 null
             );
         Map<String, Object> responseMap = entityAsMap(searchAdTaskResponse);
@@ -343,7 +343,6 @@ public class ADRestTestUtils {
                 TestHelpers.LEGACY_OPENDISTRO_AD_BASE_DETECTORS_URI + "/_search",
                 ImmutableMap.of(),
                 TestHelpers.toHttpEntity(query),
-
                 null
             );
         Map<String, Object> responseMap = entityAsMap(searchAdTaskResponse);

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -54,6 +54,7 @@ import org.opensearch.timeseries.model.Feature;
 import org.opensearch.timeseries.model.Job;
 import org.opensearch.timeseries.rest.handler.AbstractTimeSeriesActionHandler;
 import org.opensearch.timeseries.settings.TimeSeriesSettings;
+import org.opensearch.timeseries.util.RestHandlerUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -159,6 +160,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -205,6 +207,23 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         int version = (int) responseMap.get("_version");
         assertNotEquals("response is missing Id", AnomalyDetector.NO_ID, id);
         assertTrue("incorrect version", version > 0);
+
+        // users cannot specify detector id when creating a detector
+        AnomalyDetector detector2 = createIndexAndGetAnomalyDetector(INDEX_NAME);
+        String blahId = "__blah__";
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI,
+                ImmutableMap.of(RestHandlerUtils.DETECTOR_ID, blahId),
+                TestHelpers.toHttpEntity(detector2),
+                null
+            );
+        assertEquals("Create anomaly detector failed", RestStatus.CREATED, TestHelpers.restStatus(response));
+        responseMap = entityAsMap(response);
+        id = (String) responseMap.get("_id");
+        assertNotEquals("response is missing Id", blahId, id);
     }
 
     public void testCreateAnomalyDetectorWithDateNanos() throws Exception {
@@ -271,7 +290,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
         Exception ex = expectThrows(
             ResponseException.class,
@@ -338,7 +358,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
 
         updateClusterSettings(ADEnabledSetting.AD_ENABLED, false);
@@ -410,7 +431,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector1.getLastBreakingUIChangeTime()
         );
 
         TestHelpers
@@ -459,7 +481,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
 
         TestHelpers
@@ -514,7 +537,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
 
         deleteIndexWithAdminClient(CommonName.CONFIG_INDEX);
@@ -886,7 +910,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
 
         TestHelpers

--- a/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
@@ -350,7 +350,8 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
             detector.getCustomResultIndexMinSize(),
             detector.getCustomResultIndexMinAge(),
             detector.getCustomResultIndexTTL(),
-            detector.getFlattenResultIndexMapping()
+            detector.getFlattenResultIndexMapping(),
+            detector.getLastBreakingUIChangeTime()
         );
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ADHCImputeNodesResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADHCImputeNodesResponseTests.java
@@ -115,4 +115,29 @@ public class ADHCImputeNodesResponseTests extends OpenSearchTestCase {
         assertNotNull(deserializedNodeResponse.getPreviousException());
         assertEquals("exception: " + previousException.getMessage(), deserializedNodeResponse.getPreviousException().getMessage());
     }
+
+    public void testNoExceptionSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        ADHCImputeNodeResponse nodeResponse = new ADHCImputeNodeResponse(node, null);
+
+        // Act: Serialize the node response
+        BytesStreamOutput output = new BytesStreamOutput();
+        nodeResponse.writeTo(output);
+
+        // Deserialize the node response
+        StreamInput input = output.bytes().streamInput();
+        ADHCImputeNodeResponse deserializedNodeResponse = new ADHCImputeNodeResponse(input);
+
+        // Assert
+        assertEquals(node, deserializedNodeResponse.getNode());
+        assertNull(deserializedNodeResponse.getPreviousException());
+    }
 }

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -227,7 +227,8 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -258,7 +259,8 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
@@ -86,7 +86,8 @@ public class ForwardADTaskRequestTests extends OpenSearchSingleNodeTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         ForwardADTaskRequest request = new ForwardADTaskRequest(detector, null, null, null, null, Version.V_2_1_0);
         ActionRequestValidationException validate = request.validate();

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -405,7 +405,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateConfigRequest request = new ValidateConfigRequest(
@@ -454,7 +455,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateConfigRequest request = new ValidateConfigRequest(

--- a/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
+++ b/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
@@ -90,7 +90,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastUpdateTime
         );
 
         assertEquals(forecasterId, forecaster.getId());
@@ -144,7 +145,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -183,7 +185,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -222,7 +225,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -261,7 +265,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -300,7 +305,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -338,7 +344,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastUpdateTime
         );
 
         assertEquals(resultIndex, forecaster.getCustomResultIndexOrAlias());
@@ -374,7 +381,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -340,7 +340,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            lastUpdateTime
         );
     }
 
@@ -395,7 +396,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -461,7 +463,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -502,7 +505,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -535,7 +539,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -575,7 +580,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -753,7 +759,8 @@ public class TestHelpers {
                 null,
                 null,
                 null,
-                null
+                null,
+                lastUpdateTime
             );
         }
     }
@@ -790,7 +797,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -1946,7 +1954,8 @@ public class TestHelpers {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         }
     }
@@ -1974,13 +1983,15 @@ public class TestHelpers {
             null,
             randomIntBetween(1, 20),
             randomImputationOption(featureList),
-            randomIntBetween(1, 1000),
+            // Recency emphasis must be an integer greater than 1
+            randomIntBetween(2, 1000),
             randomIntBetween(1, 128),
             randomIntBetween(1, 1000),
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 

--- a/src/test/java/org/opensearch/timeseries/transport/BooleanResponseTests.java
+++ b/src/test/java/org/opensearch/timeseries/transport/BooleanResponseTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.timeseries.transport;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class BooleanResponseTests extends OpenSearchTestCase {
+
+    public void testBooleanResponseSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponseTrue = new BooleanNodeResponse(node, true);
+        BooleanNodeResponse nodeResponseFalse = new BooleanNodeResponse(node, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponseTrue, nodeResponseFalse);
+        List<FailedNodeException> failures = Collections.emptyList();
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, failures);
+
+        // Act: Serialize the response
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+
+        // Deserialize the response
+        StreamInput input = output.bytes().streamInput();
+        BooleanResponse deserializedResponse = new BooleanResponse(input);
+
+        // Assert
+        assertEquals(clusterName, deserializedResponse.getClusterName());
+        assertEquals(response.getNodes().size(), deserializedResponse.getNodes().size());
+        assertEquals(response.failures().size(), deserializedResponse.failures().size());
+        assertEquals(response.isAnswerTrue(), deserializedResponse.isAnswerTrue());
+    }
+
+    public void testBooleanResponseReadNodesFromAndWriteNodesTo() throws IOException {
+        // Arrange
+        DiscoveryNode node1 = new DiscoveryNode(
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse1 = new BooleanNodeResponse(node1, true);
+        BooleanNodeResponse nodeResponse2 = new BooleanNodeResponse(node2, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponse1, nodeResponse2);
+        ClusterName clusterName = new ClusterName("test-cluster");
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Act: Write nodes to output
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeNodesTo(output, nodes);
+
+        // Read nodes from input
+        StreamInput input = output.bytes().streamInput();
+        List<BooleanNodeResponse> readNodes = response.readNodesFrom(input);
+
+        // Assert
+        assertEquals(nodes.size(), readNodes.size());
+        assertEquals(nodes.get(0).isAnswerTrue(), readNodes.get(0).isAnswerTrue());
+        assertEquals(nodes.get(1).isAnswerTrue(), readNodes.get(1).isAnswerTrue());
+    }
+
+    public void testBooleanNodeResponseSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse = new BooleanNodeResponse(node, true);
+
+        // Act: Serialize the node response
+        BytesStreamOutput output = new BytesStreamOutput();
+        nodeResponse.writeTo(output);
+
+        // Deserialize the node response
+        StreamInput input = output.bytes().streamInput();
+        BooleanNodeResponse deserializedNodeResponse = new BooleanNodeResponse(input);
+
+        // Assert
+        assertEquals(node, deserializedNodeResponse.getNode());
+        assertEquals(nodeResponse.isAnswerTrue(), deserializedNodeResponse.isAnswerTrue());
+    }
+
+    public void testBooleanResponseAnswerAggregation() {
+        // Arrange
+        DiscoveryNode node1 = new DiscoveryNode(
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponseTrue = new BooleanNodeResponse(node1, true);
+        BooleanNodeResponse nodeResponseFalse = new BooleanNodeResponse(node2, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponseTrue, nodeResponseFalse);
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        // Act
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Assert
+        assertTrue(response.isAnswerTrue()); // Since at least one node responded true
+    }
+
+    public void testBooleanResponseAllFalse() {
+        // Arrange
+        DiscoveryNode node1 = new DiscoveryNode(
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse1 = new BooleanNodeResponse(node1, false);
+        BooleanNodeResponse nodeResponse2 = new BooleanNodeResponse(node2, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponse1, nodeResponse2);
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        // Act
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Assert
+        assertFalse(response.isAnswerTrue()); // Since all nodes responded false
+    }
+
+    public void testToXContent() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse = new BooleanNodeResponse(node, true);
+        List<BooleanNodeResponse> nodes = Collections.singletonList(nodeResponse);
+        ClusterName clusterName = new ClusterName("test-cluster");
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Act
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String jsonString = builder.toString();
+
+        // Assert
+        assertTrue(jsonString.contains("\"answer\":true"));
+    }
+}


### PR DESCRIPTION
### Description
This PR adds support for forecast task targets in profile API and enables modification of categorical and custom result index fields
* Support forecast task targets in profile API: Previously, the profile API returned empty results for forecast task targets. This update adds support for them. For details, refer to ForecastTaskProfileRunner.
* Allow modification of categorical and custom result index fields in forecasting: These fields are not editable in Anomaly Detection (AD). Implemented a lastUiBreakingChangeTime field in the config index to manage changes. Whenever the categorical or custom result index fields are updated, lastUiBreakingChangeTime is refreshed. The UI will not display results before this time to prevent inconsistencies. For details, refer to Config and AbstractTimeSeriesActionHandler.

Testing Done:
* Added ITs for both scenarios.

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
