### PR TITLE
[backport to 2.x] backport PR 1316 and fix flaky test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -696,15 +696,11 @@ List<String> jacocoExclusions = [
 
         // TODO: add test coverage (kaituo)
         'org.opensearch.forecast.*',
-        'org.opensearch.ad.transport.ADHCImputeNodeResponse',
-        'org.opensearch.ad.transport.GetAnomalyDetectorTransportAction',
-        'org.opensearch.timeseries.transport.BooleanNodeResponse',
         'org.opensearch.timeseries.ml.TimeSeriesSingleStreamCheckpointDao',
         'org.opensearch.timeseries.transport.JobRequest',
         'org.opensearch.timeseries.transport.handler.ResultBulkIndexingHandler',
         'org.opensearch.timeseries.ml.Inferencer',
         'org.opensearch.timeseries.transport.SingleStreamResultRequest',
-        'org.opensearch.timeseries.transport.BooleanResponse',
         'org.opensearch.timeseries.rest.handler.IndexJobActionHandler.1',
         'org.opensearch.timeseries.transport.SuggestConfigParamResponse',
         'org.opensearch.timeseries.transport.SuggestConfigParamRequest',
@@ -732,6 +728,7 @@ List<String> jacocoExclusions = [
         'org.opensearch.timeseries.util.TimeUtil',
         'org.opensearch.ad.transport.ADHCImputeTransportAction',
         'org.opensearch.timeseries.ml.RealTimeInferencer',
+        'org.opensearch.timeseries.util.ExpiringValue',
 ]
 
 

--- a/src/main/java/org/opensearch/ad/ml/ADRealTimeInferencer.java
+++ b/src/main/java/org/opensearch/ad/ml/ADRealTimeInferencer.java
@@ -7,6 +7,8 @@ package org.opensearch.ad.ml;
 
 import static org.opensearch.timeseries.TimeSeriesAnalyticsPlugin.AD_THREAD_POOL_NAME;
 
+import java.time.Clock;
+
 import org.opensearch.ad.caching.ADCacheProvider;
 import org.opensearch.ad.caching.ADPriorityCache;
 import org.opensearch.ad.indices.ADIndex;
@@ -32,7 +34,8 @@ public class ADRealTimeInferencer extends
         ADColdStartWorker coldStartWorker,
         ADSaveResultStrategy resultWriteWorker,
         ADCacheProvider cache,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Clock clock
     ) {
         super(
             modelManager,
@@ -43,7 +46,8 @@ public class ADRealTimeInferencer extends
             resultWriteWorker,
             cache,
             threadPool,
-            AD_THREAD_POOL_NAME
+            AD_THREAD_POOL_NAME,
+            clock
         );
     }
 

--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -345,7 +345,8 @@ public class ADTask extends TimeSeriesTask {
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
                 detector.getCustomResultIndexTTL(),
-                detector.getFlattenResultIndexMapping()
+                detector.getFlattenResultIndexMapping(),
+                detector.getLastBreakingUIChangeTime()
             );
         return new Builder()
             .taskId(parsedTaskId)

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -151,6 +151,8 @@ public class AnomalyDetector extends Config {
      * @param customResultIndexMinAge custom result index lifecycle management min age condition
      * @param customResultIndexTTL custom result index lifecycle management ttl
      * @param flattenResultIndexMapping flag to indicate whether to flatten result index mapping or not
+     * @param lastBreakingUIChangeTime last update time to configuration that can break UI and we have
+     *  to display updates from the changed time
      */
     public AnomalyDetector(
         String detectorId,
@@ -178,7 +180,8 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime
     ) {
         super(
             detectorId,
@@ -206,7 +209,8 @@ public class AnomalyDetector extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
@@ -284,6 +288,7 @@ public class AnomalyDetector extends Config {
         this.customResultIndexMinAge = input.readOptionalInt();
         this.customResultIndexTTL = input.readOptionalInt();
         this.flattenResultIndexMapping = input.readOptionalBoolean();
+        this.lastUIBreakingChangeTime = input.readOptionalInstant();
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -350,6 +355,7 @@ public class AnomalyDetector extends Config {
         output.writeOptionalInt(customResultIndexMinAge);
         output.writeOptionalInt(customResultIndexTTL);
         output.writeOptionalBoolean(flattenResultIndexMapping);
+        output.writeOptionalInstant(lastUIBreakingChangeTime);
     }
 
     @Override
@@ -447,6 +453,7 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
         Boolean flattenResultIndexMapping = null;
+        Instant lastBreakingUIChangeTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -584,6 +591,9 @@ public class AnomalyDetector extends Config {
                 case FLATTEN_RESULT_INDEX_MAPPING:
                     flattenResultIndexMapping = onlyParseBooleanValue(parser);
                     break;
+                case BREAKING_UI_CHANGE_TIME:
+                    lastBreakingUIChangeTime = ParseUtils.toInstant(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -615,7 +625,8 @@ public class AnomalyDetector extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
         detector.setDetectionDateRange(detectionDateRange);
         return detector;

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -84,6 +84,11 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
             : WriteRequest.RefreshPolicy.IMMEDIATE;
         RestRequest.Method method = request.getHttpRequest().method();
 
+        if (method == RestRequest.Method.POST && detectorId != AnomalyDetector.NO_ID) {
+            // reset detector to empty string detectorId is only meant for updating detector
+            detectorId = AnomalyDetector.NO_ID;
+        }
+
         IndexAnomalyDetectorRequest indexAnomalyDetectorRequest = new IndexAnomalyDetectorRequest(
             detectorId,
             seqNo,

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -245,7 +245,8 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
             config.getCustomResultIndexTTL(),
-            config.getFlattenResultIndexMapping()
+            config.getFlattenResultIndexMapping(),
+            breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime()
         );
     }
 

--- a/src/main/java/org/opensearch/forecast/ForecastTaskProfileRunner.java
+++ b/src/main/java/org/opensearch/forecast/ForecastTaskProfileRunner.java
@@ -14,8 +14,18 @@ public class ForecastTaskProfileRunner implements TaskProfileRunner<ForecastTask
 
     @Override
     public void getTaskProfile(ForecastTask configLevelTask, ActionListener<ForecastTaskProfile> listener) {
-        // return null since forecasting have no in-memory task profiles as AD
-        listener.onResponse(null);
+        // return null in other fields since forecasting have no in-memory task profiles as AD
+        listener
+            .onResponse(
+                new ForecastTaskProfile(
+                    configLevelTask,
+                    null,
+                    null,
+                    null,
+                    configLevelTask == null ? null : configLevelTask.getTaskId(),
+                    null
+                )
+            );
     }
 
 }

--- a/src/main/java/org/opensearch/forecast/ml/ForecastRealTimeInferencer.java
+++ b/src/main/java/org/opensearch/forecast/ml/ForecastRealTimeInferencer.java
@@ -7,6 +7,8 @@ package org.opensearch.forecast.ml;
 
 import static org.opensearch.timeseries.TimeSeriesAnalyticsPlugin.FORECAST_THREAD_POOL_NAME;
 
+import java.time.Clock;
+
 import org.opensearch.forecast.caching.ForecastCacheProvider;
 import org.opensearch.forecast.caching.ForecastPriorityCache;
 import org.opensearch.forecast.indices.ForecastIndex;
@@ -32,7 +34,8 @@ public class ForecastRealTimeInferencer extends
         ForecastColdStartWorker coldStartWorker,
         ForecastSaveResultStrategy resultWriteWorker,
         ForecastCacheProvider cache,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Clock clock
     ) {
         super(
             modelManager,
@@ -43,7 +46,8 @@ public class ForecastRealTimeInferencer extends
             resultWriteWorker,
             cache,
             threadPool,
-            FORECAST_THREAD_POOL_NAME
+            FORECAST_THREAD_POOL_NAME,
+            clock
         );
     }
 

--- a/src/main/java/org/opensearch/forecast/model/ForecastTask.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastTask.java
@@ -343,7 +343,8 @@ public class ForecastTask extends TimeSeriesTask {
                 forecaster.getCustomResultIndexMinSize(),
                 forecaster.getCustomResultIndexMinAge(),
                 forecaster.getCustomResultIndexTTL(),
-                forecaster.getFlattenResultIndexMapping()
+                forecaster.getFlattenResultIndexMapping(),
+                forecaster.getLastBreakingUIChangeTime()
             );
         return new Builder()
             .taskId(parsedTaskId)
@@ -375,10 +376,12 @@ public class ForecastTask extends TimeSeriesTask {
     @Generated
     @Override
     public boolean equals(Object other) {
-        if (this == other)
+        if (this == other) {
             return true;
-        if (other == null || getClass() != other.getClass())
+        }
+        if (other == null || getClass() != other.getClass()) {
             return false;
+        }
         ForecastTask that = (ForecastTask) other;
         return super.equals(that)
             && Objects.equal(getForecaster(), that.getForecaster())

--- a/src/main/java/org/opensearch/forecast/model/Forecaster.java
+++ b/src/main/java/org/opensearch/forecast/model/Forecaster.java
@@ -135,7 +135,8 @@ public class Forecaster extends Config {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime
     ) {
         super(
             forecasterId,
@@ -163,7 +164,8 @@ public class Forecaster extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
 
         checkAndThrowValidationErrors(ValidationAspect.FORECASTER);
@@ -306,6 +308,7 @@ public class Forecaster extends Config {
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
         Boolean flattenResultIndexMapping = null;
+        Instant lastBreakingUIChangeTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -437,6 +440,9 @@ public class Forecaster extends Config {
                 case FLATTEN_RESULT_INDEX_MAPPING:
                     flattenResultIndexMapping = parser.booleanValue();
                     break;
+                case BREAKING_UI_CHANGE_TIME:
+                    lastBreakingUIChangeTime = ParseUtils.toInstant(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -468,7 +474,8 @@ public class Forecaster extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime
         );
         return forecaster;
     }

--- a/src/main/java/org/opensearch/forecast/rest/RestIndexForecasterAction.java
+++ b/src/main/java/org/opensearch/forecast/rest/RestIndexForecasterAction.java
@@ -87,6 +87,11 @@ public class RestIndexForecasterAction extends AbstractForecasterAction {
                 : WriteRequest.RefreshPolicy.IMMEDIATE;
             RestRequest.Method method = request.getHttpRequest().method();
 
+            if (method == RestRequest.Method.POST && forecasterId != Config.NO_ID) {
+                // reset detector to empty string detectorId is only meant for updating detector
+                forecasterId = Config.NO_ID;
+            }
+
             IndexForecasterRequest indexAnomalyDetectorRequest = new IndexForecasterRequest(
                 forecasterId,
                 seqNo,

--- a/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
+++ b/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
@@ -258,7 +258,8 @@ public abstract class AbstractForecasterActionHandler<T extends ActionResponse> 
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
             config.getCustomResultIndexTTL(),
-            config.getFlattenResultIndexMapping()
+            config.getFlattenResultIndexMapping(),
+            breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime()
         );
     }
 

--- a/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
@@ -840,7 +840,8 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
             adColdstartQueue,
             adSaveResultStrategy,
             adCacheProvider,
-            threadPool
+            threadPool,
+            getClock()
         );
 
         ADCheckpointReadWorker adCheckpointReadQueue = new ADCheckpointReadWorker(
@@ -1230,7 +1231,8 @@ public class TimeSeriesAnalyticsPlugin extends Plugin implements ActionPlugin, S
             forecastColdstartQueue,
             forecastSaveResultStrategy,
             forecastCacheProvider,
-            threadPool
+            threadPool,
+            getClock()
         );
 
         ForecastCheckpointReadWorker forecastCheckpointReadQueue = new ForecastCheckpointReadWorker(

--- a/src/main/java/org/opensearch/timeseries/caching/PriorityCache.java
+++ b/src/main/java/org/opensearch/timeseries/caching/PriorityCache.java
@@ -174,7 +174,7 @@ public abstract class PriorityCache<RCFModelType extends ThresholdedRandomCutFor
                     // reset every 60 intervals
                     return new DoorKeeper(
                         TimeSeriesSettings.DOOR_KEEPER_FOR_CACHE_MAX_INSERTION,
-                        config.getIntervalDuration().multipliedBy(TimeSeriesSettings.DOOR_KEEPER_MAINTENANCE_FREQ),
+                        config.getIntervalDuration().multipliedBy(TimeSeriesSettings.EXPIRING_VALUE_MAINTENANCE_FREQ),
                         clock,
                         TimeSeriesSettings.CACHE_DOOR_KEEPER_COUNT_THRESHOLD
                     );

--- a/src/main/java/org/opensearch/timeseries/ml/ModelColdStart.java
+++ b/src/main/java/org/opensearch/timeseries/ml/ModelColdStart.java
@@ -241,7 +241,7 @@ public abstract class ModelColdStart<RCFModelType extends ThresholdedRandomCutFo
                 // reset every 60 intervals
                 return new DoorKeeper(
                     TimeSeriesSettings.DOOR_KEEPER_FOR_COLD_STARTER_MAX_INSERTION,
-                    config.getIntervalDuration().multipliedBy(TimeSeriesSettings.DOOR_KEEPER_MAINTENANCE_FREQ),
+                    config.getIntervalDuration().multipliedBy(TimeSeriesSettings.EXPIRING_VALUE_MAINTENANCE_FREQ),
                     clock,
                     TimeSeriesSettings.COLD_START_DOOR_KEEPER_COUNT_THRESHOLD
                 );
@@ -251,7 +251,7 @@ public abstract class ModelColdStart<RCFModelType extends ThresholdedRandomCutFo
                 logger
                     .info(
                         "Won't retry real-time cold start within {} intervals for model {}",
-                        TimeSeriesSettings.DOOR_KEEPER_MAINTENANCE_FREQ,
+                        TimeSeriesSettings.EXPIRING_VALUE_MAINTENANCE_FREQ,
                         modelId
                     );
                 return;

--- a/src/main/java/org/opensearch/timeseries/ml/ModelManager.java
+++ b/src/main/java/org/opensearch/timeseries/ml/ModelManager.java
@@ -169,7 +169,7 @@ public abstract class ModelManager<RCFModelType extends ThresholdedRandomCutFore
             throw e;
         } finally {
             modelState.setLastUsedTime(clock.instant());
-            modelState.setLastSeenExecutionEndTime(clock.instant());
+            modelState.setLastSeenDataEndTime(sample.getDataEndTime());
         }
         return createEmptyResult();
     }

--- a/src/main/java/org/opensearch/timeseries/ml/ModelState.java
+++ b/src/main/java/org/opensearch/timeseries/ml/ModelState.java
@@ -36,7 +36,7 @@ public class ModelState<T> implements org.opensearch.timeseries.ExpiringState {
     // time when the ML model was used last time
     protected Instant lastUsedTime;
     protected Instant lastCheckpointTime;
-    protected Instant lastSeenExecutionEndTime;
+    protected Instant lastSeenDataEndTime;
     protected Clock clock;
     protected float priority;
     protected Deque<Sample> samples;
@@ -75,7 +75,7 @@ public class ModelState<T> implements org.opensearch.timeseries.ExpiringState {
         this.priority = priority;
         this.entity = entity;
         this.samples = samples;
-        this.lastSeenExecutionEndTime = Instant.MIN;
+        this.lastSeenDataEndTime = Instant.MIN;
     }
 
     /**
@@ -252,11 +252,11 @@ public class ModelState<T> implements org.opensearch.timeseries.ExpiringState {
         };
     }
 
-    public Instant getLastSeenExecutionEndTime() {
-        return lastSeenExecutionEndTime;
+    public Instant getLastSeenDataEndTime() {
+        return lastSeenDataEndTime;
     }
 
-    public void setLastSeenExecutionEndTime(Instant lastSeenExecutionEndTime) {
-        this.lastSeenExecutionEndTime = lastSeenExecutionEndTime;
+    public void setLastSeenDataEndTime(Instant lastSeenExecutionEndTime) {
+        this.lastSeenDataEndTime = lastSeenExecutionEndTime;
     }
 }

--- a/src/main/java/org/opensearch/timeseries/ml/RealTimeInferencer.java
+++ b/src/main/java/org/opensearch/timeseries/ml/RealTimeInferencer.java
@@ -5,10 +5,12 @@
 
 package org.opensearch.timeseries.ml;
 
-import java.util.Collections;
+import java.time.Clock;
+import java.util.Comparator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.PriorityQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -19,8 +21,10 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.timeseries.MaintenanceState;
 import org.opensearch.timeseries.caching.CacheProvider;
 import org.opensearch.timeseries.caching.TimeSeriesCache;
+import org.opensearch.timeseries.common.exception.TimeSeriesException;
 import org.opensearch.timeseries.indices.IndexManagement;
 import org.opensearch.timeseries.indices.TimeSeriesIndex;
 import org.opensearch.timeseries.model.Config;
@@ -31,7 +35,9 @@ import org.opensearch.timeseries.ratelimit.ColdStartWorker;
 import org.opensearch.timeseries.ratelimit.FeatureRequest;
 import org.opensearch.timeseries.ratelimit.RequestPriority;
 import org.opensearch.timeseries.ratelimit.SaveResultStrategy;
+import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.stats.Stats;
+import org.opensearch.timeseries.util.ExpiringValue;
 
 import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
 
@@ -39,7 +45,10 @@ import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
  * Since we assume model state's last access time is current time and compare it with incoming data's execution time,
  * this class is only meant to be used by real time analysis.
  */
-public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomCutForest, ResultType extends IndexableResult, RCFResultType extends IntermediateResult<ResultType>, IndexType extends Enum<IndexType> & TimeSeriesIndex, IndexManagementType extends IndexManagement<IndexType>, CheckpointDaoType extends CheckpointDao<RCFModelType, IndexType, IndexManagementType>, CheckpointWriterType extends CheckpointWriteWorker<RCFModelType, IndexType, IndexManagementType, CheckpointDaoType>, ColdStarterType extends ModelColdStart<RCFModelType, IndexType, IndexManagementType, CheckpointDaoType, CheckpointWriterType>, ModelManagerType extends ModelManager<RCFModelType, ResultType, RCFResultType, IndexType, IndexManagementType, CheckpointDaoType, CheckpointWriterType, ColdStarterType>, SaveResultStrategyType extends SaveResultStrategy<ResultType, RCFResultType>, CacheType extends TimeSeriesCache<RCFModelType>, ColdStartWorkerType extends ColdStartWorker<RCFModelType, IndexType, IndexManagementType, CheckpointDaoType, CheckpointWriterType, ColdStarterType, CacheType, ResultType, RCFResultType, ModelManagerType, SaveResultStrategyType>> {
+public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomCutForest, ResultType extends IndexableResult, RCFResultType extends IntermediateResult<ResultType>, IndexType extends Enum<IndexType> & TimeSeriesIndex, IndexManagementType extends IndexManagement<IndexType>, CheckpointDaoType extends CheckpointDao<RCFModelType, IndexType, IndexManagementType>, CheckpointWriterType extends CheckpointWriteWorker<RCFModelType, IndexType, IndexManagementType, CheckpointDaoType>, ColdStarterType extends ModelColdStart<RCFModelType, IndexType, IndexManagementType, CheckpointDaoType, CheckpointWriterType>, ModelManagerType extends ModelManager<RCFModelType, ResultType, RCFResultType, IndexType, IndexManagementType, CheckpointDaoType, CheckpointWriterType, ColdStarterType>, SaveResultStrategyType extends SaveResultStrategy<ResultType, RCFResultType>, CacheType extends TimeSeriesCache<RCFModelType>, ColdStartWorkerType extends ColdStartWorker<RCFModelType, IndexType, IndexManagementType, CheckpointDaoType, CheckpointWriterType, ColdStarterType, CacheType, ResultType, RCFResultType, ModelManagerType, SaveResultStrategyType>>
+    implements
+        MaintenanceState {
+
     private static final Logger LOG = LogManager.getLogger(RealTimeInferencer.class);
     protected ModelManagerType modelManager;
     protected Stats stats;
@@ -48,9 +57,18 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
     protected ColdStartWorkerType coldStartWorker;
     protected SaveResultStrategyType resultWriteWorker;
     private CacheProvider<RCFModelType, CacheType> cache;
-    private Map<String, Lock> modelLocks = Collections.synchronizedMap(new WeakHashMap<>());
+    // ensure no two threads can score samples at the same time which can happen in tests
+    // where we send a lot of requests in a fast pace and the run API returns immediately
+    // without waiting for the requests get finished processing. It can also happen in
+    // production as the impute request and actual data scoring in the next interval
+    // can happen at the same time.
+    private Map<String, ExpiringValue<Lock>> modelLocks;
     private ThreadPool threadPool;
     private String threadPoolName;
+    // ensure we process samples in the ascending order of time in case race conditions.
+    private Map<String, ExpiringValue<PriorityQueue<Sample>>> sampleQueues;
+    private Comparator<Sample> sampleComparator;
+    private Clock clock;
 
     public RealTimeInferencer(
         ModelManagerType modelManager,
@@ -61,7 +79,8 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
         SaveResultStrategyType resultWriteWorker,
         CacheProvider<RCFModelType, CacheType> cache,
         ThreadPool threadPool,
-        String threadPoolName
+        String threadPoolName,
+        Clock clock
     ) {
         this.modelManager = modelManager;
         this.stats = stats;
@@ -72,10 +91,10 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
         this.cache = cache;
         this.threadPool = threadPool;
         this.threadPoolName = threadPoolName;
-        // WeakHashMap allows for automatic removal of entries when the key is no longer referenced elsewhere.
-        // This helps prevent memory leaks as the garbage collector can reclaim memory when modelId is no
-        // longer in use.
-        this.modelLocks = Collections.synchronizedMap(new WeakHashMap<>());
+        this.modelLocks = new ConcurrentHashMap<>();
+        this.sampleQueues = new ConcurrentHashMap<>();
+        this.sampleComparator = Comparator.comparing(Sample::getDataEndTime);
+        this.clock = clock;
     }
 
     /**
@@ -87,43 +106,65 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
      * @return whether process succeeds or not
      */
     public boolean process(Sample sample, ModelState<RCFModelType> modelState, Config config, String taskId) {
-        long windowDelayMillis = config.getWindowDelay() == null
-            ? 0
-            : ((IntervalTimeConfiguration) config.getWindowDelay()).toDuration().toMillis();
-        long curExecutionEnd = sample.getDataEndTime().toEpochMilli() + windowDelayMillis;
-        long nextExecutionEnd = curExecutionEnd + config.getIntervalInMilliseconds();
-
-        return processWithTimeout(sample, modelState, config, taskId, curExecutionEnd, nextExecutionEnd);
+        String modelId = modelState.getModelId();
+        ExpiringValue<PriorityQueue<Sample>> expiringSampleQueue = sampleQueues
+            .computeIfAbsent(
+                modelId,
+                k -> new ExpiringValue<>(
+                    new PriorityQueue<>(sampleComparator),
+                    config.getIntervalDuration().multipliedBy(TimeSeriesSettings.EXPIRING_VALUE_MAINTENANCE_FREQ).toMillis(),
+                    clock
+                )
+            );
+        expiringSampleQueue.getValue().add(sample);
+        return processWithTimeout(modelState, config, taskId, sample);
     }
 
-    private boolean processWithTimeout(
-        Sample sample,
-        ModelState<RCFModelType> modelState,
-        Config config,
-        String taskId,
-        long curExecutionEnd,
-        long nextExecutionEnd
-    ) {
+    private boolean processWithTimeout(ModelState<RCFModelType> modelState, Config config, String taskId, Sample sample) {
         String modelId = modelState.getModelId();
-        ReentrantLock lock = (ReentrantLock) modelLocks.computeIfAbsent(modelId, k -> new ReentrantLock());
+        ReentrantLock lock = (ReentrantLock) modelLocks
+            .computeIfAbsent(
+                modelId,
+                k -> new ExpiringValue<>(
+                    new ReentrantLock(),
+                    config.getIntervalDuration().multipliedBy(TimeSeriesSettings.EXPIRING_VALUE_MAINTENANCE_FREQ).toMillis(),
+                    clock
+                )
+            )
+            .getValue();
 
+        boolean success = false;
         if (lock.tryLock()) {
             try {
-                tryProcess(sample, modelState, config, taskId, curExecutionEnd);
+                PriorityQueue<Sample> queue = sampleQueues.get(modelId).getValue();
+                while (!queue.isEmpty()) {
+                    Sample curSample = queue.poll();
+                    long windowDelayMillis = config.getWindowDelay() == null
+                        ? 0
+                        : ((IntervalTimeConfiguration) config.getWindowDelay()).toDuration().toMillis();
+                    long curExecutionEnd = curSample.getDataEndTime().toEpochMilli() + windowDelayMillis;
+
+                    success = tryProcess(curSample, modelState, config, taskId, curExecutionEnd);
+                }
             } finally {
                 if (lock.isHeldByCurrentThread()) {
                     lock.unlock();
                 }
             }
-            return true;
         } else {
-            if (System.currentTimeMillis() >= nextExecutionEnd) {
+            long windowDelayMillis = config.getWindowDelay() == null
+                ? 0
+                : ((IntervalTimeConfiguration) config.getWindowDelay()).toDuration().toMillis();
+            long curExecutionEnd = sample.getDataEndTime().toEpochMilli() + windowDelayMillis;
+            long nextExecutionEnd = curExecutionEnd + config.getIntervalInMilliseconds();
+            // schedule a retry if not already time out
+            if (clock.millis() >= nextExecutionEnd) {
                 LOG.warn("Timeout reached, not retrying.");
             } else {
                 // Schedule a retry in one second
                 threadPool
                     .schedule(
-                        () -> processWithTimeout(sample, modelState, config, taskId, curExecutionEnd, nextExecutionEnd),
+                        () -> processWithTimeout(modelState, config, taskId, sample),
                         new TimeValue(1, TimeUnit.SECONDS),
                         threadPoolName
                     );
@@ -131,6 +172,7 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
 
             return false;
         }
+        return success;
     }
 
     private boolean tryProcess(Sample sample, ModelState<RCFModelType> modelState, Config config, String taskId, long curExecutionEnd) {
@@ -193,7 +235,7 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
         coldStartWorker
             .put(
                 new FeatureRequest(
-                    System.currentTimeMillis() + config.getIntervalInMilliseconds(),
+                    clock.millis() + config.getIntervalInMilliseconds(),
                     config.getId(),
                     RequestPriority.MEDIUM,
                     modelId,
@@ -202,5 +244,17 @@ public abstract class RealTimeInferencer<RCFModelType extends ThresholdedRandomC
                     taskId
                 )
             );
+    }
+
+    @Override
+    public void maintenance() {
+        try {
+            sampleQueues.entrySet().removeIf(entry -> entry.getValue().isExpired());
+            modelLocks.entrySet().removeIf(entry -> entry.getValue().isExpired());
+        } catch (Exception e) {
+            // will be thrown to transport broadcast handler
+            throw new TimeSeriesException("Fail to maintain RealTimeInferencer", e);
+        }
+
     }
 }

--- a/src/main/java/org/opensearch/timeseries/settings/TimeSeriesSettings.java
+++ b/src/main/java/org/opensearch/timeseries/settings/TimeSeriesSettings.java
@@ -57,7 +57,7 @@ public class TimeSeriesSettings {
     public static final int DOOR_KEEPER_FOR_COLD_STARTER_MAX_INSERTION = 100_000;
 
     // clean up door keeper every 60 intervals
-    public static final int DOOR_KEEPER_MAINTENANCE_FREQ = 60;
+    public static final int EXPIRING_VALUE_MAINTENANCE_FREQ = 60;
 
     // 1 million insertion costs roughly 1 MB.
     public static final int DOOR_KEEPER_FOR_CACHE_MAX_INSERTION = 1_000_000;

--- a/src/main/java/org/opensearch/timeseries/transport/BooleanNodeResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BooleanNodeResponse.java
@@ -31,6 +31,7 @@ public class BooleanNodeResponse extends BaseNodeResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
         out.writeBoolean(answer);
     }
 }

--- a/src/main/java/org/opensearch/timeseries/transport/BooleanResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BooleanResponse.java
@@ -37,6 +37,7 @@ public class BooleanResponse extends BaseNodesResponse<BooleanNodeResponse> impl
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
         out.writeBoolean(answer);
     }
 

--- a/src/main/java/org/opensearch/timeseries/util/ExpiringValue.java
+++ b/src/main/java/org/opensearch/timeseries/util/ExpiringValue.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.timeseries.util;
+
+import java.time.Clock;
+
+public class ExpiringValue<V> {
+    private V value;
+    private long lastAccessTime;
+    private long expirationTimeInMillis;
+    private Clock clock;
+
+    public ExpiringValue(V value, long expirationTimeInMillis, Clock clock) {
+        this.value = value;
+        this.expirationTimeInMillis = expirationTimeInMillis;
+        this.clock = clock;
+        updateLastAccessTime();
+    }
+
+    public V getValue() {
+        updateLastAccessTime();
+        return value;
+    }
+
+    public boolean isExpired() {
+        return isExpired(clock.millis());
+    }
+
+    public boolean isExpired(long currentTimeMillis) {
+        return (currentTimeMillis - lastAccessTime) >= expirationTimeInMillis;
+    }
+
+    public void updateLastAccessTime() {
+        lastAccessTime = clock.millis();
+    }
+}

--- a/src/main/resources/mappings/anomaly-detection-state.json
+++ b/src/main/resources/mappings/anomaly-detection-state.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 4
+    "schema_version": 5
   },
   "properties": {
     "schema_version": {

--- a/src/main/resources/mappings/config.json
+++ b/src/main/resources/mappings/config.json
@@ -1,7 +1,7 @@
 {
     "dynamic": false,
     "_meta": {
-        "schema_version": 6
+        "schema_version": 7
     },
     "properties": {
         "schema_version": {
@@ -232,6 +232,10 @@
         },
         "flatten_result_index_mapping": {
             "type": "boolean"
+        },
+        "last_ui_breaking_change_time" : {
+            "type": "date",
+            "format": "strict_date_time||epoch_millis"
         }
     }
 }

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -859,7 +859,8 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractTimeSeriesTe
                         detector.getCustomResultIndexMinSize(),
                         detector.getCustomResultIndexMinAge(),
                         detector.getCustomResultIndexTTL(),
-                        detector.getFlattenResultIndexMapping()
+                        detector.getFlattenResultIndexMapping(),
+                        Instant.now()
                     );
                     try {
                         listener.onResponse((Response) TestHelpers.createGetResponse(clone, clone.getId(), CommonName.CONFIG_INDEX));

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -315,7 +315,8 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
                 detector.getCustomResultIndexTTL(),
-                detector.getFlattenResultIndexMapping()
+                detector.getFlattenResultIndexMapping(),
+                detector.getLastBreakingUIChangeTime()
             ),
             detectorJob,
             historicalAdTask,
@@ -642,7 +643,8 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             anomalyDetector.getCustomResultIndexMinSize(),
             anomalyDetector.getCustomResultIndexMinAge(),
             anomalyDetector.getCustomResultIndexTTL(),
-            anomalyDetector.getFlattenResultIndexMapping()
+            anomalyDetector.getFlattenResultIndexMapping(),
+            Instant.now()
         );
         return detector;
     }

--- a/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/org/opensearch/ad/ml/EntityColdStarterTests.java
@@ -1144,7 +1144,7 @@ public class EntityColdStarterTests extends AbstractCosineDataTest {
 
         // make sure when the next maintenance coming, current door keeper gets reset
         // note our detector interval is 1 minute and the door keeper will expire in 60 intervals, which are 60 minutes
-        when(clock.instant()).thenReturn(Instant.now().plus(TimeSeriesSettings.DOOR_KEEPER_MAINTENANCE_FREQ + 1, ChronoUnit.MINUTES));
+        when(clock.instant()).thenReturn(Instant.now().plus(TimeSeriesSettings.EXPIRING_VALUE_MAINTENANCE_FREQ + 1, ChronoUnit.MINUTES));
         entityColdStarter.maintenance();
 
         modelState = createStateForCacheRelease();

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -344,7 +344,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -381,7 +382,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -418,7 +420,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -455,7 +458,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -492,7 +496,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -529,7 +534,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -566,7 +572,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    Instant.now()
                 )
             );
     }
@@ -602,7 +609,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Recency emphasis must be an integer greater than 1.", exception.getMessage());
@@ -639,7 +647,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Detection interval must be a positive integer", exception.getMessage());
@@ -676,7 +685,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Interval -1 should be non-negative", exception.getMessage());
@@ -726,7 +736,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
     }
@@ -761,7 +772,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         // seasonalityIntervals is not null and custom shingle size is null, use seasonalityIntervals to deterine shingle size
         assertEquals(seasonalityIntervals / TimeSeriesSettings.SEASONALITY_TO_SHINGLE_RATIO, (int) anomalyDetector.getShingleSize());
@@ -792,7 +804,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         // seasonalityIntervals is null and custom shingle size is null, use default shingle size
         assertEquals(TimeSeriesSettings.DEFAULT_SHINGLE_SIZE, (int) anomalyDetector.getShingleSize());
@@ -825,7 +838,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         assertNotNull(anomalyDetector.getFeatureAttributes());
         assertEquals(0, anomalyDetector.getFeatureAttributes().size());
@@ -858,7 +872,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         String errorMessage = anomalyDetector.validateCustomResultIndex("abc");
         assertEquals(ADCommonMessages.INVALID_RESULT_INDEX_PREFIX, errorMessage);
@@ -1025,7 +1040,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                Instant.now()
             )
         );
         assertEquals("Got: " + e.getMessage(), "Enabled features are present, but no default fill values are provided.", e.getMessage());

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -159,7 +160,8 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             coldstartQueue,
             resultWriteStrategy,
             cacheProvider,
-            threadPool
+            threadPool,
+            mock(Clock.class)
         );
 
         // Integer.MAX_VALUE makes a huge heap

--- a/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
+++ b/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
@@ -226,7 +226,8 @@ public class ADRestTestUtils {
             null,
             null,
             null,
-            null
+            null,
+            now
         );
 
         if (historical) {
@@ -316,7 +317,6 @@ public class ADRestTestUtils {
                 TestHelpers.LEGACY_OPENDISTRO_AD_BASE_DETECTORS_URI + "/results/_search",
                 ImmutableMap.of(),
                 TestHelpers.toHttpEntity(query),
-
                 null
             );
         Map<String, Object> responseMap = entityAsMap(searchAdTaskResponse);
@@ -342,7 +342,6 @@ public class ADRestTestUtils {
                 TestHelpers.LEGACY_OPENDISTRO_AD_BASE_DETECTORS_URI + "/_search",
                 ImmutableMap.of(),
                 TestHelpers.toHttpEntity(query),
-
                 null
             );
         Map<String, Object> responseMap = entityAsMap(searchAdTaskResponse);

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -54,6 +54,7 @@ import org.opensearch.timeseries.model.Feature;
 import org.opensearch.timeseries.model.Job;
 import org.opensearch.timeseries.rest.handler.AbstractTimeSeriesActionHandler;
 import org.opensearch.timeseries.settings.TimeSeriesSettings;
+import org.opensearch.timeseries.util.RestHandlerUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -159,6 +160,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -205,6 +207,23 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         int version = (int) responseMap.get("_version");
         assertNotEquals("response is missing Id", AnomalyDetector.NO_ID, id);
         assertTrue("incorrect version", version > 0);
+
+        // users cannot specify detector id when creating a detector
+        AnomalyDetector detector2 = createIndexAndGetAnomalyDetector(INDEX_NAME);
+        String blahId = "__blah__";
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI,
+                ImmutableMap.of(RestHandlerUtils.DETECTOR_ID, blahId),
+                TestHelpers.toHttpEntity(detector2),
+                null
+            );
+        assertEquals("Create anomaly detector failed", RestStatus.CREATED, TestHelpers.restStatus(response));
+        responseMap = entityAsMap(response);
+        id = (String) responseMap.get("_id");
+        assertNotEquals("response is missing Id", blahId, id);
     }
 
     public void testCreateAnomalyDetectorWithDateNanos() throws Exception {
@@ -271,7 +290,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
         Exception ex = expectThrows(
             ResponseException.class,
@@ -338,7 +358,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
 
         updateClusterSettings(ADEnabledSetting.AD_ENABLED, false);
@@ -410,7 +431,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector1.getLastBreakingUIChangeTime()
         );
 
         TestHelpers
@@ -459,7 +481,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
 
         TestHelpers
@@ -514,7 +537,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
 
         deleteIndexWithAdminClient(CommonName.CONFIG_INDEX);
@@ -886,7 +910,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            detector.getLastBreakingUIChangeTime()
         );
 
         TestHelpers

--- a/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
@@ -349,7 +349,8 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
             detector.getCustomResultIndexMinSize(),
             detector.getCustomResultIndexMinAge(),
             detector.getCustomResultIndexTTL(),
-            detector.getFlattenResultIndexMapping()
+            detector.getFlattenResultIndexMapping(),
+            detector.getLastBreakingUIChangeTime()
         );
     }
 

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.http.HttpHeaders;
@@ -73,34 +74,66 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         String lowerCase = "abcdefghijklmnopqrstuvwxyz";
         String digits = "0123456789";
         String special = "_";
+
+        // Remove characters from username (case-insensitive)
+        String usernameLower = username.toLowerCase(Locale.ROOT);
+        for (char c : usernameLower.toCharArray()) {
+            upperCase = upperCase.replaceAll("(?i)" + c, "");
+            lowerCase = lowerCase.replaceAll("(?i)" + c, "");
+            digits = digits.replace(String.valueOf(c), "");
+            special = special.replace(String.valueOf(c), "");
+        }
+
+        // Combine all remaining characters
         String characters = upperCase + lowerCase + digits + special;
 
+        // Check if we have enough characters to proceed
+        if (characters.length() < 4) {
+            throw new IllegalArgumentException("Not enough characters to generate password without using username characters.");
+        }
+
         SecureRandom rng = new SecureRandom();
+        String password;
 
-        // Ensure password includes at least one character from each set
-        char[] password = new char[15];
-        password[0] = upperCase.charAt(rng.nextInt(upperCase.length()));
-        password[1] = lowerCase.charAt(rng.nextInt(lowerCase.length()));
-        password[2] = digits.charAt(rng.nextInt(digits.length()));
-        password[3] = special.charAt(rng.nextInt(special.length()));
+        do {
+            // Ensure password includes at least one character from each set, if available
+            StringBuilder passwordBuilder = new StringBuilder();
+            if (!upperCase.isEmpty()) {
+                passwordBuilder.append(upperCase.charAt(rng.nextInt(upperCase.length())));
+            }
+            if (!lowerCase.isEmpty()) {
+                passwordBuilder.append(lowerCase.charAt(rng.nextInt(lowerCase.length())));
+            }
+            if (!digits.isEmpty()) {
+                passwordBuilder.append(digits.charAt(rng.nextInt(digits.length())));
+            }
+            if (!special.isEmpty()) {
+                passwordBuilder.append(special.charAt(rng.nextInt(special.length())));
+            }
 
-        for (int i = 4; i < 15; i++) {
-            char nextChar;
-            do {
-                nextChar = characters.charAt(rng.nextInt(characters.length()));
-            } while (username.indexOf(nextChar) > -1);
-            password[i] = nextChar;
-        }
+            // Fill the rest of the password length with random characters
+            int remainingLength = 15 - passwordBuilder.length();
+            for (int i = 0; i < remainingLength; i++) {
+                passwordBuilder.append(characters.charAt(rng.nextInt(characters.length())));
+            }
 
-        // Shuffle the array to ensure the first 4 characters are not always in the same position
-        for (int i = password.length - 1; i > 0; i--) {
-            int index = rng.nextInt(i + 1);
-            char temp = password[index];
-            password[index] = password[i];
-            password[i] = temp;
-        }
+            // Convert to char array for shuffling
+            char[] passwordChars = passwordBuilder.toString().toCharArray();
 
-        return new String(password);
+            // Shuffle the password characters
+            for (int i = passwordChars.length - 1; i > 0; i--) {
+                int index = rng.nextInt(i + 1);
+                char temp = passwordChars[index];
+                passwordChars[index] = passwordChars[i];
+                passwordChars[i] = temp;
+            }
+
+            password = new String(passwordChars);
+
+            // Repeat if password contains the username as a substring (case-insensitive)
+        } while (password.toLowerCase(Locale.ROOT).contains(usernameLower.toLowerCase(Locale.ROOT)));
+
+        return password;
     }
 
     @Before
@@ -304,7 +337,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         // User client has admin all access, and has "opensearch" backend role so client should be able to update detector
         // But the detector's backend role should not be replaced as client's backend roles (all_access).
@@ -359,7 +393,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         enableFilterBy();
         // User Fish has AD full access, and has "odfe" backend role which is one of Alice's backend role, so

--- a/src/test/java/org/opensearch/ad/transport/ADHCImputeNodesResponseTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADHCImputeNodesResponseTests.java
@@ -115,4 +115,29 @@ public class ADHCImputeNodesResponseTests extends OpenSearchTestCase {
         assertNotNull(deserializedNodeResponse.getPreviousException());
         assertEquals("exception: " + previousException.getMessage(), deserializedNodeResponse.getPreviousException().getMessage());
     }
+
+    public void testNoExceptionSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        ADHCImputeNodeResponse nodeResponse = new ADHCImputeNodeResponse(node, null);
+
+        // Act: Serialize the node response
+        BytesStreamOutput output = new BytesStreamOutput();
+        nodeResponse.writeTo(output);
+
+        // Deserialize the node response
+        StreamInput input = output.bytes().streamInput();
+        ADHCImputeNodeResponse deserializedNodeResponse = new ADHCImputeNodeResponse(input);
+
+        // Assert
+        assertEquals(node, deserializedNodeResponse.getNode());
+        assertNull(deserializedNodeResponse.getPreviousException());
+    }
 }

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -37,6 +37,7 @@ import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.timeseries.TestHelpers.createIndexBlockedState;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -365,7 +366,8 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
             coldStartWorker,
             mock(ADSaveResultStrategy.class),
             cacheProvider,
-            threadPool
+            threadPool,
+            mock(Clock.class)
         );
     }
 
@@ -625,7 +627,8 @@ public class AnomalyResultTests extends AbstractTimeSeriesTest {
             coldStartWorker,
             mock(ADSaveResultStrategy.class),
             cacheProvider,
-            threadPool
+            threadPool,
+            mock(Clock.class)
         );
 
         ADPriorityCache adPriorityCache = mock(ADPriorityCache.class);

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -227,7 +227,8 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -258,7 +259,8 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 

--- a/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
@@ -264,7 +264,16 @@ public class EntityResultTransportActionTests extends AbstractTimeSeriesTest {
         adStats = new ADStats(statsMap);
         resultSaver = new ADSaveResultStrategy(1, resultWriteQueue);
 
-        inferencer = new ADRealTimeInferencer(manager, adStats, checkpointDao, entityColdStartQueue, resultSaver, provider, threadPool);
+        inferencer = new ADRealTimeInferencer(
+            manager,
+            adStats,
+            checkpointDao,
+            entityColdStartQueue,
+            resultSaver,
+            provider,
+            threadPool,
+            clock
+        );
 
         entityResult = new EntityADResultTransportAction(
             actionFilters,
@@ -397,7 +406,8 @@ public class EntityResultTransportActionTests extends AbstractTimeSeriesTest {
             entityColdStartQueue,
             resultSaver,
             provider,
-            threadPool
+            threadPool,
+            clock
         );
         entityResult = new EntityADResultTransportAction(
             actionFilters,

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
@@ -86,7 +86,8 @@ public class ForwardADTaskRequestTests extends OpenSearchSingleNodeTestCase {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         ForwardADTaskRequest request = new ForwardADTaskRequest(detector, null, null, null, null, Version.V_2_1_0);
         ActionRequestValidationException validate = request.validate();

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -330,7 +330,8 @@ public class MultiEntityResultTests extends AbstractTimeSeriesTest {
             entityColdStartQueue,
             resultSaver,
             provider,
-            threadPool
+            threadPool,
+            clock
         );
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -405,7 +405,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateConfigRequest request = new ValidateConfigRequest(
@@ -454,7 +455,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
         ValidateConfigRequest request = new ValidateConfigRequest(

--- a/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
+++ b/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
@@ -90,7 +90,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastUpdateTime
         );
 
         assertEquals(forecasterId, forecaster.getId());
@@ -144,7 +145,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -183,7 +185,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -222,7 +225,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -261,7 +265,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -300,7 +305,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 
@@ -338,7 +344,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping
+            flattenResultIndexMapping,
+            lastUpdateTime
         );
 
         assertEquals(resultIndex, forecaster.getCustomResultIndexOrAlias());
@@ -374,7 +381,8 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         });
 

--- a/src/test/java/org/opensearch/forecast/rest/ForecastRestApiIT.java
+++ b/src/test/java/org/opensearch/forecast/rest/ForecastRestApiIT.java
@@ -6,33 +6,49 @@
 package org.opensearch.forecast.rest;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.timeseries.util.RestHandlerUtils.RUN_ONCE;
+import static org.opensearch.timeseries.util.RestHandlerUtils.START_JOB;
+import static org.opensearch.timeseries.util.RestHandlerUtils.STOP_JOB;
 import static org.opensearch.timeseries.util.RestHandlerUtils.SUGGEST;
 import static org.opensearch.timeseries.util.RestHandlerUtils.VALIDATE;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.ParseException;
+import org.apache.http.util.EntityUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.forecast.AbstractForecastSyntheticDataTest;
+import org.opensearch.forecast.constant.ForecastCommonName;
+import org.opensearch.forecast.model.ForecastTaskProfile;
 import org.opensearch.forecast.model.Forecaster;
 import org.opensearch.forecast.settings.ForecastEnabledSetting;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
 import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.EntityTaskProfile;
+import org.opensearch.timeseries.model.TaskState;
+import org.opensearch.timeseries.util.RestHandlerUtils;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonObject;
 
 /**
@@ -40,14 +56,22 @@ import com.google.gson.JsonObject;
  *  - Suggest
  *  - Validate
  *  - Create
- *
+ *  - run once
+ *  - start
+ *  - stop
+ *  - update
  */
 public class ForecastRestApiIT extends AbstractForecastSyntheticDataTest {
+    public static final int MAX_RETRY_TIMES = 200;
     private static final String SUGGEST_INTERVAL_URI;
     private static final String SUGGEST_INTERVAL_HORIZON_HISTORY_URI;
     private static final String VALIDATE_FORECASTER;
     private static final String VALIDATE_FORECASTER_MODEL;
     private static final String CREATE_FORECASTER;
+    private static final String RUN_ONCE_FORECASTER;
+    private static final String START_FORECASTER;
+    private static final String STOP_FORECASTER;
+    private static final String UPDATE_FORECASTER;
 
     static {
         SUGGEST_INTERVAL_URI = String
@@ -72,6 +96,10 @@ public class ForecastRestApiIT extends AbstractForecastSyntheticDataTest {
         VALIDATE_FORECASTER_MODEL = String
             .format(Locale.ROOT, "%s/%s/%s", TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI, VALIDATE, "model");
         CREATE_FORECASTER = TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI;
+        RUN_ONCE_FORECASTER = String.format(Locale.ROOT, "%s/%s/%s", TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI, "%s", RUN_ONCE);
+        START_FORECASTER = String.format(Locale.ROOT, "%s/%s/%s", TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI, "%s", START_JOB);
+        STOP_FORECASTER = String.format(Locale.ROOT, "%s/%s/%s", TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI, "%s", STOP_JOB);
+        UPDATE_FORECASTER = String.format(Locale.ROOT, "%s/%s", TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI, "%s");
     }
 
     @Override
@@ -1947,7 +1975,7 @@ public class ForecastRestApiIT extends AbstractForecastSyntheticDataTest {
                 .makeRequest(
                     client(),
                     "POST",
-                    String.format(Locale.ROOT, CREATE_FORECASTER),// VALIDATE_FORECASTER_MODEL),
+                    String.format(Locale.ROOT, CREATE_FORECASTER),
                     ImmutableMap.of(),
                     TestHelpers.toHttpEntity(formattedForecaster),
                     null
@@ -2033,5 +2061,498 @@ public class ForecastRestApiIT extends AbstractForecastSyntheticDataTest {
             );
         Map<String, Object> responseMap = entityAsMap(response);
         assertEquals("opensearch-forecast-result-b", ((Map<String, Object>) responseMap.get("forecaster")).get("result_index"));
+    }
+
+    public void testRunOnce() throws Exception {
+        Instant trainTime = loadRuleData(200);
+        // case 1: happy case
+        String forecasterDef = "{\n"
+            + "    \"name\": \"Second-Test-Forecaster-4\",\n"
+            + "    \"description\": \"ok rate\",\n"
+            + "    \"time_field\": \"timestamp\",\n"
+            + "    \"indices\": [\n"
+            + "        \"%s\"\n"
+            + "    ],\n"
+            + "    \"feature_attributes\": [\n"
+            + "        {\n"
+            + "            \"feature_id\": \"max1\",\n"
+            + "            \"feature_name\": \"max1\",\n"
+            + "            \"feature_enabled\": true,\n"
+            + "            \"importance\": 1,\n"
+            + "            \"aggregation_query\": {\n"
+            + "                        \"max1\": {\n"
+            + "                            \"max\": {\n"
+            + "                                \"field\": \"transform._doc_count\"\n"
+            + "                            }\n"
+            + "                        }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"window_delay\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": %d,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"ui_metadata\": {\n"
+            + "        \"aabb\": {\n"
+            + "            \"ab\": \"bb\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"schema_version\": 2,\n"
+            + "    \"horizon\": 24,\n"
+            + "    \"forecast_interval\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": 10,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+
+        // +1 to make sure it is big enough
+        long windowDelayMinutes = Duration.between(trainTime, Instant.now()).toMinutes() + 1;
+        final String formattedForecaster = String.format(Locale.ROOT, forecasterDef, RULE_DATASET_NAME, windowDelayMinutes);
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(Locale.ROOT, CREATE_FORECASTER),
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(formattedForecaster),
+                null
+            );
+        Map<String, Object> responseMap = entityAsMap(response);
+        String forecasterId = (String) responseMap.get("_id");
+
+        // run once
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(Locale.ROOT, RUN_ONCE_FORECASTER, forecasterId),
+                ImmutableMap.of(),
+                (HttpEntity) null,
+                null
+            );
+
+        ForecastTaskProfile forecastTaskProfile = (ForecastTaskProfile) waitUntilTaskReachState(
+            forecasterId,
+            ImmutableSet.of(TaskState.TEST_COMPLETE.name())
+        ).get(0);
+        assertTrue(forecastTaskProfile != null);
+        assertTrue(forecastTaskProfile.getTask().isLatest());
+
+        responseMap = entityAsMap(response);
+        String taskId = (String) responseMap.get(EntityTaskProfile.TASK_ID_FIELD);
+        assertEquals(taskId, forecastTaskProfile.getTaskId());
+
+        response = searchTaskResult(taskId);
+        responseMap = entityAsMap(response);
+        int total = (int) (((Map<String, Object>) ((Map<String, Object>) responseMap.get("hits")).get("total")).get("value"));
+        assertTrue("actual: " + total, total > 40);
+
+        // case 2: cannot run once while forecaster is started
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(Locale.ROOT, START_FORECASTER, forecasterId),
+                ImmutableMap.of(),
+                (HttpEntity) null,
+                null
+            );
+        responseMap = entityAsMap(response);
+        assertEquals(forecasterId, responseMap.get("_id"));
+
+        // starting another run once before finishing causes error
+        Exception ex = expectThrows(
+            ResponseException.class,
+            () -> TestHelpers
+                .makeRequest(
+                    client(),
+                    "POST",
+                    String.format(Locale.ROOT, RUN_ONCE_FORECASTER, forecasterId),
+                    ImmutableMap.of(),
+                    (HttpEntity) null,
+                    null
+                )
+        );
+
+        String reason = ex.getMessage();
+        assertTrue("actual: " + reason, reason.contains("Cannot run once " + forecasterId + " when real time job is running."));
+
+        // case 3: stop forecaster
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(Locale.ROOT, STOP_FORECASTER, forecasterId),
+                ImmutableMap.of(),
+                (HttpEntity) null,
+                null
+            );
+        responseMap = entityAsMap(response);
+        assertEquals(forecasterId, responseMap.get("_id"));
+    }
+
+    public ForecastTaskProfile getForecastTaskProfile(String forecasterId) throws IOException, ParseException {
+        Response profileResponse = TestHelpers
+            .makeRequest(
+                client(),
+                "GET",
+                TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI + "/" + forecasterId + "/_profile/" + ForecastCommonName.FORECAST_TASK,
+                ImmutableMap.of(),
+                "",
+                null
+            );
+        return parseForecastTaskProfile(profileResponse);
+    }
+
+    public Response searchTaskResult(String taskId) throws IOException {
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "GET",
+                "opensearch-forecast-result*/_search",
+                ImmutableMap.of(),
+                TestHelpers
+                    .toHttpEntity(
+                        "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"task_id\":\"" + taskId + "\"}}]}},\"track_total_hits\":true}"
+                    ),
+                null
+            );
+        return response;
+    }
+
+    public ForecastTaskProfile parseForecastTaskProfile(Response profileResponse) throws IOException, ParseException {
+        String profileResult = EntityUtils.toString(profileResponse.getEntity());
+        XContentParser parser = TestHelpers.parser(profileResult);
+        ForecastTaskProfile forecastTaskProfile = null;
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            if ("forecast_task".equals(fieldName)) {
+                forecastTaskProfile = ForecastTaskProfile.parse(parser);
+            } else {
+                parser.skipChildren();
+            }
+        }
+        return forecastTaskProfile;
+    }
+
+    protected List<Object> waitUntilTaskReachState(String forecasterId, Set<String> targetStates) throws InterruptedException {
+        List<Object> results = new ArrayList<>();
+        int i = 0;
+        ForecastTaskProfile forecastTaskProfile = null;
+        // Increase retryTimes if some task can't reach done state
+        while ((forecastTaskProfile == null || !targetStates.contains(forecastTaskProfile.getTask().getState())) && i < MAX_RETRY_TIMES) {
+            try {
+                forecastTaskProfile = getForecastTaskProfile(forecasterId);
+            } catch (Exception e) {
+                logger.error("failed to get ForecastTaskProfile", e);
+            } finally {
+                Thread.sleep(1000);
+            }
+            i++;
+        }
+        assertNotNull(forecastTaskProfile);
+        results.add(forecastTaskProfile);
+        results.add(i);
+        return results;
+    }
+
+    public void testCreateDetector() throws Exception {
+        // Case 1: users cannot specify forecaster id when creating a forecaster
+        Instant trainTime = loadRuleData(200);
+        String forecasterDef = "{\n"
+            + "    \"name\": \"Second-Test-Forecaster-4\",\n"
+            + "    \"description\": \"ok rate\",\n"
+            + "    \"time_field\": \"timestamp\",\n"
+            + "    \"indices\": [\n"
+            + "        \"%s\"\n"
+            + "    ],\n"
+            + "    \"feature_attributes\": [\n"
+            + "        {\n"
+            + "            \"feature_id\": \"max1\",\n"
+            + "            \"feature_name\": \"max1\",\n"
+            + "            \"feature_enabled\": true,\n"
+            + "            \"importance\": 1,\n"
+            + "            \"aggregation_query\": {\n"
+            + "                        \"max1\": {\n"
+            + "                            \"max\": {\n"
+            + "                                \"field\": \"transform._doc_count\"\n"
+            + "                            }\n"
+            + "                        }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"window_delay\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": %d,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"ui_metadata\": {\n"
+            + "        \"aabb\": {\n"
+            + "            \"ab\": \"bb\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"schema_version\": 2,\n"
+            + "    \"horizon\": 24,\n"
+            + "    \"forecast_interval\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": 10,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+
+        // +1 to make sure it is big enough
+        long windowDelayMinutes = Duration.between(trainTime, Instant.now()).toMinutes() + 1;
+        final String formattedForecaster = String.format(Locale.ROOT, forecasterDef, RULE_DATASET_NAME, windowDelayMinutes);
+        String blahId = "__blah__";
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(Locale.ROOT, CREATE_FORECASTER),
+                ImmutableMap.of(RestHandlerUtils.FORECASTER_ID, blahId),
+                TestHelpers.toHttpEntity(formattedForecaster),
+                null
+            );
+        Map<String, Object> responseMap = entityAsMap(response);
+        String forecasterId = (String) responseMap.get("_id");
+        assertNotEquals("response is missing Id", blahId, forecasterId);
+    }
+
+    public void testUpdateDetector() throws Exception {
+        // Case 1: update non-impactful fields like name or description won't change last breaking change UI time
+        Instant trainTime = loadRuleData(200);
+        String forecasterDef = "{\n"
+            + "    \"name\": \"Second-Test-Forecaster-4\",\n"
+            + "    \"description\": \"ok rate\",\n"
+            + "    \"time_field\": \"timestamp\",\n"
+            + "    \"indices\": [\n"
+            + "        \"%s\"\n"
+            + "    ],\n"
+            + "    \"feature_attributes\": [\n"
+            + "        {\n"
+            + "            \"feature_id\": \"max1\",\n"
+            + "            \"feature_name\": \"max1\",\n"
+            + "            \"feature_enabled\": true,\n"
+            + "            \"importance\": 1,\n"
+            + "            \"aggregation_query\": {\n"
+            + "                        \"max1\": {\n"
+            + "                            \"max\": {\n"
+            + "                                \"field\": \"transform._doc_count\"\n"
+            + "                            }\n"
+            + "                        }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"window_delay\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": %d,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"ui_metadata\": {\n"
+            + "        \"aabb\": {\n"
+            + "            \"ab\": \"bb\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"schema_version\": 2,\n"
+            + "    \"horizon\": 24,\n"
+            + "    \"forecast_interval\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": 10,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+
+        // +1 to make sure it is big enough
+        long windowDelayMinutes = Duration.between(trainTime, Instant.now()).toMinutes() + 1;
+        final String formattedForecaster = String.format(Locale.ROOT, forecasterDef, RULE_DATASET_NAME, windowDelayMinutes);
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(Locale.ROOT, CREATE_FORECASTER),
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(formattedForecaster),
+                null
+            );
+        Map<String, Object> responseMap = entityAsMap(response);
+        String forecasterId = (String) responseMap.get("_id");
+        assertEquals(null, responseMap.get("last_ui_breaking_change_time"));
+
+        // changing description won't change last_breaking_change_ui_time
+        forecasterDef = "{\n"
+            + "    \"name\": \"Second-Test-Forecaster-4\",\n"
+            + "    \"description\": \"ok rate1\",\n"
+            + "    \"time_field\": \"timestamp\",\n"
+            + "    \"indices\": [\n"
+            + "        \"%s\"\n"
+            + "    ],\n"
+            + "    \"feature_attributes\": [\n"
+            + "        {\n"
+            + "            \"feature_id\": \"max1\",\n"
+            + "            \"feature_name\": \"max1\",\n"
+            + "            \"feature_enabled\": true,\n"
+            + "            \"importance\": 1,\n"
+            + "            \"aggregation_query\": {\n"
+            + "                        \"max1\": {\n"
+            + "                            \"max\": {\n"
+            + "                                \"field\": \"transform._doc_count\"\n"
+            + "                            }\n"
+            + "                        }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"window_delay\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": %d,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"ui_metadata\": {\n"
+            + "        \"aabb\": {\n"
+            + "            \"ab\": \"bb\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"schema_version\": 2,\n"
+            + "    \"horizon\": 24,\n"
+            + "    \"forecast_interval\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": 10,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                String.format(Locale.ROOT, UPDATE_FORECASTER, forecasterId),
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(formattedForecaster),
+                null
+            );
+        responseMap = entityAsMap(response);
+        assertEquals(null, responseMap.get("last_ui_breaking_change_time"));
+
+        // changing categorical fields changes last_ui_breaking_change_time
+        forecasterDef = "{\n"
+            + "    \"name\": \"Second-Test-Forecaster-4\",\n"
+            + "    \"description\": \"ok rate1\",\n"
+            + "    \"time_field\": \"timestamp\",\n"
+            + "    \"indices\": [\n"
+            + "        \"%s\"\n"
+            + "    ],\n"
+            + "    \"feature_attributes\": [\n"
+            + "        {\n"
+            + "            \"feature_id\": \"max1\",\n"
+            + "            \"feature_name\": \"max1\",\n"
+            + "            \"feature_enabled\": true,\n"
+            + "            \"importance\": 1,\n"
+            + "            \"aggregation_query\": {\n"
+            + "                        \"max1\": {\n"
+            + "                            \"max\": {\n"
+            + "                                \"field\": \"transform._doc_count\"\n"
+            + "                            }\n"
+            + "                        }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"window_delay\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": %d,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"ui_metadata\": {\n"
+            + "        \"aabb\": {\n"
+            + "            \"ab\": \"bb\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"schema_version\": 2,\n"
+            + "    \"horizon\": 24,\n"
+            + "    \"forecast_interval\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": 10,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"category_field\": [\"componentName\"]"
+            + "}";
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                String.format(Locale.ROOT, UPDATE_FORECASTER, forecasterId),
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(formattedForecaster),
+                null
+            );
+        responseMap = entityAsMap(response);
+        assertEquals(responseMap.get("last_update_time"), responseMap.get("last_ui_breaking_change_time"));
+
+        // changing custom result index changes last_ui_breaking_change_time
+        forecasterDef = "{\n"
+            + "    \"name\": \"Second-Test-Forecaster-4\",\n"
+            + "    \"description\": \"ok rate1\",\n"
+            + "    \"time_field\": \"timestamp\",\n"
+            + "    \"indices\": [\n"
+            + "        \"%s\"\n"
+            + "    ],\n"
+            + "    \"feature_attributes\": [\n"
+            + "        {\n"
+            + "            \"feature_id\": \"max1\",\n"
+            + "            \"feature_name\": \"max1\",\n"
+            + "            \"feature_enabled\": true,\n"
+            + "            \"importance\": 1,\n"
+            + "            \"aggregation_query\": {\n"
+            + "                        \"max1\": {\n"
+            + "                            \"max\": {\n"
+            + "                                \"field\": \"transform._doc_count\"\n"
+            + "                            }\n"
+            + "                        }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"window_delay\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": %d,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"ui_metadata\": {\n"
+            + "        \"aabb\": {\n"
+            + "            \"ab\": \"bb\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"schema_version\": 2,\n"
+            + "    \"horizon\": 24,\n"
+            + "    \"forecast_interval\": {\n"
+            + "        \"period\": {\n"
+            + "            \"interval\": 10,\n"
+            + "            \"unit\": \"MINUTES\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"category_field\": [\"componentName\"],"
+            + "    \"result_index\": \"opensearch-forecast-result-b\""
+            + "}";
+        response = TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                String.format(Locale.ROOT, UPDATE_FORECASTER, forecasterId),
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(formattedForecaster),
+                null
+            );
+        responseMap = entityAsMap(response);
+        assertEquals(responseMap.get("last_update_time"), responseMap.get("last_ui_breaking_change_time"));
     }
 }

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -340,7 +340,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            lastUpdateTime
         );
     }
 
@@ -395,7 +396,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -461,7 +463,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -502,7 +505,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now()
         );
     }
 
@@ -535,7 +539,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -575,7 +580,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -753,7 +759,8 @@ public class TestHelpers {
                 null,
                 null,
                 null,
-                null
+                null,
+                lastUpdateTime
             );
         }
     }
@@ -790,7 +797,8 @@ public class TestHelpers {
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -1940,13 +1948,15 @@ public class TestHelpers {
                 resultIndex,
                 horizon,
                 imputationOption,
-                randomIntBetween(1, 1000),
+                // Recency emphasis must be an integer greater than 1
+                randomIntBetween(2, 1000),
                 randomIntBetween(1, 128),
                 randomIntBetween(1, 1000),
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping
+                flattenResultIndexMapping,
+                lastUpdateTime
             );
         }
     }
@@ -1974,13 +1984,15 @@ public class TestHelpers {
             null,
             randomIntBetween(1, 20),
             randomImputationOption(featureList),
-            randomIntBetween(1, 1000),
+            // Recency emphasis must be an integer greater than 1
+            randomIntBetween(2, 1000),
             randomIntBetween(1, 128),
             randomIntBetween(1, 1000),
             null,
             null,
             null,
-            null
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 

--- a/src/test/java/org/opensearch/timeseries/transport/BooleanResponseTests.java
+++ b/src/test/java/org/opensearch/timeseries/transport/BooleanResponseTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.timeseries.transport;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class BooleanResponseTests extends OpenSearchTestCase {
+
+    public void testBooleanResponseSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponseTrue = new BooleanNodeResponse(node, true);
+        BooleanNodeResponse nodeResponseFalse = new BooleanNodeResponse(node, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponseTrue, nodeResponseFalse);
+        List<FailedNodeException> failures = Collections.emptyList();
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, failures);
+
+        // Act: Serialize the response
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+
+        // Deserialize the response
+        StreamInput input = output.bytes().streamInput();
+        BooleanResponse deserializedResponse = new BooleanResponse(input);
+
+        // Assert
+        assertEquals(clusterName, deserializedResponse.getClusterName());
+        assertEquals(response.getNodes().size(), deserializedResponse.getNodes().size());
+        assertEquals(response.failures().size(), deserializedResponse.failures().size());
+        assertEquals(response.isAnswerTrue(), deserializedResponse.isAnswerTrue());
+    }
+
+    public void testBooleanResponseReadNodesFromAndWriteNodesTo() throws IOException {
+        // Arrange
+        DiscoveryNode node1 = new DiscoveryNode(
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse1 = new BooleanNodeResponse(node1, true);
+        BooleanNodeResponse nodeResponse2 = new BooleanNodeResponse(node2, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponse1, nodeResponse2);
+        ClusterName clusterName = new ClusterName("test-cluster");
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Act: Write nodes to output
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeNodesTo(output, nodes);
+
+        // Read nodes from input
+        StreamInput input = output.bytes().streamInput();
+        List<BooleanNodeResponse> readNodes = response.readNodesFrom(input);
+
+        // Assert
+        assertEquals(nodes.size(), readNodes.size());
+        assertEquals(nodes.get(0).isAnswerTrue(), readNodes.get(0).isAnswerTrue());
+        assertEquals(nodes.get(1).isAnswerTrue(), readNodes.get(1).isAnswerTrue());
+    }
+
+    public void testBooleanNodeResponseSerialization() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse = new BooleanNodeResponse(node, true);
+
+        // Act: Serialize the node response
+        BytesStreamOutput output = new BytesStreamOutput();
+        nodeResponse.writeTo(output);
+
+        // Deserialize the node response
+        StreamInput input = output.bytes().streamInput();
+        BooleanNodeResponse deserializedNodeResponse = new BooleanNodeResponse(input);
+
+        // Assert
+        assertEquals(node, deserializedNodeResponse.getNode());
+        assertEquals(nodeResponse.isAnswerTrue(), deserializedNodeResponse.isAnswerTrue());
+    }
+
+    public void testBooleanResponseAnswerAggregation() {
+        // Arrange
+        DiscoveryNode node1 = new DiscoveryNode(
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponseTrue = new BooleanNodeResponse(node1, true);
+        BooleanNodeResponse nodeResponseFalse = new BooleanNodeResponse(node2, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponseTrue, nodeResponseFalse);
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        // Act
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Assert
+        assertTrue(response.isAnswerTrue()); // Since at least one node responded true
+    }
+
+    public void testBooleanResponseAllFalse() {
+        // Arrange
+        DiscoveryNode node1 = new DiscoveryNode(
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse1 = new BooleanNodeResponse(node1, false);
+        BooleanNodeResponse nodeResponse2 = new BooleanNodeResponse(node2, false);
+        List<BooleanNodeResponse> nodes = List.of(nodeResponse1, nodeResponse2);
+        ClusterName clusterName = new ClusterName("test-cluster");
+
+        // Act
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Assert
+        assertFalse(response.isAnswerTrue()); // Since all nodes responded false
+    }
+
+    public void testToXContent() throws IOException {
+        // Arrange
+        DiscoveryNode node = new DiscoveryNode(
+            "nodeId",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.emptySet(),
+            Version.CURRENT
+        );
+
+        BooleanNodeResponse nodeResponse = new BooleanNodeResponse(node, true);
+        List<BooleanNodeResponse> nodes = Collections.singletonList(nodeResponse);
+        ClusterName clusterName = new ClusterName("test-cluster");
+        BooleanResponse response = new BooleanResponse(clusterName, nodes, Collections.emptyList());
+
+        // Act
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String jsonString = builder.toString();
+
+        // Assert
+        assertTrue(jsonString.contains("\"answer\":true"));
+    }
+}

--- a/src/test/java/org/opensearch/timeseries/transport/CronTransportActionTests.java
+++ b/src/test/java/org/opensearch/timeseries/transport/CronTransportActionTests.java
@@ -28,6 +28,7 @@ import org.opensearch.ad.caching.ADPriorityCache;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 import org.opensearch.ad.ml.ADColdStart;
 import org.opensearch.ad.ml.ADModelManager;
+import org.opensearch.ad.ml.ADRealTimeInferencer;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -40,6 +41,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.forecast.caching.ForecastCacheProvider;
 import org.opensearch.forecast.caching.ForecastPriorityCache;
 import org.opensearch.forecast.ml.ForecastColdStart;
+import org.opensearch.forecast.ml.ForecastRealTimeInferencer;
 import org.opensearch.forecast.task.ForecastTaskManager;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AbstractTimeSeriesTest;
@@ -83,6 +85,9 @@ public class CronTransportActionTests extends AbstractTimeSeriesTest {
         when(forecastCacheProvider.get()).thenReturn(forecastCache);
         ForecastTaskManager forecastTaskManager = mock(ForecastTaskManager.class);
 
+        ADRealTimeInferencer adRealTimeInferencer = mock(ADRealTimeInferencer.class);
+        ForecastRealTimeInferencer forecastRealTimeInferencer = mock(ForecastRealTimeInferencer.class);
+
         action = new CronTransportAction(
             threadPool,
             clusterService,
@@ -95,7 +100,9 @@ public class CronTransportActionTests extends AbstractTimeSeriesTest {
             entityColdStarter,
             forecastColdStarter,
             adTaskManager,
-            forecastTaskManager
+            forecastTaskManager,
+            adRealTimeInferencer,
+            forecastRealTimeInferencer
         );
     }
 


### PR DESCRIPTION
### Description

This PR backport https://github.com/opensearch-project/anomaly-detection/pull/1316 to 2.x

Also, there is a flaky test org.opensearch.ad.e2e.RealTimeRuleModelPerfIT.testRule exposed by the PR. The test intermittently fails with an "incorrect ordering of time" error:

```
? ERROR][o.o.t.m.ModelManager     ] [integTest-0] Fail to score for [componentName=Phoenix] at [1695121800]: model Id [SJJ-MJIBXTsDe_KkqmOm_entity_xdZvcSGAl1UW0rzpOU5XxA], feature [[6810.0]]
?  java.lang.IllegalArgumentException: incorrect ordering of time
?  	at com.amazon.randomcutforest.CommonUtils.checkArgument(CommonUtils.java:44) ~[randomcutforest-core-4.1.0.jar:?]
?  	at com.amazon.randomcutforest.preprocessor.ImputePreprocessor.getScaledShingledInput(ImputePreprocessor.java:59) ~[randomcutforest-core-4.1.0.jar:?]
?  	at com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest.initialSetup(ThresholdedRandomCutForest.java:474) ~[randomcutforest-parkservices-4.1.0.jar:?]
?  	at com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest.augment(ThresholdedRandomCutForest.java:213) ~[randomcutforest-parkservices-4.1.0.jar:?]
?  	at com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest.process(ThresholdedRandomCutForest.java:261) ~[randomcutforest-parkservices-4.1.0.jar:?]
?  	at org.opensearch.timeseries.ml.ModelManager.score(ModelManager.java:182) ~[opensearch-anomaly-detection-2.18.0.0-SNAPSHOT.jar:2.18.0.0-SNAPSHOT]
?  	at org.opensearch.timeseries.ml.ModelManager.score(ModelManager.java:155) [opensearch-anomaly-detection-2.18.0.0-SNAPSHOT.jar:2.18.0.0-SNAPSHOT]
?  	at org.opensearch.timeseries.ml.ModelManager.getResult(ModelManager.java:103) [opensearch-anomaly-detection-2.18.0.0-SNAPSHOT.jar:2.18.0.0-SNAPSHOT]
?  	at org.opensearch.timeseries.ml.RealTimeInferencer.tryProcess(RealTimeInferencer.java:139) [opensearch-anomaly-detection-2.18.0.0-SNAPSHOT.jar:2.18.0.0-SNAPSHOT]
?  	at org.opensearch.timeseries.ml.RealTimeInferencer.processWithTimeout(RealTimeInferencer.java:112) [opensearch-anomaly-detection-2.18.0.0-SNAPSHOT.jar:2.18.0.0-SNAPSHOT]
?  	at org.opensearch.timeseries.ml.RealTimeInferencer.lambda$processWithTimeout$1(RealTimeInferencer.java:126) [opensearch-anomaly-detection-2.18.0.0-SNAPSHOT.jar:2.18.0.0-SNAPSHOT]
?  	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:946) [opensearch-2.18.0-SNAPSHOT.jar:2.18.0-SNAPSHOT]
?  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
?  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
?  	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
? WARN ][o.o.t.m.RealTimeInferencer] [integTest-0] incorrect ordering of time for config SJJ-MJIBXTsDe_KkqmOm model SJJ-MJIBXTsDe_KkqmOm_entity_xdZvcSGAl1UW0rzpOU5XxA at data end time 1695121800000
```
**Root Cause:**

- When a lock is held during processing, retries are scheduled.
- In the meantime, another thread with a future sample might acquire the lock and complete scoring.
- As a result, when the retry occurs, it processes an older sample after a newer one, causing the time ordering error.

**Fix Implemented:**

1. **Sample Ordering:**
   - Introduced a `PriorityQueue<Sample>` in `RealTimeInferencer` to maintain samples ordered by their data end time.
   - Ensures samples are processed in chronological order, preventing out-of-order processing when retries occur.

2. **Time Comparison Adjustment:**
   - Previously, we imputed data when the current execution end time was larger than the model state's last seen execution end time.
   - In test environments, data end times can be set in the future, causing discrepancies because the last seen execution time is based on the current clock.
   - Updated the logic to compare the current data end time with the model state's last seen data end time.
   - This aligns the comparison with the source of the timestamps, ensuring consistent behavior even with future-dated samples in tests.

Detailed changes can be found here: https://github.com/opensearch-project/anomaly-detection/compare/3445d6d7363f31c936ad2949796952c8f01c5145..519640ff228b97ff6f221821ec55272079cce882

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
