### PR TITLE
Bump RCF Version and Fix Default Rules Bug in AnomalyDetector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,9 +126,9 @@ dependencies {
     implementation group: 'com.yahoo.datasketches', name: 'memory', version: '0.12.2'
     implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
     implementation group: 'org.apache.commons', name: 'commons-pool2', version: '2.12.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-serialization:4.1.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:4.1.0'
-    implementation 'software.amazon.randomcutforest:randomcutforest-core:4.1.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-serialization:4.2.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:4.2.0'
+    implementation 'software.amazon.randomcutforest:randomcutforest-core:4.2.0'
 
     // we inherit jackson-core from opensearch core
     implementation "com.fasterxml.jackson.core:jackson-databind:2.16.1"
@@ -700,9 +700,6 @@ List<String> jacocoExclusions = [
 
         // TODO: add test coverage (kaituo)
         'org.opensearch.forecast.*',
-        'org.opensearch.timeseries.transport.handler.ResultBulkIndexingHandler',
-        'org.opensearch.timeseries.transport.SingleStreamResultRequest',
-        'org.opensearch.timeseries.rest.handler.IndexJobActionHandler.1',
         'org.opensearch.timeseries.transport.SuggestConfigParamResponse',
         'org.opensearch.timeseries.transport.SuggestConfigParamRequest',
         'org.opensearch.timeseries.ml.MemoryAwareConcurrentHashmap',

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -233,7 +233,7 @@ public class AnomalyDetector extends Config {
 
         this.detectorType = isHC(categoryFields) ? MULTI_ENTITY.name() : SINGLE_ENTITY.name();
 
-        this.rules = rules == null ? getDefaultRule() : rules;
+        this.rules = rules == null || rules.isEmpty() ? getDefaultRule() : rules;
     }
 
     /*

--- a/src/main/java/org/opensearch/timeseries/JobProcessor.java
+++ b/src/main/java/org/opensearch/timeseries/JobProcessor.java
@@ -200,7 +200,7 @@ public abstract class JobProcessor<IndexType extends Enum<IndexType> & TimeSerie
      * @param executionStartTime analysis start time
      * @param executionEndTime analysis end time
      * @param recorder utility to record job execution result
-     * @param detector associated detector accessor
+     * @param config associated config accessor
      */
     public void runJob(
         Job jobParameter,
@@ -209,7 +209,7 @@ public abstract class JobProcessor<IndexType extends Enum<IndexType> & TimeSerie
         Instant executionStartTime,
         Instant executionEndTime,
         ExecuteResultResponseRecorderType recorder,
-        Config detector
+        Config config
     ) {
         String configId = jobParameter.getName();
         if (lock == null) {
@@ -222,7 +222,7 @@ public abstract class JobProcessor<IndexType extends Enum<IndexType> & TimeSerie
                 "Can't run job due to null lock",
                 false,
                 recorder,
-                detector
+                config
             );
             return;
         }
@@ -243,7 +243,7 @@ public abstract class JobProcessor<IndexType extends Enum<IndexType> & TimeSerie
             user,
             roles,
             recorder,
-            detector
+            config
         );
     }
 

--- a/src/main/java/org/opensearch/timeseries/ratelimit/ColdStartWorker.java
+++ b/src/main/java/org/opensearch/timeseries/ratelimit/ColdStartWorker.java
@@ -163,19 +163,18 @@ public abstract class ColdStartWorker<RCFModelType extends ThresholdedRandomCutF
                         );
                         IntermediateResultType result = modelManager.getResult(currentSample, modelState, modelId, config, taskId);
                         resultSaver.saveResult(result, config, coldStartRequest, modelId);
-                    }
 
-                    // only load model to memory for real time analysis that has no task id
-                    if (null == coldStartRequest.getTaskId()) {
-                        boolean hosted = cacheProvider.hostIfPossible(configOptional.get(), modelState);
-                        LOG
-                            .debug(
-                                hosted
-                                    ? new ParameterizedMessage("Loaded model {}.", modelState.getModelId())
-                                    : new ParameterizedMessage("Failed to load model {}.", modelState.getModelId())
-                            );
+                        // only load model to memory for real time analysis that has no task id
+                        if (null == coldStartRequest.getTaskId()) {
+                            boolean hosted = cacheProvider.hostIfPossible(configOptional.get(), modelState);
+                            LOG
+                                .debug(
+                                    hosted
+                                        ? new ParameterizedMessage("Loaded model {}.", modelState.getModelId())
+                                        : new ParameterizedMessage("Failed to load model {}.", modelState.getModelId())
+                                );
+                        }
                     }
-
                 } finally {
                     listener.onResponse(null);
                 }

--- a/src/main/java/org/opensearch/timeseries/rest/handler/IndexJobActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/IndexJobActionHandler.java
@@ -462,7 +462,7 @@ public abstract class IndexJobActionHandler<IndexType extends Enum<IndexType> & 
         }));
     }
 
-    private ActionListener<StopConfigResponse> stopConfigListener(
+    public ActionListener<StopConfigResponse> stopConfigListener(
         String configId,
         TransportService transportService,
         ActionListener<JobResponse> listener

--- a/src/main/java/org/opensearch/timeseries/transport/handler/ResultBulkIndexingHandler.java
+++ b/src/main/java/org/opensearch/timeseries/transport/handler/ResultBulkIndexingHandler.java
@@ -145,7 +145,7 @@ public class ResultBulkIndexingHandler<ResultType extends IndexableResult, Index
         } catch (Exception e) {
             String error = "Failed to bulk index result";
             LOG.error(error, e);
-            listener.onFailure(new TimeSeriesException(error, e));
+            listener.onFailure(new TimeSeriesException(configId, error, e));
         }
     }
 

--- a/src/test/java/org/opensearch/ad/e2e/AbstractRuleTestCase.java
+++ b/src/test/java/org/opensearch/ad/e2e/AbstractRuleTestCase.java
@@ -84,7 +84,7 @@ public abstract class AbstractRuleTestCase extends AbstractADSyntheticDataTest {
         if (relative) {
             thresholdType1 = "actual_over_expected_ratio";
             thresholdType2 = "expected_over_actual_ratio";
-            value = 0.3;
+            value = 0.2;
         } else {
             thresholdType1 = "actual_over_expected_margin";
             thresholdType2 = "expected_over_actual_margin";

--- a/src/test/java/org/opensearch/ad/ml/ADColdStartTests.java
+++ b/src/test/java/org/opensearch/ad/ml/ADColdStartTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ad.ml;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.timeseries.TestHelpers;
+
+import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
+
+public class ADColdStartTests extends OpenSearchTestCase {
+    private int baseDimensions = 1;
+    private int shingleSize = 8;
+    private int dimensions;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        dimensions = baseDimensions * shingleSize;
+    }
+
+    /**
+     * Test if no explicit rule is provided, we apply 20% rule.
+     * @throws IOException when failing to constructor detector
+     */
+    public void testEmptyRule() throws IOException {
+        AnomalyDetector detector = TestHelpers.AnomalyDetectorBuilder.newInstance(1).setRules(new ArrayList<>()).build();
+        ThresholdedRandomCutForest.Builder builder = new ThresholdedRandomCutForest.Builder<>()
+            .dimensions(dimensions)
+            .shingleSize(shingleSize);
+        ADColdStart.applyRule(builder, detector);
+
+        ThresholdedRandomCutForest forest = builder.build();
+        double[] ignore = forest.getPredictorCorrector().getIgnoreNearExpected();
+
+        // Specify a small delta for floating-point comparison
+        double delta = 1e-6;
+
+        assertArrayEquals("The double arrays are not equal", new double[] { 0, 0, 0.2, 0.2 }, ignore, delta);
+    }
+
+    public void testNullRule() throws IOException {
+        AnomalyDetector detector = TestHelpers.AnomalyDetectorBuilder.newInstance(1).setRules(null).build();
+        ThresholdedRandomCutForest.Builder builder = new ThresholdedRandomCutForest.Builder<>()
+            .dimensions(dimensions)
+            .shingleSize(shingleSize);
+        ADColdStart.applyRule(builder, detector);
+
+        ThresholdedRandomCutForest forest = builder.build();
+        double[] ignore = forest.getPredictorCorrector().getIgnoreNearExpected();
+
+        // Specify a small delta for floating-point comparison
+        double delta = 1e-6;
+
+        assertArrayEquals("The double arrays are not equal", new double[] { 0, 0, 0.2, 0.2 }, ignore, delta);
+    }
+}

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -755,7 +755,7 @@ public class TestHelpers {
                 // as ModelColdStart.selectNumberOfSamples will select the smaller of
                 // 32 and historical intervals.
                 randomIntBetween(TimeSeriesSettings.NUM_MIN_SAMPLES, 1000),
-                null,
+                rules,
                 null,
                 null,
                 null,

--- a/src/test/java/org/opensearch/timeseries/transport/JobRequestTests.java
+++ b/src/test/java/org/opensearch/timeseries/transport/JobRequestTests.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.timeseries.transport;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.timeseries.constant.CommonName;
+
+public class JobRequestTests extends OpenSearchTestCase {
+    public void testSerializationDeserialization() throws IOException {
+        String configId = "test-config-id";
+        String modelId = "test-model-id";
+        long startMillis = 1622548800000L; // June 1, 2021 00:00:00 GMT
+        long endMillis = 1622635200000L;   // June 2, 2021 00:00:00 GMT
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = "test-task-id";
+
+        // Create the original request
+        SingleStreamResultRequest originalRequest = new SingleStreamResultRequest(
+            configId,
+            modelId,
+            startMillis,
+            endMillis,
+            datapoint,
+            taskId
+        );
+
+        // Serialize the request to a BytesStreamOutput
+        BytesStreamOutput out = new BytesStreamOutput();
+        originalRequest.writeTo(out);
+
+        // Deserialize the request from the StreamInput
+        StreamInput in = out.bytes().streamInput();
+        SingleStreamResultRequest deserializedRequest = new SingleStreamResultRequest(in);
+
+        // Assert that the deserialized request matches the original
+        assertEquals(originalRequest.getConfigId(), deserializedRequest.getConfigId());
+        assertEquals(originalRequest.getModelId(), deserializedRequest.getModelId());
+        assertEquals(originalRequest.getStart(), deserializedRequest.getStart());
+        assertEquals(originalRequest.getEnd(), deserializedRequest.getEnd());
+        assertArrayEquals(originalRequest.getDataPoint(), deserializedRequest.getDataPoint(), 0.0001);
+        assertEquals(originalRequest.getTaskId(), deserializedRequest.getTaskId());
+    }
+
+    public void testSerializationDeserialization_NullTaskId() throws IOException {
+        String configId = "test-config-id";
+        String modelId = "test-model-id";
+        long startMillis = 1622548800000L;
+        long endMillis = 1622635200000L;
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = null;
+
+        SingleStreamResultRequest originalRequest = new SingleStreamResultRequest(
+            configId,
+            modelId,
+            startMillis,
+            endMillis,
+            datapoint,
+            taskId
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        originalRequest.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        SingleStreamResultRequest deserializedRequest = new SingleStreamResultRequest(in);
+
+        assertEquals(originalRequest.getConfigId(), deserializedRequest.getConfigId());
+        assertEquals(originalRequest.getModelId(), deserializedRequest.getModelId());
+        assertEquals(originalRequest.getStart(), deserializedRequest.getStart());
+        assertEquals(originalRequest.getEnd(), deserializedRequest.getEnd());
+        assertArrayEquals(originalRequest.getDataPoint(), deserializedRequest.getDataPoint(), 0.0001);
+        assertNull(deserializedRequest.getTaskId());
+    }
+
+    public void testToXContent() throws IOException {
+        String configId = "test-config-id";
+        String modelId = "test-model-id";
+        long startMillis = 1622548800000L;
+        long endMillis = 1622635200000L;
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = "test-task-id";
+
+        SingleStreamResultRequest request = new SingleStreamResultRequest(configId, modelId, startMillis, endMillis, datapoint, taskId);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        request.toXContent(builder, null);
+        String jsonString = builder.toString();
+
+        String expectedJson = String
+            .format(
+                Locale.ROOT,
+                "{\"%s\":\"%s\",\"%s\":\"%s\",\"%s\":%d,\"%s\":%d,\"%s\":[1.0,2.0,3.0],\"%s\":\"%s\"}",
+                CommonName.CONFIG_ID_KEY,
+                configId,
+                CommonName.MODEL_ID_KEY,
+                modelId,
+                CommonName.START_JSON_KEY,
+                startMillis,
+                CommonName.END_JSON_KEY,
+                endMillis,
+                CommonName.VALUE_LIST_FIELD,
+                CommonName.RUN_ONCE_FIELD,
+                taskId
+            );
+
+        assertEquals(expectedJson, jsonString);
+    }
+
+    public void testToXContent_NullTaskId() throws IOException {
+        String configId = "test-config-id";
+        String modelId = "test-model-id";
+        long startMillis = 1622548800000L;
+        long endMillis = 1622635200000L;
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = null;
+
+        SingleStreamResultRequest request = new SingleStreamResultRequest(configId, modelId, startMillis, endMillis, datapoint, taskId);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        request.toXContent(builder, null);
+        String jsonString = builder.toString();
+
+        String expectedJson = String
+            .format(
+                Locale.ROOT,
+                "{\"%s\":\"%s\",\"%s\":\"%s\",\"%s\":%d,\"%s\":%d,\"%s\":[1.0,2.0,3.0],\"%s\":null}",
+                CommonName.CONFIG_ID_KEY,
+                configId,
+                CommonName.MODEL_ID_KEY,
+                modelId,
+                CommonName.START_JSON_KEY,
+                startMillis,
+                CommonName.END_JSON_KEY,
+                endMillis,
+                CommonName.VALUE_LIST_FIELD,
+                CommonName.RUN_ONCE_FIELD
+            );
+
+        assertEquals(expectedJson, jsonString);
+    }
+
+    public void testValidate_MissingConfigId() {
+        String configId = null; // Missing configId
+        String modelId = "test-model-id";
+        long startMillis = 1622548800000L;
+        long endMillis = 1622635200000L;
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = "test-task-id";
+
+        SingleStreamResultRequest request = new SingleStreamResultRequest(configId, modelId, startMillis, endMillis, datapoint, taskId);
+
+        ActionRequestValidationException validationException = request.validate();
+        assertNotNull(validationException);
+        assertTrue("actual: " + validationException.getMessage(), validationException.getMessage().contains("config ID is missing"));
+    }
+
+    public void testValidate_MissingModelId() {
+        String configId = "test-config-id";
+        String modelId = null; // Missing modelId
+        long startMillis = 1622548800000L;
+        long endMillis = 1622635200000L;
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = "test-task-id";
+
+        SingleStreamResultRequest request = new SingleStreamResultRequest(configId, modelId, startMillis, endMillis, datapoint, taskId);
+
+        ActionRequestValidationException validationException = request.validate();
+        assertNotNull(validationException);
+        assertTrue("actual: " + validationException.getMessage(), validationException.getMessage().contains("model ID is missing"));
+    }
+
+    public void testValidate_InvalidTimestamps() {
+        String configId = "test-config-id";
+        String modelId = "test-model-id";
+        long startMillis = 1622635200000L; // End time before start time
+        long endMillis = 1622548800000L;
+        double[] datapoint = new double[] { 1.0, 2.0, 3.0 };
+        String taskId = "test-task-id";
+
+        SingleStreamResultRequest request = new SingleStreamResultRequest(configId, modelId, startMillis, endMillis, datapoint, taskId);
+
+        ActionRequestValidationException validationException = request.validate();
+        assertNotNull(validationException);
+        assertTrue("actual: " + validationException.getMessage(), validationException.getMessage().contains("timestamp is invalid"));
+    }
+}


### PR DESCRIPTION
### Description
* Updated RCF version to the latest release.
* Fixed a bug in AnomalyDetector where default rules were not applied when the user provided an empty ruleset.

Testing:
* Added unit tests to cover the bug fix

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
