### PR TITLE
Revert "Add flatten_result_index_mapping field to Config (#1317)"

### DIFF
--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -345,7 +345,6 @@ public class ADTask extends TimeSeriesTask {
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
                 detector.getCustomResultIndexTTL(),
-                detector.getFlattenResultIndexMapping(),
                 detector.getLastBreakingUIChangeTime()
             );
         return new Builder()

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -152,7 +152,6 @@ public class AnomalyDetector extends Config {
      * @param customResultIndexMinSize custom result index lifecycle management min size condition
      * @param customResultIndexMinAge custom result index lifecycle management min age condition
      * @param customResultIndexTTL custom result index lifecycle management ttl
-     * @param flattenResultIndexMapping flag to indicate whether to flatten result index mapping or not
      * @param lastBreakingUIChangeTime last update time to configuration that can break UI and we have
      *  to display updates from the changed time
      */
@@ -182,7 +181,6 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping,
         Instant lastBreakingUIChangeTime
     ) {
         super(
@@ -211,7 +209,6 @@ public class AnomalyDetector extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping,
             lastBreakingUIChangeTime
         );
 
@@ -291,7 +288,6 @@ public class AnomalyDetector extends Config {
         this.customResultIndexMinSize = input.readOptionalInt();
         this.customResultIndexMinAge = input.readOptionalInt();
         this.customResultIndexTTL = input.readOptionalInt();
-        this.flattenResultIndexMapping = input.readOptionalBoolean();
         this.lastUIBreakingChangeTime = input.readOptionalInstant();
     }
 
@@ -358,7 +354,6 @@ public class AnomalyDetector extends Config {
         output.writeOptionalInt(customResultIndexMinSize);
         output.writeOptionalInt(customResultIndexMinAge);
         output.writeOptionalInt(customResultIndexTTL);
-        output.writeOptionalBoolean(flattenResultIndexMapping);
         output.writeOptionalInstant(lastUIBreakingChangeTime);
     }
 
@@ -456,7 +451,6 @@ public class AnomalyDetector extends Config {
         Integer customResultIndexMinSize = null;
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
-        Boolean flattenResultIndexMapping = null;
         Instant lastBreakingUIChangeTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -592,9 +586,6 @@ public class AnomalyDetector extends Config {
                 case RESULT_INDEX_FIELD_TTL:
                     customResultIndexTTL = onlyParseNumberValue(parser);
                     break;
-                case FLATTEN_RESULT_INDEX_MAPPING:
-                    flattenResultIndexMapping = onlyParseBooleanValue(parser);
-                    break;
                 case BREAKING_UI_CHANGE_TIME:
                     lastBreakingUIChangeTime = ParseUtils.toInstant(parser);
                     break;
@@ -629,7 +620,6 @@ public class AnomalyDetector extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping,
             lastBreakingUIChangeTime
         );
         detector.setDetectionDateRange(detectionDateRange);
@@ -714,13 +704,6 @@ public class AnomalyDetector extends Config {
     private static Integer onlyParseNumberValue(XContentParser parser) throws IOException {
         if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
             return parser.intValue();
-        }
-        return null;
-    }
-
-    private static Boolean onlyParseBooleanValue(XContentParser parser) throws IOException {
-        if (parser.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
-            return parser.booleanValue();
         }
         return null;
     }

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -245,7 +245,6 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
             config.getCustomResultIndexTTL(),
-            config.getFlattenResultIndexMapping(),
             breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime()
         );
     }

--- a/src/main/java/org/opensearch/forecast/model/ForecastTask.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastTask.java
@@ -1,8 +1,5 @@
 /*
-<<<<<<< HEAD
  * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
-=======
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
@@ -11,7 +8,6 @@
  *
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
->>>>>>> f22eaa95 (test)
  */
 
 package org.opensearch.forecast.model;
@@ -343,7 +339,6 @@ public class ForecastTask extends TimeSeriesTask {
                 forecaster.getCustomResultIndexMinSize(),
                 forecaster.getCustomResultIndexMinAge(),
                 forecaster.getCustomResultIndexTTL(),
-                forecaster.getFlattenResultIndexMapping(),
                 forecaster.getLastBreakingUIChangeTime()
             );
         return new Builder()

--- a/src/main/java/org/opensearch/forecast/model/Forecaster.java
+++ b/src/main/java/org/opensearch/forecast/model/Forecaster.java
@@ -135,7 +135,6 @@ public class Forecaster extends Config {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping,
         Instant lastBreakingUIChangeTime
     ) {
         super(
@@ -164,7 +163,6 @@ public class Forecaster extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping,
             lastBreakingUIChangeTime
         );
 
@@ -307,7 +305,6 @@ public class Forecaster extends Config {
         Integer customResultIndexMinSize = null;
         Integer customResultIndexMinAge = null;
         Integer customResultIndexTTL = null;
-        Boolean flattenResultIndexMapping = null;
         Instant lastBreakingUIChangeTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -437,9 +434,6 @@ public class Forecaster extends Config {
                 case RESULT_INDEX_FIELD_TTL:
                     customResultIndexTTL = parser.intValue();
                     break;
-                case FLATTEN_RESULT_INDEX_MAPPING:
-                    flattenResultIndexMapping = parser.booleanValue();
-                    break;
                 case BREAKING_UI_CHANGE_TIME:
                     lastBreakingUIChangeTime = ParseUtils.toInstant(parser);
                     break;
@@ -474,7 +468,6 @@ public class Forecaster extends Config {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping,
             lastBreakingUIChangeTime
         );
         return forecaster;

--- a/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
+++ b/src/main/java/org/opensearch/forecast/rest/handler/AbstractForecasterActionHandler.java
@@ -258,7 +258,6 @@ public abstract class AbstractForecasterActionHandler<T extends ActionResponse> 
             config.getCustomResultIndexMinSize(),
             config.getCustomResultIndexMinAge(),
             config.getCustomResultIndexTTL(),
-            config.getFlattenResultIndexMapping(),
             breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime()
         );
     }

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -79,7 +79,6 @@ public abstract class Config implements Writeable, ToXContentObject {
     public static final String RESULT_INDEX_FIELD_MIN_SIZE = "result_index_min_size";
     public static final String RESULT_INDEX_FIELD_MIN_AGE = "result_index_min_age";
     public static final String RESULT_INDEX_FIELD_TTL = "result_index_ttl";
-    public static final String FLATTEN_RESULT_INDEX_MAPPING = "flatten_result_index_mapping";
     // Changing categorical field, feature attributes, interval, windowDelay, time field, horizon, indices,
     // result index would force us to display results only from the most recent update. Otherwise,
     // the UI appear cluttered and unclear.
@@ -124,7 +123,6 @@ public abstract class Config implements Writeable, ToXContentObject {
     protected Integer customResultIndexMinSize;
     protected Integer customResultIndexMinAge;
     protected Integer customResultIndexTTL;
-    protected Boolean flattenResultIndexMapping;
     protected Instant lastUIBreakingChangeTime;
 
     public static String INVALID_RESULT_INDEX_NAME_SIZE = "Result index name size must contains less than "
@@ -157,7 +155,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         Integer customResultIndexMinSize,
         Integer customResultIndexMinAge,
         Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping,
         Instant lastBreakingUIChangeTime
     ) {
         if (Strings.isBlank(name)) {
@@ -297,7 +294,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.customResultIndexMinSize = Strings.trimToNull(resultIndex) == null ? null : customResultIndexMinSize;
         this.customResultIndexMinAge = Strings.trimToNull(resultIndex) == null ? null : customResultIndexMinAge;
         this.customResultIndexTTL = Strings.trimToNull(resultIndex) == null ? null : customResultIndexTTL;
-        this.flattenResultIndexMapping = Strings.trimToNull(resultIndex) == null ? null : flattenResultIndexMapping;
         this.lastUIBreakingChangeTime = lastBreakingUIChangeTime;
     }
 
@@ -342,7 +338,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.customResultIndexMinSize = input.readOptionalInt();
         this.customResultIndexMinAge = input.readOptionalInt();
         this.customResultIndexTTL = input.readOptionalInt();
-        this.flattenResultIndexMapping = input.readOptionalBoolean();
         this.lastUIBreakingChangeTime = input.readOptionalInstant();
     }
 
@@ -396,7 +391,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         output.writeOptionalInt(customResultIndexMinSize);
         output.writeOptionalInt(customResultIndexMinAge);
         output.writeOptionalInt(customResultIndexTTL);
-        output.writeOptionalBoolean(flattenResultIndexMapping);
         output.writeOptionalInstant(lastUIBreakingChangeTime);
     }
 
@@ -454,8 +448,7 @@ public abstract class Config implements Writeable, ToXContentObject {
             && Objects.equal(historyIntervals, config.historyIntervals)
             && Objects.equal(customResultIndexMinSize, config.customResultIndexMinSize)
             && Objects.equal(customResultIndexMinAge, config.customResultIndexMinAge)
-            && Objects.equal(customResultIndexTTL, config.customResultIndexTTL)
-            && Objects.equal(flattenResultIndexMapping, config.flattenResultIndexMapping);
+            && Objects.equal(customResultIndexTTL, config.customResultIndexTTL);
     }
 
     @Generated
@@ -482,8 +475,7 @@ public abstract class Config implements Writeable, ToXContentObject {
                 historyIntervals,
                 customResultIndexMinSize,
                 customResultIndexMinAge,
-                customResultIndexTTL,
-                flattenResultIndexMapping
+                customResultIndexTTL
             );
     }
 
@@ -531,9 +523,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         }
         if (customResultIndexTTL != null) {
             builder.field(RESULT_INDEX_FIELD_TTL, customResultIndexTTL);
-        }
-        if (flattenResultIndexMapping != null) {
-            builder.field(FLATTEN_RESULT_INDEX_MAPPING, flattenResultIndexMapping);
         }
         if (lastUIBreakingChangeTime != null) {
             builder.field(BREAKING_UI_CHANGE_TIME, lastUIBreakingChangeTime.toEpochMilli());
@@ -746,10 +735,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         return customResultIndexTTL;
     }
 
-    public Boolean getFlattenResultIndexMapping() {
-        return flattenResultIndexMapping;
-    }
-
     public Instant getLastBreakingUIChangeTime() {
         return lastUIBreakingChangeTime;
     }
@@ -806,7 +791,6 @@ public abstract class Config implements Writeable, ToXContentObject {
             .append("customResultIndexMinSize", customResultIndexMinSize)
             .append("customResultIndexMinAge", customResultIndexMinAge)
             .append("customResultIndexTTL", customResultIndexTTL)
-            .append("flattenResultIndexMapping", flattenResultIndexMapping)
             .toString();
     }
 }

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -859,7 +859,6 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractTimeSeriesTe
                         detector.getCustomResultIndexMinSize(),
                         detector.getCustomResultIndexMinAge(),
                         detector.getCustomResultIndexTTL(),
-                        detector.getFlattenResultIndexMapping(),
                         Instant.now()
                     );
                     try {

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -314,7 +314,6 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getCustomResultIndexMinSize(),
                 detector.getCustomResultIndexMinAge(),
                 detector.getCustomResultIndexTTL(),
-                detector.getFlattenResultIndexMapping(),
                 detector.getLastBreakingUIChangeTime()
             ),
             detectorJob,
@@ -584,7 +583,6 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             anomalyDetector.getCustomResultIndexMinSize(),
             anomalyDetector.getCustomResultIndexMinAge(),
             anomalyDetector.getCustomResultIndexTTL(),
-            anomalyDetector.getFlattenResultIndexMapping(),
             Instant.now()
         );
         return detector;

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -345,7 +345,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null,
                     Instant.now()
                 )
             );
@@ -379,7 +378,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     randomIntBetween(1, 10000),
                     randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                     randomIntBetween(1, 1000),
-                    null,
                     null,
                     null,
                     null,
@@ -421,7 +419,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null,
                     Instant.now()
                 )
             );
@@ -455,7 +452,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     randomIntBetween(1, 10000),
                     randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                     randomIntBetween(1, 1000),
-                    null,
                     null,
                     null,
                     null,
@@ -497,7 +493,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null,
                     Instant.now()
                 )
             );
@@ -531,7 +526,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     randomIntBetween(1, 10000),
                     randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                     randomIntBetween(1, 1000),
-                    null,
                     null,
                     null,
                     null,
@@ -573,7 +567,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     null,
                     null,
-                    null,
                     Instant.now()
                 )
             );
@@ -606,7 +599,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 -1,
                 randomIntBetween(1, 256),
                 randomIntBetween(1, 1000),
-                null,
                 null,
                 null,
                 null,
@@ -648,7 +640,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 null,
                 null,
-                null,
                 Instant.now()
             )
         );
@@ -682,7 +673,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null, // emphasis is not customized
                 randomIntBetween(1, 256),
                 randomIntBetween(1, 1000),
-                null,
                 null,
                 null,
                 null,
@@ -737,7 +727,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
@@ -773,7 +762,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
         // seasonalityIntervals is not null and custom shingle size is null, use seasonalityIntervals to deterine shingle size
@@ -801,7 +789,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -839,7 +826,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
         assertNotNull(anomalyDetector.getFeatureAttributes());
@@ -869,7 +855,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             randomIntBetween(1, 10000),
             randomIntBetween(1, TimeSeriesSettings.MAX_SHINGLE_SIZE * TimeSeriesSettings.SEASONALITY_TO_SHINGLE_RATIO),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -962,21 +947,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
         assertEquals(30, (int) parsedDetector.getCustomResultIndexTTL());
     }
 
-    public void testParseAnomalyDetector_withCustomIndex_withFlattenResultIndexMapping() throws IOException {
-        String detectorString = "{\"name\":\"AhtYYGWTgqkzairTchcs\",\"description\":\"iIiAVPMyFgnFlEniLbMyfJxyoGvJAl\","
-            + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
-            + "{\"field\":\"value\",\"boost\":1}}],\"adjust_pure_negative\":true,\"boost\":1}},\"window_delay\":"
-            + "{\"period\":{\"interval\":2,\"unit\":\"Minutes\"}},\"shingle_size\":8,\"schema_version\":-512063255,"
-            + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":true,"
-            + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
-            + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"result_index\":"
-            + "\"opensearch-ad-plugin-result-test\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"default_fill\""
-            + ":[{\"feature_name\":\"eYYCM\", \"data\": 3}]},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
-            + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[],\"flatten_result_index_mapping\":true}";
-        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
-        assertEquals(true, (boolean) parsedDetector.getFlattenResultIndexMapping());
-    }
-
     public void testSerializeAndDeserializeAnomalyDetector() throws IOException {
         // register writer and reader for type Feature
         Writeable.WriteableRegistry.registerWriter(Feature.class, (o, v) -> {
@@ -1037,7 +1007,6 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 randomIntBetween(1, 10000),
                 randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
                 randomIntBetween(1, 1000),
-                null,
                 null,
                 null,
                 null,

--- a/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
+++ b/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
@@ -226,7 +226,6 @@ public class ADRestTestUtils {
             null,
             null,
             null,
-            null,
             now
         );
 

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -160,7 +160,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null,
             null
         );
 
@@ -290,7 +289,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null,
             detector.getLastBreakingUIChangeTime()
         );
         Exception ex = expectThrows(
@@ -354,7 +352,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -431,7 +428,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null,
             detector1.getLastBreakingUIChangeTime()
         );
 
@@ -477,7 +473,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -533,7 +528,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -919,7 +913,6 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
@@ -349,7 +349,6 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
             detector.getCustomResultIndexMinSize(),
             detector.getCustomResultIndexMinAge(),
             detector.getCustomResultIndexTTL(),
-            detector.getFlattenResultIndexMapping(),
             detector.getLastBreakingUIChangeTime()
         );
     }

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -264,7 +264,6 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
         // User client has admin all access, and has "opensearch" backend role so client should be able to update detector
@@ -316,7 +315,6 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -227,7 +227,6 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
     }
@@ -255,7 +254,6 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
@@ -86,7 +86,6 @@ public class ForwardADTaskRequestTests extends OpenSearchSingleNodeTestCase {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
         ForwardADTaskRequest request = new ForwardADTaskRequest(detector, null, null, null, null, Version.V_2_1_0);

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -405,7 +405,6 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             null,
             null,
-            null,
             Instant.now()
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
@@ -451,7 +450,6 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             randomIntBetween(1, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
+++ b/src/test/java/org/opensearch/forecast/model/ForecasterTests.java
@@ -59,7 +59,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
     Integer customResultIndexMinSize = null;
     Integer customResultIndexMinAge = null;
     Integer customResultIndexTTL = null;
-    Boolean flattenResultIndexMapping = null;
 
     public void testForecasterConstructor() {
         ImputationOption imputationOption = TestHelpers.randomImputationOption(features);
@@ -90,7 +89,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping,
             lastUpdateTime
         );
 
@@ -145,7 +143,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         });
@@ -185,7 +182,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         });
@@ -225,7 +221,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         });
@@ -265,7 +260,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         });
@@ -305,7 +299,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         });
@@ -344,7 +337,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             customResultIndexMinSize,
             customResultIndexMinAge,
             customResultIndexTTL,
-            flattenResultIndexMapping,
             lastUpdateTime
         );
 
@@ -381,7 +373,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         });
@@ -477,24 +468,6 @@ public class ForecasterTests extends AbstractTimeSeriesTest {
             .setCustomResultIndexMinAge(7)
             .setCustomResultIndexTTL(30)
             .build();
-        String forecasterString = TestHelpers
-            .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
-        LOG.info(forecasterString);
-        Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
-        assertEquals(forecaster, parsedForecaster);
-    }
-
-    public void testParseNullCustomResultIndex_nullFlattenResultIndexMapping() throws IOException {
-        Forecaster forecaster = TestHelpers.ForecasterBuilder.newInstance().setFlattenResultIndexMapping(null).build();
-        String forecasterString = TestHelpers
-            .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
-        LOG.info(forecasterString);
-        Forecaster parsedForecaster = Forecaster.parse(TestHelpers.parser(forecasterString));
-        assertEquals(forecaster, parsedForecaster);
-    }
-
-    public void testValidCustomResultIndex_withFlattenResultIndexMapping() throws IOException {
-        Forecaster forecaster = TestHelpers.ForecasterBuilder.newInstance().setFlattenResultIndexMapping(true).build();
         String forecasterString = TestHelpers
             .xContentBuilderToString(forecaster.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         LOG.info(forecasterString);

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -340,7 +340,6 @@ public class TestHelpers {
             null,
             null,
             null,
-            null,
             lastUpdateTime
         );
     }
@@ -392,7 +391,6 @@ public class TestHelpers {
             randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -463,7 +461,6 @@ public class TestHelpers {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
     }
@@ -505,7 +502,6 @@ public class TestHelpers {
             null,
             null,
             null,
-            null,
             Instant.now()
         );
     }
@@ -535,7 +531,6 @@ public class TestHelpers {
             randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -576,7 +571,6 @@ public class TestHelpers {
             randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -759,7 +753,6 @@ public class TestHelpers {
                 null,
                 null,
                 null,
-                null,
                 lastUpdateTime
             );
         }
@@ -793,7 +786,6 @@ public class TestHelpers {
             randomIntBetween(2, 10000),
             randomInt(TimeSeriesSettings.MAX_SHINGLE_SIZE / 2),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,
@@ -1780,7 +1772,6 @@ public class TestHelpers {
         Integer customResultIndexMinSize;
         Integer customResultIndexMinAge;
         Integer customResultIndexTTL;
-        Boolean flattenResultIndexMapping;
 
         ForecasterBuilder() throws IOException {
             forecasterId = randomAlphaOfLength(10);
@@ -1805,7 +1796,6 @@ public class TestHelpers {
             customResultIndexMinSize = null;
             customResultIndexMinAge = null;
             customResultIndexTTL = null;
-            flattenResultIndexMapping = null;
         }
 
         public static ForecasterBuilder newInstance() throws IOException {
@@ -1912,11 +1902,6 @@ public class TestHelpers {
             return this;
         }
 
-        public ForecasterBuilder setFlattenResultIndexMapping(Boolean flattenResultIndexMapping) {
-            this.flattenResultIndexMapping = flattenResultIndexMapping;
-            return this;
-        }
-
         public ForecasterBuilder setNullImputationOption() {
             this.imputationOption = null;
             return this;
@@ -1955,7 +1940,6 @@ public class TestHelpers {
                 customResultIndexMinSize,
                 customResultIndexMinAge,
                 customResultIndexTTL,
-                flattenResultIndexMapping,
                 lastUpdateTime
             );
         }
@@ -1988,7 +1972,6 @@ public class TestHelpers {
             randomIntBetween(2, 1000),
             randomIntBetween(1, 128),
             randomIntBetween(1, 1000),
-            null,
             null,
             null,
             null,


### PR DESCRIPTION
This reverts commit cbe1f336faf237907e4786d4c7db429a9126954c.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
