### PR TITLE
Fix race condition in PageListener

### DIFF
--- a/src/main/java/org/opensearch/timeseries/transport/ResultBulkTransportAction.java
+++ b/src/main/java/org/opensearch/timeseries/transport/ResultBulkTransportAction.java
@@ -85,7 +85,6 @@ public abstract class ResultBulkTransportAction<ResultType extends IndexableResu
         // all non-zero anomaly grade index requests and index zero anomaly grade index requests with probability (1 - index pressure).
         long totalBytes = indexingPressure.getCurrentCombinedCoordinatingAndPrimaryBytes() + indexingPressure.getCurrentReplicaBytes();
         float indexingPressurePercent = (float) totalBytes / primaryAndCoordinatingLimits;
-        @SuppressWarnings("rawtypes")
         List<? extends ResultWriteRequest> results = request.getResults();
 
         if (results == null || results.size() < 1) {

--- a/src/main/java/org/opensearch/timeseries/transport/ResultProcessor.java
+++ b/src/main/java/org/opensearch/timeseries/transport/ResultProcessor.java
@@ -229,15 +229,15 @@ public abstract class ResultProcessor<TransportResultRequestType extends ResultR
 
         @Override
         public void onResponse(CompositeRetriever.Page entityFeatures) {
+            // Increment pagesInFlight to track the processing of this page
+            pagesInFlight.incrementAndGet();
+
             // start processing next page after sending out features for previous page
             if (pageIterator.hasNext()) {
                 pageIterator.next(this);
             } else if (config.getImputationOption() != null) {
                 scheduleImputeHCTask();
             }
-
-            // Increment pagesInFlight to track the processing of this page
-            pagesInFlight.incrementAndGet();
 
             if (entityFeatures != null && false == entityFeatures.isEmpty()) {
                 LOG

--- a/src/test/java/org/opensearch/ad/e2e/AbstractMissingSingleFeatureTestCase.java
+++ b/src/test/java/org/opensearch/ad/e2e/AbstractMissingSingleFeatureTestCase.java
@@ -28,7 +28,8 @@ public abstract class AbstractMissingSingleFeatureTestCase extends MissingIT {
         long windowDelayMinutes,
         boolean hc,
         ImputationMethod imputation,
-        long trainTimeMillis
+        long trainTimeMillis,
+        String name
     ) {
         StringBuilder sb = new StringBuilder();
         // common part

--- a/src/test/java/org/opensearch/ad/e2e/MissingIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/MissingIT.java
@@ -78,13 +78,25 @@ public abstract class MissingIT extends AbstractADSyntheticDataTest {
         List<JsonObject> data,
         ImputationMethod imputation,
         boolean hc,
-        long trainTimeMillis
+        long trainTimeMillis,
+        String name
     ) throws Exception {
-        TrainResult trainResult = createDetector(numberOfEntities, trainTestSplit, data, imputation, hc, trainTimeMillis);
+        TrainResult trainResult = createDetector(numberOfEntities, trainTestSplit, data, imputation, hc, trainTimeMillis, name);
         List<JsonObject> result = startRealTimeDetector(trainResult, numberOfEntities, intervalMinutes, true);
         recordLastSeenFromResult(result);
 
         return trainResult;
+    }
+
+    protected TrainResult createAndStartRealTimeDetector(
+        int numberOfEntities,
+        int trainTestSplit,
+        List<JsonObject> data,
+        ImputationMethod imputation,
+        boolean hc,
+        long trainTimeMillis
+    ) throws Exception {
+        return createAndStartRealTimeDetector(numberOfEntities, trainTestSplit, data, imputation, hc, trainTimeMillis, "test");
     }
 
     protected TrainResult createAndStartHistoricalDetector(
@@ -115,18 +127,30 @@ public abstract class MissingIT extends AbstractADSyntheticDataTest {
         List<JsonObject> data,
         ImputationMethod imputation,
         boolean hc,
-        long trainTimeMillis
+        long trainTimeMillis,
+        String name
     ) throws Exception {
         Instant trainTime = Instant.ofEpochMilli(trainTimeMillis);
 
         Duration windowDelay = getWindowDelay(trainTimeMillis);
-        String detector = genDetector(trainTestSplit, windowDelay.toMinutes(), hc, imputation, trainTimeMillis);
+        String detector = genDetector(trainTestSplit, windowDelay.toMinutes(), hc, imputation, trainTimeMillis, name);
 
         RestClient client = client();
         String detectorId = createDetector(client, detector);
         LOG.info("Created detector {}", detectorId);
 
         return new TrainResult(detectorId, data, trainTestSplit * numberOfEntities, windowDelay, trainTime, "timestamp");
+    }
+
+    protected TrainResult createDetector(
+        int numberOfEntities,
+        int trainTestSplit,
+        List<JsonObject> data,
+        ImputationMethod imputation,
+        boolean hc,
+        long trainTimeMillis
+    ) throws Exception {
+        return createDetector(numberOfEntities, trainTestSplit, data, imputation, hc, trainTimeMillis, "test");
     }
 
     protected Duration getWindowDelay(long trainTimeMillis) {
@@ -156,7 +180,8 @@ public abstract class MissingIT extends AbstractADSyntheticDataTest {
         long windowDelayMinutes,
         boolean hc,
         ImputationMethod imputation,
-        long trainTimeMillis
+        long trainTimeMillis,
+        String name
     );
 
     protected abstract AbstractSyntheticDataTest.GenData genData(

--- a/src/test/java/org/opensearch/ad/e2e/PreviewMissingSingleFeatureIT.java
+++ b/src/test/java/org/opensearch/ad/e2e/PreviewMissingSingleFeatureIT.java
@@ -35,7 +35,7 @@ public class PreviewMissingSingleFeatureIT extends AbstractMissingSingleFeatureT
         );
 
         Duration windowDelay = getWindowDelay(dataGenerated.testStartTime);
-        String detector = genDetector(trainTestSplit, windowDelay.toMinutes(), false, method, dataGenerated.testStartTime);
+        String detector = genDetector(trainTestSplit, windowDelay.toMinutes(), false, method, dataGenerated.testStartTime, "test");
 
         Instant begin = Instant.ofEpochMilli(dataGenerated.data.get(0).get("timestamp").getAsLong());
         Instant end = Instant.ofEpochMilli(dataGenerated.data.get(dataGenerated.data.size() - 1).get("timestamp").getAsLong());
@@ -63,7 +63,7 @@ public class PreviewMissingSingleFeatureIT extends AbstractMissingSingleFeatureT
         );
 
         Duration windowDelay = getWindowDelay(dataGenerated.testStartTime);
-        String detector = genDetector(trainTestSplit, windowDelay.toMinutes(), true, method, dataGenerated.testStartTime);
+        String detector = genDetector(trainTestSplit, windowDelay.toMinutes(), true, method, dataGenerated.testStartTime, "test");
 
         Instant begin = Instant.ofEpochMilli(dataGenerated.data.get(0).get("timestamp").getAsLong());
         Instant end = Instant.ofEpochMilli(dataGenerated.data.get(dataGenerated.data.size() - 1).get("timestamp").getAsLong());


### PR DESCRIPTION
### Description
This PR
- Introduced an `AtomicInteger` called `pagesInFlight` to track the number of pages currently being processed. 
- Incremented `pagesInFlight` before processing each page and decremented it after processing is complete
- Adjusted the condition in `scheduleImputeHCTask` to check both `pagesInFlight.get() == 0` (all pages have been processed) and `sentOutPages.get() == receivedPages.get()` (all responses have been received) before scheduling the `imputeHC` task. 
- Removed the previous final check in `onResponse` that decided when to schedule `imputeHC`, relying instead on the updated counters for accurate synchronization.

These changes address the race condition where `sentOutPages` might not have been incremented in time before checking whether to schedule the `imputeHC` task. By accurately tracking the number of in-flight pages and sent pages, we ensure that `imputeHC` is executed only after all pages have been fully processed and all responses have been received.

Testing done:
1. Reproduced the race condition by starting two detectors with imputation. This causes an out of order illegal argument exception from RCF due to this race condition. Also verified the change fixed the problem.
2. added an IT for the above scenario.

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
