### PR TITLE
Adding feature direction rules

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/IgnoreSimilarExtractor.java
+++ b/src/main/java/org/opensearch/ad/ml/IgnoreSimilarExtractor.java
@@ -54,7 +54,7 @@ public class IgnoreSimilarExtractor {
             for (Rule rule : rules) {
                 for (Condition condition : rule.getConditions()) {
                     if (condition.getThresholdType() != ThresholdType.ACTUAL_IS_BELOW_EXPECTED
-                        || condition.getThresholdType() != ThresholdType.ACTUAL_IS_OVER_EXPECTED) {
+                        && condition.getThresholdType() != ThresholdType.ACTUAL_IS_OVER_EXPECTED) {
                         processCondition(
                             condition,
                             featureNames,

--- a/src/main/java/org/opensearch/ad/ml/IgnoreSimilarExtractor.java
+++ b/src/main/java/org/opensearch/ad/ml/IgnoreSimilarExtractor.java
@@ -53,15 +53,18 @@ public class IgnoreSimilarExtractor {
         if (rules != null) {
             for (Rule rule : rules) {
                 for (Condition condition : rule.getConditions()) {
-                    processCondition(
-                        condition,
-                        featureNames,
-                        baseDimension,
-                        ignoreSimilarFromAbove,
-                        ignoreSimilarFromBelow,
-                        ignoreSimilarFromAboveByRatio,
-                        ignoreSimilarFromBelowByRatio
-                    );
+                    if (condition.getThresholdType() != ThresholdType.ACTUAL_IS_BELOW_EXPECTED
+                        || condition.getThresholdType() != ThresholdType.ACTUAL_IS_OVER_EXPECTED) {
+                        processCondition(
+                            condition,
+                            featureNames,
+                            baseDimension,
+                            ignoreSimilarFromAbove,
+                            ignoreSimilarFromBelow,
+                            ignoreSimilarFromAboveByRatio,
+                            ignoreSimilarFromBelowByRatio
+                        );
+                    }
                 }
             }
         }
@@ -100,7 +103,10 @@ public class IgnoreSimilarExtractor {
         int featureIndex = featureNames.indexOf(featureName);
 
         ThresholdType thresholdType = condition.getThresholdType();
-        double value = condition.getValue();
+        Double value = condition.getValue();
+        if (value == null) {
+            value = 0d;
+        }
 
         switch (thresholdType) {
             case ACTUAL_OVER_EXPECTED_MARGIN:

--- a/src/main/java/org/opensearch/ad/ml/ThresholdingResult.java
+++ b/src/main/java/org/opensearch/ad/ml/ThresholdingResult.java
@@ -12,6 +12,7 @@
 package org.opensearch.ad.ml;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -19,7 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.model.Rule;
 import org.opensearch.timeseries.ml.IntermediateResult;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.Entity;
@@ -331,6 +334,12 @@ public class ThresholdingResult extends IntermediateResult<AnomalyResult> {
         String taskId,
         String error
     ) {
+        List<Rule> rules = new ArrayList<>();
+        if (detector instanceof AnomalyDetector) {
+            AnomalyDetector detectorConfig = (AnomalyDetector) detector;
+            rules = detectorConfig.getRules();
+        }
+
         return Collections
             .singletonList(
                 AnomalyResult
@@ -358,7 +367,8 @@ public class ThresholdingResult extends IntermediateResult<AnomalyResult> {
                         likelihoodOfValues,
                         threshold,
                         currentData,
-                        featureImputed
+                        featureImputed,
+                        rules
                     )
             );
     }

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -835,6 +835,17 @@ public class AnomalyDetector extends Config {
                         this.issueType = ValidationIssueType.RULE;
                         return;
                     }
+                } else if (thresholdType == ThresholdType.ACTUAL_IS_BELOW_EXPECTED
+                    || thresholdType == ThresholdType.ACTUAL_IS_OVER_EXPECTED) {
+                    // Check if both operator and value are null
+                    if (condition.getOperator() != null || condition.getValue() != null) {
+                        this.errorMessage = SUPPRESSION_RULE_ISSUE_PREFIX
+                            + "For threshold type \""
+                            + thresholdType
+                            + "\", both operator and value must be empty or null, as this rule compares actual to expected values directly";
+                        this.issueType = ValidationIssueType.RULE;
+                        return;
+                    }
                 }
             }
         }

--- a/src/main/java/org/opensearch/ad/model/Condition.java
+++ b/src/main/java/org/opensearch/ad/model/Condition.java
@@ -29,9 +29,9 @@ public class Condition implements Writeable, ToXContentObject {
     private String featureName;
     private ThresholdType thresholdType;
     private Operator operator;
-    private double value;
+    private Double value;
 
-    public Condition(String featureName, ThresholdType thresholdType, Operator operator, double value) {
+    public Condition(String featureName, ThresholdType thresholdType, Operator operator, Double value) {
         this.featureName = featureName;
         this.thresholdType = thresholdType;
         this.operator = operator;
@@ -42,7 +42,7 @@ public class Condition implements Writeable, ToXContentObject {
         this.featureName = input.readString();
         this.thresholdType = input.readEnum(ThresholdType.class);
         this.operator = input.readEnum(Operator.class);
-        this.value = input.readDouble();
+        this.value = input.readBoolean() ? input.readDouble() : null;
     }
 
     /**
@@ -56,7 +56,7 @@ public class Condition implements Writeable, ToXContentObject {
         String featureName = null;
         ThresholdType thresholdType = null;
         Operator operator = null;
-        Double value = 0d;
+        Double value = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -70,11 +70,19 @@ public class Condition implements Writeable, ToXContentObject {
                 case THRESHOLD_TYPE_FIELD:
                     thresholdType = ThresholdType.valueOf(parser.text().toUpperCase(Locale.ROOT));
                     break;
-                case OPERATOR_FIELD:
-                    operator = Operator.valueOf(parser.text().toUpperCase(Locale.ROOT));
+                case "operator":
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        operator = null; // Set operator to null if the field is missing
+                    } else {
+                        operator = Operator.valueOf(parser.text().toUpperCase(Locale.ROOT));
+                    }
                     break;
                 case VALUE_FIELD:
-                    value = parser.doubleValue();
+                    if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        value = null;
+                    } else {
+                        value = parser.doubleValue();
+                    }
                     break;
                 default:
                     break;
@@ -89,8 +97,10 @@ public class Condition implements Writeable, ToXContentObject {
             .startObject()
             .field(FEATURE_NAME_FIELD, featureName)
             .field(THRESHOLD_TYPE_FIELD, thresholdType)
-            .field(OPERATOR_FIELD, operator)
-            .field(VALUE_FIELD, value);
+            .field(OPERATOR_FIELD, operator);
+        if (value != null) {
+            builder.field("value", value);
+        }
         return xContentBuilder.endObject();
     }
 
@@ -99,7 +109,10 @@ public class Condition implements Writeable, ToXContentObject {
         out.writeString(featureName);
         out.writeEnum(thresholdType);
         out.writeEnum(operator);
-        out.writeDouble(value);
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeDouble(value);
+        }
     }
 
     public String getFeatureName() {
@@ -114,7 +127,7 @@ public class Condition implements Writeable, ToXContentObject {
         return operator;
     }
 
-    public double getValue() {
+    public Double getValue() {
         return value;
     }
 

--- a/src/main/java/org/opensearch/ad/model/Condition.java
+++ b/src/main/java/org/opensearch/ad/model/Condition.java
@@ -70,7 +70,7 @@ public class Condition implements Writeable, ToXContentObject {
                 case THRESHOLD_TYPE_FIELD:
                     thresholdType = ThresholdType.valueOf(parser.text().toUpperCase(Locale.ROOT));
                     break;
-                case "operator":
+                case OPERATOR_FIELD:
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         operator = null; // Set operator to null if the field is missing
                     } else {
@@ -79,7 +79,7 @@ public class Condition implements Writeable, ToXContentObject {
                     break;
                 case VALUE_FIELD:
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
-                        value = null;
+                        value = null; // Set value to null if the field is missing
                     } else {
                         value = parser.doubleValue();
                     }

--- a/src/main/java/org/opensearch/ad/model/ThresholdType.java
+++ b/src/main/java/org/opensearch/ad/model/ThresholdType.java
@@ -57,7 +57,19 @@ public enum ThresholdType {
      * should be ignored if the ratio of the deviation from the expected to the actual
      * (b-a)/|a| is less than or equal to ignoreNearExpectedFromBelowByRatio.
      */
-    EXPECTED_OVER_ACTUAL_RATIO("the ratio of the expected value over the actual value");
+    EXPECTED_OVER_ACTUAL_RATIO("the ratio of the expected value over the actual value"),
+
+    /**
+      * Specifies a threshold for ignoring anomalies based on whether the actual value
+      * is over the expected value returned from the model.
+      */
+    ACTUAL_IS_OVER_EXPECTED("the actual value is over the expected value"),
+
+    /**
+    * Specifies a threshold for ignoring anomalies based on whether the actual value
+    * is below the expected value returned from the model.
+     * */
+    ACTUAL_IS_BELOW_EXPECTED("the actual value is below the expected value");
 
     private final String description;
 

--- a/src/main/java/org/opensearch/forecast/transport/ForecastResultResponse.java
+++ b/src/main/java/org/opensearch/forecast/transport/ForecastResultResponse.java
@@ -25,6 +25,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.forecast.model.ForecastResult;
 import org.opensearch.timeseries.constant.CommonName;
+import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.FeatureData;
 import org.opensearch.timeseries.transport.ResultResponse;
 
@@ -169,7 +170,7 @@ public class ForecastResultResponse extends ResultResponse<ForecastResult> {
     *
     * Convert ForecastResultResponse to ForecastResult
     *
-    * @param forecastId Forecaster Id
+    * @param config config
     * @param dataStartInstant data start time
     * @param dataEndInstant data end time
     * @param executionStartInstant  execution start time
@@ -181,7 +182,7 @@ public class ForecastResultResponse extends ResultResponse<ForecastResult> {
     */
     @Override
     public List<ForecastResult> toIndexableResults(
-        String forecastId,
+        Config config,
         Instant dataStartInstant,
         Instant dataEndInstant,
         Instant executionStartInstant,
@@ -194,7 +195,7 @@ public class ForecastResultResponse extends ResultResponse<ForecastResult> {
         long forecasterIntervalMilli = Duration.between(dataStartInstant, dataEndInstant).toMillis();
         return ForecastResult
             .fromRawRCFCasterResult(
-                forecastId,
+                config.getId(),
                 forecasterIntervalMilli,
                 dataQuality,
                 features,

--- a/src/main/java/org/opensearch/timeseries/ExecuteResultResponseRecorder.java
+++ b/src/main/java/org/opensearch/timeseries/ExecuteResultResponseRecorder.java
@@ -119,7 +119,7 @@ public abstract class ExecuteResultResponseRecorder<IndexType extends Enum<Index
 
             List<IndexableResultType> analysisResults = response
                 .toIndexableResults(
-                    configId,
+                    config,
                     dataStartTime,
                     dataEndTime,
                     executionStartTime,

--- a/src/main/java/org/opensearch/timeseries/model/Feature.java
+++ b/src/main/java/org/opensearch/timeseries/model/Feature.java
@@ -15,6 +15,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 
 import java.io.IOException;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.common.UUIDs;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -169,4 +170,15 @@ public class Feature implements Writeable, ToXContentObject {
     public AggregationBuilder getAggregation() {
         return aggregation;
     }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("id", id)
+            .append("name", name)
+            .append("enabled", enabled)
+            .append("aggregation", aggregation)
+            .toString();
+    }
+
 }

--- a/src/main/java/org/opensearch/timeseries/model/FeatureData.java
+++ b/src/main/java/org/opensearch/timeseries/model/FeatureData.java
@@ -15,6 +15,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 
 import java.io.IOException;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -106,5 +107,10 @@ public class FeatureData extends DataByFeatureId {
         out.writeString(featureId);
         out.writeString(featureName);
         out.writeDouble(data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("featureId", featureId).append("featureName", featureName).append("data", data).toString();
     }
 }

--- a/src/main/java/org/opensearch/timeseries/rest/handler/IndexJobActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/IndexJobActionHandler.java
@@ -161,23 +161,20 @@ public abstract class IndexJobActionHandler<IndexType extends Enum<IndexType> & 
                     executionStartTime.toEpochMilli(),
                     executionEndTime.toEpochMilli()
                 );
-                client
-                    .execute(
-                        resultAction,
-                        getRequest,
-                        ActionListener
-                            .wrap(response -> recorder.indexResult(executionStartTime, executionEndTime, response, config), exception -> {
+                client.execute(resultAction, getRequest, ActionListener.wrap(response -> {
 
-                                recorder
-                                    .indexResultException(
-                                        executionStartTime,
-                                        executionEndTime,
-                                        Throwables.getStackTraceAsString(exception),
-                                        null,
-                                        config
-                                    );
-                            })
-                    );
+                    recorder.indexResult(executionStartTime, executionEndTime, response, config);
+                }, exception -> {
+
+                    recorder
+                        .indexResultException(
+                            executionStartTime,
+                            executionEndTime,
+                            Throwables.getStackTraceAsString(exception),
+                            null,
+                            config
+                        );
+                }));
             } catch (Exception ex) {
                 listener.onFailure(ex);
                 return;

--- a/src/main/java/org/opensearch/timeseries/transport/ResultResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/ResultResponse.java
@@ -19,6 +19,7 @@ import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.FeatureData;
 import org.opensearch.timeseries.model.IndexableResult;
 
@@ -89,7 +90,7 @@ public abstract class ResultResponse<IndexableResultType extends IndexableResult
     }
 
     public abstract List<IndexableResultType> toIndexableResults(
-        String configId,
+        Config configId,
         Instant dataStartInstant,
         Instant dataEndInstant,
         Instant executionStartInstant,

--- a/src/main/java/org/opensearch/timeseries/transport/ResultResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/ResultResponse.java
@@ -90,7 +90,7 @@ public abstract class ResultResponse<IndexableResultType extends IndexableResult
     }
 
     public abstract List<IndexableResultType> toIndexableResults(
-        Config configId,
+        Config config,
         Instant dataStartInstant,
         Instant dataEndInstant,
         Instant executionStartInstant,

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -905,6 +905,42 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
         assertEquals(parsedDetector.getDescription(), "");
     }
 
+    public void testParseAnomalyDetectorWithRuleWithNullValue() throws IOException {
+        String detectorString = "{\"name\":\"AhtYYGWTgqkzairTchcs\",\"description\":\"iIiAVPMyFgnFlEniLbMyfJxyoGvJAl\","
+            + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
+            + "{\"field\":\"value\",\"boost\":1}}],\"adjust_pure_negative\":true,\"boost\":1}},\"window_delay\":"
+            + "{\"period\":{\"interval\":2,\"unit\":\"Minutes\"}},\"shingle_size\":8,\"schema_version\":-512063255,"
+            + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
+            + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"result_index\":"
+            + "\"opensearch-ad-plugin-result-test\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"default_fill\""
+            + ":[{\"feature_name\":\"eYYCM\", \"data\": 3}]},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
+            + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[{\"action\":\"IGNORE_ANOMALY\","
+            + "\"conditions\":[{\"feature_name\":\"eYYCM\",\"threshold_type\":\"ACTUAL_IS_OVER_EXPECTED\","
+            + "\"value\":null,\"operator\":null}]}],\"result_index_min_size\":1500}";
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
+        assertEquals(parsedDetector.getRules().get(0).getConditions().get(0).getValue(), null);
+        assertEquals(parsedDetector.getRules().get(0).getConditions().get(0).getOperator(), null);
+    }
+
+    public void testParseAnomalyDetectorWithRuleWithNoValue() throws IOException {
+        String detectorString = "{\"name\":\"AhtYYGWTgqkzairTchcs\",\"description\":\"iIiAVPMyFgnFlEniLbMyfJxyoGvJAl\","
+            + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
+            + "{\"field\":\"value\",\"boost\":1}}],\"adjust_pure_negative\":true,\"boost\":1}},\"window_delay\":"
+            + "{\"period\":{\"interval\":2,\"unit\":\"Minutes\"}},\"shingle_size\":8,\"schema_version\":-512063255,"
+            + "\"feature_attributes\":[{\"feature_id\":\"OTYJs\",\"feature_name\":\"eYYCM\",\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"XzewX\":{\"value_count\":{\"field\":\"ok\"}}}}],\"recency_emphasis\":3342,"
+            + "\"history\":62,\"last_update_time\":1717192049845,\"category_field\":[\"Tcqcb\"],\"result_index\":"
+            + "\"opensearch-ad-plugin-result-test\",\"imputation_option\":{\"method\":\"FIXED_VALUES\",\"default_fill\""
+            + ":[{\"feature_name\":\"eYYCM\", \"data\": 3}]},\"suggested_seasonality\":64,\"detection_interval\":{\"period\":"
+            + "{\"interval\":5,\"unit\":\"Minutes\"}},\"detector_type\":\"MULTI_ENTITY\",\"rules\":[{\"action\":\"IGNORE_ANOMALY\","
+            + "\"conditions\":[{\"feature_name\":\"eYYCM\",\"threshold_type\":\"ACTUAL_IS_OVER_EXPECTED\""
+            + "}]}],\"result_index_min_size\":1500}";
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
+        assertEquals(parsedDetector.getRules().get(0).getConditions().get(0).getValue(), null);
+        assertEquals(parsedDetector.getRules().get(0).getConditions().get(0).getOperator(), null);
+    }
+
     public void testParseAnomalyDetector_withCustomIndex_withCustomResultIndexMinSize() throws IOException {
         String detectorString = "{\"name\":\"AhtYYGWTgqkzairTchcs\",\"description\":\"iIiAVPMyFgnFlEniLbMyfJxyoGvJAl\","
             + "\"time_field\":\"HmdFH\",\"indices\":[\"ffsBF\"],\"filter_query\":{\"bool\":{\"filter\":[{\"exists\":"
@@ -1165,6 +1201,64 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             );
             assertEquals(ValidationIssueType.RULE, e.getType());
         }
+    }
+
+    /**
+     * Test that validation fails when a ACTUAL_IS_BELOW_EXPECTED plus non-null or empty operator and value are given
+     */
+    public void testValidateRulesWithValueAndAbsoluteThresholdType() throws IOException {
+        String featureName = "testFeature";
+        Feature feature = TestHelpers.randomFeature(featureName, "agg", true);
+
+        Condition condition = new Condition(
+            featureName, // featureName not in features
+            ThresholdType.ACTUAL_IS_BELOW_EXPECTED,
+            Operator.LTE,
+            0.5
+        );
+        Rule rule = new Rule(Action.IGNORE_ANOMALY, Arrays.asList(condition));
+        List<Rule> rules = Arrays.asList(rule);
+
+        try {
+            TestHelpers.AnomalyDetectorBuilder.newInstance(1).setFeatureAttributes(Arrays.asList(feature)).setRules(rules).build();
+            fail("both operator and value must be empty or null");
+        } catch (ValidationException e) {
+            assertTrue(e.getMessage().contains("both operator and value must be empty or null"));
+            assertEquals(ValidationIssueType.RULE, e.getType());
+        }
+    }
+
+    /**
+     * Test that validation fails when a ACTUAL_IS_BELOW_EXPECTED plus non-null operator given
+     */
+    public void testValidateRulesWithOperatorAndAbsoluteThresholdType() throws IOException {
+        String featureName = "testFeature";
+        Feature feature = TestHelpers.randomFeature(featureName, "agg", true);
+
+        Condition condition = new Condition(featureName, ThresholdType.ACTUAL_IS_BELOW_EXPECTED, Operator.LTE, null);
+        Rule rule = new Rule(Action.IGNORE_ANOMALY, Arrays.asList(condition));
+        List<Rule> rules = Arrays.asList(rule);
+
+        try {
+            TestHelpers.AnomalyDetectorBuilder.newInstance(1).setFeatureAttributes(Arrays.asList(feature)).setRules(rules).build();
+            fail("both operator and value must be empty or null");
+        } catch (ValidationException e) {
+            assertTrue(e.getMessage().contains("both operator and value must be empty or null"));
+            assertEquals(ValidationIssueType.RULE, e.getType());
+        }
+    }
+
+    /**
+     * Test that validation fails when a ACTUAL_IS_BELOW_EXPECTED with null value and operator
+     */
+    public void testValidateRulesWithNullValueAndOperatorAndAbsoluteThresholdType() throws IOException {
+        String featureName = "testFeature";
+        Feature feature = TestHelpers.randomFeature(featureName, "agg", true);
+
+        Condition condition = new Condition(featureName, ThresholdType.ACTUAL_IS_BELOW_EXPECTED, null, null);
+        Rule rule = new Rule(Action.IGNORE_ANOMALY, Arrays.asList(condition));
+        List<Rule> rules = Arrays.asList(rule);
+        TestHelpers.AnomalyDetectorBuilder.newInstance(1).setFeatureAttributes(Arrays.asList(feature)).setRules(rules).build();
     }
 
     /**

--- a/src/test/java/org/opensearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyResultTests.java
@@ -13,6 +13,7 @@ package org.opensearch.ad.model;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -213,7 +214,78 @@ public class AnomalyResultTests extends OpenSearchSingleNodeTestCase {
                 likelihoodOfValues,
                 threshold,
                 currentData,
-                featureImputed
+                featureImputed,
+                Collections.emptyList()
+            );
+
+        // Assert that the confidence is capped at 1.0
+        assertEquals("Confidence should be capped at 1.0", 1.0, result.getConfidence(), 0.00001);
+    }
+
+    public void testFromRawTRCFResultWithRules() {
+        // Set up test parameters
+        String detectorId = "test-detector-id";
+        long intervalMillis = 60000; // Example interval
+        String taskId = "test-task-id";
+        Double rcfScore = 0.5;
+        Double grade = 0.0; // Non-anomalous
+        Double confidence = 1.03; // Confidence greater than 1
+        List<FeatureData> featureData = Collections.emptyList(); // Assuming empty for simplicity
+        Instant dataStartTime = Instant.now();
+        Instant dataEndTime = dataStartTime.plusMillis(intervalMillis);
+        Instant executionStartTime = Instant.now();
+        Instant executionEndTime = executionStartTime.plusMillis(500);
+        String error = null;
+        Optional<Entity> entity = Optional.empty();
+        User user = null; // Replace with actual user if needed
+        Integer schemaVersion = 1;
+        String modelId = "test-model-id";
+        double[] relevantAttribution = null;
+        Integer relativeIndex = null;
+        double[] pastValues = null;
+        double[][] expectedValuesList = null;
+        double[] likelihoodOfValues = null;
+        Double threshold = null;
+        double[] currentData = null;
+        boolean[] featureImputed = null;
+
+        Condition condition = new Condition(
+            "testFeature", // featureName not in features
+            ThresholdType.ACTUAL_IS_BELOW_EXPECTED,
+            null,
+            null
+        );
+        Rule rule = new Rule(Action.IGNORE_ANOMALY, Arrays.asList(condition));
+        List<Rule> rules = Arrays.asList(rule);
+
+        // Invoke the method under test
+        AnomalyResult result = AnomalyResult
+            .fromRawTRCFResult(
+                detectorId,
+                intervalMillis,
+                taskId,
+                rcfScore,
+                grade,
+                confidence,
+                featureData,
+                dataStartTime,
+                dataEndTime,
+                executionStartTime,
+                executionEndTime,
+                error,
+                entity,
+                user,
+                schemaVersion,
+                modelId,
+                relevantAttribution,
+                relativeIndex,
+                pastValues,
+                expectedValuesList,
+                likelihoodOfValues,
+                threshold,
+                currentData,
+                featureImputed,
+                rules
             );
 
         // Assert that the confidence is capped at 1.0


### PR DESCRIPTION
### Description
This PR expands on the custom supression rules that we have added in 2.17. Users now have the ability to configures rules which have x number of conditions in them regarding the feature. 

Rules can look like this:
```
rules": [
            {
              "action": "IGNORE_ANOMALY",
              "conditions": [
                {
                  "feature_name": "logVolume",
                  "threshold_type": "
ACTUAL_OVER_EXPECTED_RATIO",
                  "value": 0.3,
                  "operator": LTE
                }
              ]
            }
    ]
```
This rule means that we will ignore anomalies if the actual value is less than or equal too 30% higher than the expected.
For example: "Ignore anomalies for feature logVolume when the actual value is no more than 30% above the expected value."

These first sets of threshold are based on either ration or value margin between the actual and expected value compared to a given value by the user. These rules are given to the RCF model and RCF code takes care of applying these. 

In this PR we are adding two more generic rules that are simply checking if the actual value is below or above the expected value. These rules wont need a value or operator as they are more absolute comparison. Currently RCF doesn’t have the logic to handles such rules so we decided to go with the approach of overriding the anomaly grade in the Anomaly Result. This takes care of both historical, real time and preview results. 

Newly accepted payloads:
```
rules": [
            {
              "action": "IGNORE_ANOMALY",
              "conditions": [
                {
                  "feature_name": "sum_http_4xx",
                  "threshold_type": "ACTUAL_IS_OVER_EXPECTED",
                  "value": null,
                  "operator": null
                }
              ]
            }
    ]
```
or

```
"conditions": [
                {
                  "feature_name": "sum_http_4xx",
                  "threshold_type": "ACTUAL_IS_OVER_EXPECTED"
                }
              ]
 ```             
Edge cases:

* I first consider past values for comparison with expected value if they are present
* We only care about the feature with the highest attribution when looking at the rules, if they are equal then we look at both. 


### Related Issues
#616 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
