### PR TITLE
Changing replica count to up 2 for custom result index

### DIFF
--- a/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
+++ b/src/main/java/org/opensearch/timeseries/indices/IndexManagement.java
@@ -103,6 +103,7 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
     public static final String META = "_meta";
     public static final String SCHEMA_VERSION = "schema_version";
 
+    public static final String customResultIndexAutoExpandReplica = "0-2";
     protected ClusterService clusterService;
     protected final Client client;
     protected final AdminClient adminClient;
@@ -1349,6 +1350,13 @@ public abstract class IndexManagement<IndexType extends Enum<IndexType> & TimeSe
         if (defaultResultIndex) {
             adminClient.indices().create(request, markMappingUpToDate(resultIndex, actionListener));
         } else {
+            request
+                .settings(
+                    Settings
+                        .builder()
+                        // Support up to 2 replicas at least
+                        .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, customResultIndexAutoExpandReplica)
+                );
             adminClient.indices().create(request, actionListener);
         }
     }


### PR DESCRIPTION
### Description
Changing auto expand replica setting for custom result index to 0-2 so we have at least 2 replicas when node count is over 2.


### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
