### PR TITLE
Not blocking detector creation on unknown feature validation error

### DIFF
--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -890,6 +890,7 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
                 feature.getId()
             );
             ssb.aggregation(internalAgg.getAggregatorFactories().iterator().next());
+            ssb.trackTotalHits(false);
             SearchRequest searchRequest = new SearchRequest().indices(config.getIndices().toArray(new String[0])).source(ssb);
             ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(response -> {
                 Optional<double[]> aggFeatureResult = searchFeatureDao.parseResponse(response, Arrays.asList(feature.getId()), false);
@@ -907,11 +908,17 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
                 String errorMessage;
                 if (isExceptionCausedByInvalidQuery(e)) {
                     errorMessage = CommonMessages.FEATURE_WITH_INVALID_QUERY_MSG + feature.getName();
+                    logger.error(errorMessage, e);
+                    multiFeatureQueriesResponseListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.BAD_REQUEST, e));
                 } else {
                     errorMessage = CommonMessages.UNKNOWN_SEARCH_QUERY_EXCEPTION_MSG + feature.getName();
+                    logger.error(errorMessage, e);
+                    // If we see an unexpected error such as timeout or some task cancellation cause of search backpressure
+                    // we don't want to block detector creation as this is unlikely an error due to wrong configs
+                    // but we want to record what error was seen
+                    multiFeatureQueriesResponseListener
+                        .onResponse(new MergeableList<>(new ArrayList<>(List.of(Optional.of(new double[] { 1.0 })))));
                 }
-                logger.error(errorMessage, e);
-                multiFeatureQueriesResponseListener.onFailure(new OpenSearchStatusException(errorMessage, RestStatus.BAD_REQUEST, e));
             });
             clientUtil.asyncRequestWithInjectedSecurity(searchRequest, client::search, user, client, context, searchResponseListener);
         }


### PR DESCRIPTION
### Description
Currently during detector creation we check for a few different things in relation to the configured feature. If aggregation is valid, if we have at least one feature, that we don't aggregate over a non numerical field with something like average.
However we currently fail on any seen exception, we want to change this that if there is an unknown exception that we don't completely block detector creation. This is due to the fact that we might get things like timeout or search cancellation that are related to the cluster, not cause the configuration is wrong. Users should be able to still create the detector and handle any cluster or settings changes they need to later on if it effects the actual detector creation.

### Related Issues
Resolves #1365

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
