### PR TITLE
Updating setup-java, byte buddy, jacoco and mockito dependencies 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - "*"
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -34,17 +31,19 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
 
       - name: Checkout AD
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and Run Tests
         run: |

--- a/.github/workflows/link-check-workflow.yml
+++ b/.github/workflows/link-check-workflow.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   linkchecker:
     runs-on: ubuntu-latest

--- a/.github/workflows/long_running.yml
+++ b/.github/workflows/long_running.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - "*"
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -34,17 +31,19 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
 
       - name: Checkout AD
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and Run Tests
         run: |

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -8,9 +8,6 @@ on:
         - '1.*'
         - '2.*'
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   build-and-publish-snapshots:
     strategy:
@@ -23,12 +20,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4.0.1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - "*"
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -21,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
@@ -39,7 +36,7 @@ jobs:
       JENKINS_URL: build.ci.opensearch.org
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -69,20 +66,22 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     env:
       JENKINS_URL: build.ci.opensearch.org
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Checkout AD
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Assemble / build / mavenlocal / integTest
         run: |
@@ -106,7 +105,7 @@ jobs:
 
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/test_bwc.yml
+++ b/.github/workflows/test_bwc.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - "*"
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -30,18 +27,20 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       # anomaly-detection
       - name: Checkout AD
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Assemble anomaly-detection
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -142,20 +142,20 @@ dependencies {
 
 
     implementation "org.jacoco:org.jacoco.agent:0.8.12"
-    implementation ("org.jacoco:org.jacoco.ant:0.8.11") {
+    implementation ("org.jacoco:org.jacoco.ant:0.8.12") {
         exclude group: 'org.ow2.asm', module: 'asm-commons'
         exclude group: 'org.ow2.asm', module: 'asm'
         exclude group: 'org.ow2.asm', module: 'asm-tree'
     }
 
     // used for output encoding of config descriptions
-    implementation group: 'org.owasp.encoder' , name: 'encoder', version: '1.2.3'
+    implementation group: 'org.owasp.encoder' , name: 'encoder', version: '1.3.1'
 
     testImplementation group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.14.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.14.2'
     testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.3'
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.9'
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.9'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.15.10'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.15.10'
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
     // jupiter is required to run unit tests not inherited from OpenSearchTestCase (e.g., PreviousValueImputerTests)
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.2'
@@ -186,7 +186,7 @@ allprojects {
     version = "${opensearch_build}"
 
     plugins.withId('jacoco') {
-        jacoco.toolVersion = '0.8.11'
+        jacoco.toolVersion = '0.8.12'
     }
 }
 
@@ -218,10 +218,10 @@ configurations.all {
         force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
         force "commons-codec:commons-codec:${versions.commonscodec}"
 
-        force "org.mockito:mockito-core:5.14.1"
+        force "org.mockito:mockito-core:5.14.2"
         force "org.objenesis:objenesis:3.3"
-        force "net.bytebuddy:byte-buddy:1.14.9"
-        force "net.bytebuddy:byte-buddy-agent:1.14.9"
+        force "net.bytebuddy:byte-buddy:1.15.10"
+        force "net.bytebuddy:byte-buddy-agent:1.15.10"
         force "com.google.code.gson:gson:2.8.9"
         force "junit:junit:4.13.2"
 


### PR DESCRIPTION
### Description
Updating several different dependencies that we have outdated depandabot PRs for.
Also testing out this [solution](https://github.com/opensearch-project/opensearch-build/issues/5178) for some of our workflows that still have checkout@v3. 

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
