### PR TITLE
Use testclusters when testing with security

### DIFF
--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -1,85 +1,49 @@
-name: Security test workflow for Anomaly Detection
+name: Security test workflow
+# This workflow is triggered on pull requests to main
 on:
-  push:
-    branches:
-      - "*"
   pull_request:
     branches:
-      - "*"
-
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      - "**"
+  push:
+    branches:
+      - "**"
 
 jobs:
-  Build-ad:
-    strategy:
-      matrix:
-        java: [21]
-      fail-fast: false
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch
 
-    name: Security test workflow for Anomaly Detection
+  security-test:
+    needs: Get-CI-Image-Tag
+    # This job runs on Linux
     runs-on: ubuntu-latest
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
-      - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-
-      # time-series-analytics
-      - name: Checkout AD
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 21
+      # index-management
+      - name: Checkout Branch
         uses: actions/checkout@v4
-
-      - name: Build Anomaly Detection
+      - name: Run integration tests
         run: |
-          ./gradlew assemble
-      # example of variables:
-      # plugin = opensearch-time-series-analytics-2.10.0.0-SNAPSHOT.zip
-      # version = 2.10.0, plugin_version = 2.10.0.0, qualifier = SNAPSHOT
-      - name: Pull and Run Docker
-        run: |
-          plugin=`basename $(ls build/distributions/*.zip)`
-          version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
-          plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
-          qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
-
-          if $qualifier!=SNAPSHOT
-          then
-            docker_version=$version-$qualifier
-          else
-            docker_version=$version
-          fi
-          echo plugin version plugin_version qualifier docker_version
-          echo "($plugin) ($version) ($plugin_version) ($qualifier) ($docker_version)"
-
-          cd ..
-          if docker pull opensearchstaging/opensearch:$docker_version
-          then
-            echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
-            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-anomaly-detection ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-anomaly-detection; fi" >> Dockerfile
-            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-time-series-analytics ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-time-series-analytics; fi" >> Dockerfile
-            echo "ADD anomaly-detection/build/distributions/$plugin /tmp/" >> Dockerfile
-            echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile
-            docker build -t opensearch-ad:test .
-            echo "imagePresent=true" >> $GITHUB_ENV
-          else
-            echo "imagePresent=false" >> $GITHUB_ENV
-          fi
-      - name: Run Docker Image
-        if: env.imagePresent == 'true'
-        run: |
-          cd ..
-          docker run -p 9200:9200 -d -p 9600:9600 -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" -e "discovery.type=single-node" opensearch-ad:test
-          sleep 90
-      - name: Run AD Test
-        if: env.imagePresent == 'true'
-        run: |
-          security=`curl -XGET https://localhost:9200/_cat/plugins?v -u admin:myStrongPassword123! --insecure |grep opensearch-security|wc -l`
-          if [ $security -gt 0 ]
-          then
-            echo "Security plugin is available"
-            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!
-          else
-            echo "Security plugin is NOT available, skipping integration tests"
-          fi
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "./gradlew integTest -Dsecurity=true -Dhttps=true --tests '*IT'"
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: logs
+          overwrite: 'true'
+          path: build/testclusters/integTest-*/logs/*

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,18 @@ ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
+
+    ['esnode.pem', 'esnode-key.pem', 'kirk.pem', 'kirk-key.pem', 'root-ca.pem', 'sample.pem', 'test-kirk.jks'].forEach { file ->
+        File local = getLayout().getBuildDirectory().file(file).get().getAsFile()
+        download.run {
+            src "https://raw.githubusercontent.com/opensearch-project/security/refs/heads/main/bwc-test/src/test/resources/security/" + file
+            dest local
+            overwrite false
+        }
+        processResources {
+            from(local)
+        }
+    }
 }
 
 opensearchplugin {
@@ -397,6 +409,9 @@ integTest {
     }
 }
 
+// === Setup security test ===
+// This flag indicates the existence of security plugin
+def securityEnabled = System.getProperty("security", "false") == "true" || System.getProperty("https", "false") == "true"
 testClusters.integTest {
     testDistribution = "ARCHIVE"
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
@@ -446,6 +461,31 @@ testClusters.integTest {
         def firstPlugin = plugins.get(0)
         plugins.remove(0)
         plugins.add(firstPlugin)
+
+        if (securityEnabled) {
+            node.extraConfigFile("kirk.pem", file("build/resources/main/kirk.pem"))
+            node.extraConfigFile("kirk-key.pem", file("build/resources/main/kirk-key.pem"))
+            node.extraConfigFile("esnode.pem", file("build/resources/main/esnode.pem"))
+            node.extraConfigFile("esnode-key.pem", file("build/resources/main/esnode-key.pem"))
+            node.extraConfigFile("root-ca.pem", file("build/resources/main/root-ca.pem"))
+            node.setting("plugins.security.ssl.transport.pemcert_filepath", "esnode.pem")
+            node.setting("plugins.security.ssl.transport.pemkey_filepath", "esnode-key.pem")
+            node.setting("plugins.security.ssl.transport.pemtrustedcas_filepath", "root-ca.pem")
+            node.setting("plugins.security.ssl.transport.enforce_hostname_verification", "false")
+            node.setting("plugins.security.ssl.http.enabled", "true")
+            node.setting("plugins.security.ssl.http.pemcert_filepath", "esnode.pem")
+            node.setting("plugins.security.ssl.http.pemkey_filepath", "esnode-key.pem")
+            node.setting("plugins.security.ssl.http.pemtrustedcas_filepath", "root-ca.pem")
+            node.setting("plugins.security.allow_unsafe_democertificates", "true")
+            node.setting("plugins.security.allow_default_init_securityindex", "true")
+            node.setting("plugins.security.authcz.admin_dn", "\n - CN=kirk,OU=client,O=client,L=test,C=de")
+            node.setting("plugins.security.audit.type", "internal_opensearch")
+            node.setting("plugins.security.enable_snapshot_restore_privilege", "true")
+            node.setting("plugins.security.check_snapshot_restore_write_privileges", "true")
+            node.setting("plugins.security.restapi.roles_enabled", "[\"all_access\", \"security_rest_api_access\"]")
+            node.setting("plugins.security.system_indices.enabled", "true")
+            // node.setting("plugins.security.system_indices.indices", "[\".opendistro-ism-config\"]")
+        }
     }
 }
 


### PR DESCRIPTION
### Description

This PR changes the `Test with Security` workflow to use testclusters instead of the docker image. The `integTest` task in OpenSearch is meant to be run against an opensearch testcluster ([example from ISM](https://github.com/opensearch-project/index-management/blob/main/build.gradle#L347-L413)) and the current workflow ends up spinning up 2 clusters (one testcluster and 1 cluster w/ docker) unnecessarily.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
