### PR TITLE
Distinguish local cluster when local name is same as remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 - Github workflow for changelog verification ([#1413](https://github.com/opensearch-project/anomaly-detection/pull/1413))
 ### Bug Fixes
+- Distinguish local cluster when local name is same as remote ([#1446](https://github.com/opensearch-project/anomaly-detection/pull/1446))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/timeseries/util/CrossClusterConfigUtils.java
+++ b/src/main/java/org/opensearch/timeseries/util/CrossClusterConfigUtils.java
@@ -28,7 +28,9 @@ public class CrossClusterConfigUtils {
      * @return The local {@link NodeClient} for the local cluster, or a remote client for a remote cluster.
      */
     public static Client getClientForCluster(String clusterName, Client client, String localClusterName) {
-        return clusterName.equals(localClusterName) ? client : client.getRemoteClusterClient(clusterName);
+        return clusterName.contains("#local") && clusterName.split("#")[0].equals(localClusterName)
+            ? client
+            : client.getRemoteClusterClient(clusterName);
     }
 
     /**
@@ -68,9 +70,9 @@ public class CrossClusterConfigUtils {
             String clusterName = clusterAndIndex.getKey();
             String indexName = clusterAndIndex.getValue();
 
-            // If the index entry does not have a cluster_name, it indicates the index is on the local cluster.
             if (clusterName.isEmpty()) {
-                clusterName = localClusterName;
+                // Use #local marker to indicate local cluster to avoid clashing if local cluster has the same name as remote cluster
+                clusterName = localClusterName + "#local";
             }
             output.computeIfAbsent(clusterName, k -> new ArrayList<>()).add(indexName);
         }


### PR DESCRIPTION
### Description
Added `#local` to local cluster when index originates from local cluster name to distinguish from a remote cluster with the same name. `#` isn't valid to use in a cluster name so this wont clash with existing names

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
