### PR TITLE
Switch guava deps from compileOnly to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,8 @@ dependencies {
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${job_scheduler_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
-    compileOnly group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
+    implementation group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    implementation group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
     implementation group: 'com.yahoo.datasketches', name: 'sketches-core', version: '0.13.4'


### PR DESCRIPTION
### Description

AD has its guava dependencies set at compileOnly level which means they are not packaged into the AD assembly and available at runtime. 

AD uses these deps at runtime, however, the way this works is because of the extending relationship between AD and JS plugin where the deps of the extended plugin are available to the extending plugin at runtime.

In https://github.com/opensearch-project/job-scheduler/pull/773, guava was removed from JS which means these deps are no longer available to AD at runtime. I'm creating this PR to change the guava deps from compileOnly to implementation to ensure they are included in the assembly and available at runtime.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
