### PR TITLE
Fix incorrect task state handling in ForecastRunOnceTransportAction

### DIFF
--- a/release-notes/opensearch-anomaly-detection.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-anomaly-detection.release-notes-3.1.0.0.md
@@ -6,3 +6,7 @@ Compatible with OpenSearch 3.1.0
 - Use Centralized Resource Access Control framework provided by security plugin ([#1400](https://github.com/opensearch-project/anomaly-detection/pull/1400))
 - Introduce state machine, separate config index, improve suggest/validate APIs, and persist cold-start results for run-once visualization ([#1479](https://github.com/opensearch-project/anomaly-detection/pull/1479))
 
+### Bug Fixes
+- Fix incorrect task state handling in ForecastRunOnceTransportAction ([#1489](https://github.com/opensearch-project/anomaly-detection/pull/1489))
+
+

--- a/src/main/java/org/opensearch/forecast/model/ForecastResult.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastResult.java
@@ -174,7 +174,10 @@ public class ForecastResult extends IndexableResult {
     ) {
         int inputLength = featureData.size();
         int numberOfForecasts = 0;
-        // it is possible we might get all 0 forecast even though dataQuality is 0 at the beginning
+        // it is possible we might get all 0 forecast when dataQuality is 0 at the beginning.
+        // it is also possible we get non-zero forecast and dataQuality is 0 when we have
+        // processed more than outputAfter length of data.
+        // We will ignore forecast values when dataQuality is 0.
         if (forecastsValues != null && dataQuality > 0) {
             numberOfForecasts = forecastsValues.length / inputLength;
         }

--- a/src/main/java/org/opensearch/forecast/transport/ForecastRunOnceTransportAction.java
+++ b/src/main/java/org/opensearch/forecast/transport/ForecastRunOnceTransportAction.java
@@ -420,7 +420,7 @@ public class ForecastRunOnceTransportAction extends HandledTransportAction<Forec
                         if (r.isPresent()) {
                             String state = r.get().getState();
                             // If there is no state, update it; otherwise, it might have been set elsewhere (e.g., by ColdStartWorker)
-                            if (Strings.isEmpty(state)) {
+                            if (Strings.isEmpty(state) || TaskState.NOT_ENDED_STATES.contains(state)) {
                                 updateTask(forecastID, taskId, TaskState.INIT_TEST_FAILED, exceptionMsg);
                             }
                         } else {

--- a/src/main/java/org/opensearch/timeseries/util/ParseUtils.java
+++ b/src/main/java/org/opensearch/timeseries/util/ParseUtils.java
@@ -487,7 +487,7 @@ public final class ParseUtils {
      */
     public static User getUserContext(Client client) {
         String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
-        logger.info("Filtering result by " + userStr);
+        logger.debug("Filtering result by " + userStr);
         return User.parse(userStr);
     }
 


### PR DESCRIPTION
### Description
Previously, the task state was not updated to a failure state if it was non-empty, even when the state represented an incomplete task (e.g., INIT_TEST). This fix ensures the task state is updated to INIT_TEST_FAILED unless it is already in an ended state (e.g., INACTIVE).

Testing:
- Manual testing verified correct state transitions.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
