### PR TITLE
Fix LatestTimeRetriever range query failing on non-epoch date mappings

### DIFF
--- a/release-notes/opensearch-anomaly-detection.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-anomaly-detection.release-notes-3.1.0.0.md
@@ -8,5 +8,6 @@ Compatible with OpenSearch 3.1.0
 
 ### Bug Fixes
 - Fix incorrect task state handling in ForecastRunOnceTransportAction ([#1489](https://github.com/opensearch-project/anomaly-detection/pull/1489))
+- Fix incorrect task state handling in ForecastRunOnceTransportAction ([#1493](https://github.com/opensearch-project/anomaly-detection/pull/1493))
 
 

--- a/src/main/java/org/opensearch/timeseries/rest/handler/LatestTimeRetriever.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/LatestTimeRetriever.java
@@ -39,6 +39,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.feature.SearchFeatureDao;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
@@ -119,7 +120,9 @@ public class LatestTimeRetriever {
             .getTimeRangeBounds(new IntervalTimeConfiguration(maxIntervalInMinutes, ChronoUnit.MINUTES), latestTimeMillis);
         RangeQueryBuilder rangeQuery = new RangeQueryBuilder(config.getTimeField())
             .from(timeRangeBounds.getMin())
-            .to(timeRangeBounds.getMax());
+            .to(timeRangeBounds.getMax())
+            // user index time field might not have epoch_millis format, so we need to format it
+            .format(CommonName.EPOCH_MILLIS_FORMAT);
         AggregationBuilder bucketAggs;
         Map<String, Object> topKeys = new HashMap<>();
         if (config.getCategoryFields().size() == 1) {


### PR DESCRIPTION
### Description
When the user’s time field mapping didn’t include `epoch_millis`, the numeric bounds we pass to `RangeQueryBuilder` were parsed with the field’s default format (`yyyy-MM-dd HH:mm:ss`), triggering a `SearchPhaseExecutionException: all shards failed`. This PR Import `CommonName` and call `.format(CommonName.EPOCH_MILLIS_FORMAT)` to explicitly tell OpenSearch that the `from/to` values are epoch-millis.

Testing done:
1. added cypress IT: https://tinyurl.com/5n98z3ue

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
