### PR TITLE
Fix stopping issue when forecaster is in FORECAST_FAILURE state

### DIFF
--- a/release-notes/opensearch-anomaly-detection.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-anomaly-detection.release-notes-3.1.0.0.md
@@ -10,4 +10,5 @@ Compatible with OpenSearch 3.1.0
 - Fix incorrect task state handling in ForecastRunOnceTransportAction ([#1489](https://github.com/opensearch-project/anomaly-detection/pull/1489))
 - Fix incorrect task state handling in ForecastRunOnceTransportAction ([#1493](https://github.com/opensearch-project/anomaly-detection/pull/1493))
 - Refine cold-start, window delay, and task updates ([#1496](https://github.com/opensearch-project/anomaly-detection/pull/1496))
+- Fix stopping issue when forecaster is in FORECAST_FAILURE state ([#1502](https://github.com/opensearch-project/anomaly-detection/pull/1502))
 

--- a/src/main/java/org/opensearch/timeseries/model/TaskState.java
+++ b/src/main/java/org/opensearch/timeseries/model/TaskState.java
@@ -90,7 +90,8 @@ public enum TaskState {
             TaskState.RUNNING.name(),
             INIT_TEST.name(),
             AWAITING_DATA_TO_INIT.name(),
-            AWAITING_DATA_TO_RESTART.name()
+            AWAITING_DATA_TO_RESTART.name(),
+            FORECAST_FAILURE.name()
         );
 
     public static boolean isAwaitState(String state) {

--- a/src/test/java/org/opensearch/timeseries/model/TaskStateTests.java
+++ b/src/test/java/org/opensearch/timeseries/model/TaskStateTests.java
@@ -31,13 +31,14 @@ public class TaskStateTests extends OpenSearchTestCase {
         List<String> list = TaskState.NOT_ENDED_STATES;
 
         // expected size and membership
-        assertEquals(6, list.size());
+        assertEquals(7, list.size());
         assertTrue(list.contains(TaskState.CREATED.name()));
         assertTrue(list.contains(TaskState.INIT.name()));
         assertTrue(list.contains(TaskState.RUNNING.name()));
         assertTrue(list.contains(TaskState.INIT_TEST.name()));
         assertTrue(list.contains(TaskState.AWAITING_DATA_TO_INIT.name()));
         assertTrue(list.contains(TaskState.AWAITING_DATA_TO_RESTART.name()));
+        assertTrue(list.contains(TaskState.FORECAST_FAILURE.name()));
 
         // an obviously ended state must be absent
         assertFalse(list.contains(TaskState.FINISHED.name()));


### PR DESCRIPTION
### Description
Mark FORECAST_FAILURE as a non-ending state so TaskManager recognizes the task as stoppable. Previously, TaskManager.stopLatestRealtimeTask failed to stop the task, as `isDone()` returned false for FORECAST_FAILURE, causing a "job is already stopped" error.

Testing:
- Manually verified forecaster can now be stopped successfully from FORECAST_FAILURE state.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
