### PR TITLE
Fixing concurrency bug on writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 
 ### Bug Fixes
+- Fixing concurrency bug on writer ([#1508](https://github.com/opensearch-project/anomaly-detection/pull/1508))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/ad/task/ADTaskManager.java
+++ b/src/main/java/org/opensearch/ad/task/ADTaskManager.java
@@ -1928,7 +1928,7 @@ public class ADTaskManager extends TaskManager<ADTaskCacheManager, ADTaskType, A
     protected String triageState(Boolean hasResult, String error, Long rcfTotalUpdates) {
         if (hasResult != null && hasResult) {
             return TaskState.RUNNING.name();
-        } else if (rcfTotalUpdates != null && rcfTotalUpdates < TimeSeriesSettings.NUM_MIN_SAMPLES) {
+        } else if (rcfTotalUpdates == null || rcfTotalUpdates < TimeSeriesSettings.NUM_MIN_SAMPLES) {
             return TaskState.INIT.name();
         } else {
             return TaskState.RUNNING.name();

--- a/src/main/java/org/opensearch/timeseries/ratelimit/BatchWorker.java
+++ b/src/main/java/org/opensearch/timeseries/ratelimit/BatchWorker.java
@@ -113,8 +113,11 @@ public abstract class BatchWorker<RequestType extends QueuedRequest, BatchReques
         if (false == toProcess.isEmpty()) {
             final List<String> inflights = new ArrayList<>();
             for (RequestType request : toProcess) {
-                inflightConfigs.add(request.getConfigId());
-                inflights.add(request.getConfigId());
+                String configId = request.getConfigId();
+                if (configId != null) {
+                    inflightConfigs.add(configId);
+                    inflights.add(configId);
+                }
             }
 
             BatchRequestType batchRequest = toBatchRequest(toProcess);

--- a/src/main/java/org/opensearch/timeseries/ratelimit/RateLimitedRequestWorker.java
+++ b/src/main/java/org/opensearch/timeseries/ratelimit/RateLimitedRequestWorker.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -249,7 +250,7 @@ public abstract class RateLimitedRequestWorker<RequestType extends QueuedRequest
         this.stateTtl = stateTtl;
         this.nodeStateManager = nodeStateManager;
         this.context = context;
-        this.inflightConfigs = new HashSet<>();
+        this.inflightConfigs = ConcurrentHashMap.newKeySet();
     }
 
     public String getWorkerName() {

--- a/src/main/java/org/opensearch/timeseries/ratelimit/SingleRequestWorker.java
+++ b/src/main/java/org/opensearch/timeseries/ratelimit/SingleRequestWorker.java
@@ -92,7 +92,10 @@ public abstract class SingleRequestWorker<RequestType extends QueuedRequest> ext
         if (false == queue.isEmpty()) {
             request = queue.poll();
             if (request != null) {
-                inflightConfigs.add(request.getConfigId());
+                String configId = request.getConfigId();
+                if (configId != null) {
+                    inflightConfigs.add(configId);
+                }
             }
         }
 

--- a/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
@@ -222,8 +222,9 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
         }
     }
 
-   private boolean runConcurrencyTest() throws InterruptedException {
-        final int numberOfThreads = 20; final CountDownLatch startLatch = new CountDownLatch(1);
+    private boolean runConcurrencyTest() throws InterruptedException {
+        final int numberOfThreads = 20;
+        final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
         final AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
 
@@ -254,23 +255,23 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
                     for (int j = 0; j < 30; j++) {
                         try {
                             String detectorId = "detector-" + (j % 3);
-                            resultWriteQueue.put(
+                            resultWriteQueue
+                                .put(
                                     new ADResultWriteRequest(
-                                            System.currentTimeMillis() + j,
-                                            detectorId,
-                                            RequestPriority.MEDIUM,
-                                            detectResult,
-                                            null,
-                                            null
+                                        System.currentTimeMillis() + j,
+                                        detectorId,
+                                        RequestPriority.MEDIUM,
+                                        detectResult,
+                                        null,
+                                        null
                                     )
-                            );
+                                );
                         } catch (ConcurrentModificationException e) {
                             exceptionOccurred.set(true);
                             return;
                         }
                     }
-                } catch (Exception ignored) {
-                } finally {
+                } catch (Exception ignored) {} finally {
                     endLatch.countDown();
                 }
             });
@@ -278,6 +279,6 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
         }
         startLatch.countDown();
         assertTrue("Test should complete", endLatch.await(30, TimeUnit.SECONDS));
-       return exceptionOccurred.get();
+        return exceptionOccurred.get();
     }
 }

--- a/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
@@ -26,9 +26,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opensearch.OpenSearchStatusException;
@@ -208,5 +211,73 @@ public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
         // one flush from the original request; and one due to retry
         verify(resultHandler, times(1)).flush(any(), any());
         verify(nodeStateManager, times(1)).setException(eq(detectorId), any(OpenSearchRejectedExecutionException.class));
+    }
+
+    public void testConcurrentModificationException() throws InterruptedException {
+        for (int attempt = 0; attempt < 10; attempt++) {
+            if (runConcurrencyTest()) {
+                fail("ConcurrentModificationException occurred on attempt " + (attempt + 1));
+            }
+            Thread.sleep(5);
+        }
+    }
+
+   private boolean runConcurrencyTest() throws InterruptedException {
+        final int numberOfThreads = 20; final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
+        final AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            ActionListener<ResultBulkResponse> listener = invocation.getArgument(1);
+            try {
+                Thread.sleep(5);
+                listener.onResponse(new ResultBulkResponse(Collections.emptyList()));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+            return null;
+        }).when(resultHandler).flush(any(), any());
+
+        doAnswer(invocation -> {
+            Exception e = invocation.getArgument(1);
+            if (e instanceof ConcurrentModificationException) {
+                exceptionOccurred.set(true);
+            }
+            return null;
+        }).when(nodeStateManager).setException(any(), any());
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    // Each thread adds requests
+                    for (int j = 0; j < 30; j++) {
+                        try {
+                            String detectorId = "detector-" + (j % 3);
+                            resultWriteQueue.put(
+                                    new ADResultWriteRequest(
+                                            System.currentTimeMillis() + j,
+                                            detectorId,
+                                            RequestPriority.MEDIUM,
+                                            detectResult,
+                                            null,
+                                            null
+                                    )
+                            );
+                        } catch (ConcurrentModificationException e) {
+                            exceptionOccurred.set(true);
+                            return;
+                        }
+                    }
+                } catch (Exception ignored) {
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+            thread.start();
+        }
+        startLatch.countDown();
+        assertTrue("Test should complete", endLatch.await(30, TimeUnit.SECONDS));
+       return exceptionOccurred.get();
     }
 }

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -653,6 +653,14 @@ public class ADTaskManagerTests extends AbstractTimeSeriesTest {
         verify(actionListener, times(1)).onResponse(any());
     }
 
+    public void testTriageStateWithNullRcfTotalUpdates() {
+        Boolean hasResult = true;
+        String error = null;
+        Long rcfTotalUpdates = null;
+        String result = adTaskManager.triageState(hasResult, error, rcfTotalUpdates);
+        assertEquals(TaskState.INIT.name(), result);
+    }
+
     public void testGetLocalADTaskProfilesByDetectorId() {
         doReturn(node1).when(clusterService).localNode();
         when(adTaskCacheManager.isHCTaskRunning(anyString())).thenReturn(true);

--- a/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/org/opensearch/ad/task/ADTaskManagerTests.java
@@ -654,7 +654,7 @@ public class ADTaskManagerTests extends AbstractTimeSeriesTest {
     }
 
     public void testTriageStateWithNullRcfTotalUpdates() {
-        Boolean hasResult = true;
+        Boolean hasResult = null;
         String error = null;
         Long rcfTotalUpdates = null;
         String result = adTaskManager.triageState(hasResult, error, rcfTotalUpdates);


### PR DESCRIPTION
### Description
1. Fix ConcurrentModificationException in BatchWorker execution
2. Fix NullPointerException in ADTaskManager.triageState()
3. Fix NullPointerException with ConcurrentHashMap null key handling

Added tests for these.

Exceptions I saw while running HCAD on multi node cluster before bug fixes:
```
ERROR][o.o.a.t.h.ADIndexMemoryPressureAwareResultHandler] [integTest-0] Error in bulking results
»  java.util.ConcurrentModificationException: null
»       at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
»       at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1628) ~[?:?]
»       at java.base/java.util.AbstractSet.removeAll(AbstractSet.java:175) ~[?:?]
»       at org.opensearch.timeseries.ratelimit.BatchWorker.lambda$execute$1(BatchWorker.java:133) ~[?:?]
»       at org.opensearch.core.action.ActionListener$5.onResponse(ActionListener.java:270) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
»       at org.opensearch.ad.transport.handler.ADIndexMemoryPressureAwareResultHandler.lambda$bulk$0(ADIndexMemoryPressureAwareResultHandler.java:53) ~[?:?]
»       at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
```

```

[2025-06-23T17:03:29,469][ERROR][o.o.t.ExecuteResultResponseRecorder] [integTest-1] Fail to confirm rcf update
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because "rcfTotalUpdates" is null
        at org.opensearch.ad.task.ADTaskManager.triageState(ADTaskManager.java:1929) ~[?:?]
        at org.opensearch.timeseries.task.TaskManager.updateLatestRealtimeTask(TaskManager.java:255) ~[?:?]
        at org.opensearch.timeseries.task.TaskManager.updateLatestRealtimeTaskOnCoordinatingNode(TaskManager.java:323) ~[?:?]
        at org.opensearch.timeseries.ExecuteResultResponseRecorder.lambda$updateLatestRealtimeTask$8(ExecuteResultResponseRecorder.java:229) ~[?:?]
        at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        at org.opensearch.timeseries.ExecuteResultResponseRecorder.lambda$hasRecentResult$11(ExecuteResultResponseRecorder.java:331) ~[?:?]
        at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        at org.opensearch.action.support.TransportAction$1.onFailure(TransportAction.java:124) ~[opensearch-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:84) ~[opensearch-core-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        at org.opensearch.search.pipeline.Pipeline.transformRequest(Pipeline.java:125) ~[opensearch-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]
        
   ```


### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
