### PR TITLE
[Test Refactor] Remove instantiation of LockService from JS and use Mock instead

### DIFF
--- a/src/test/java/org/opensearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -225,7 +225,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractTimeSeriesTest {
 
         adJobProcessor.setIndexManagement(anomalyDetectionIndices);
 
-        lockService = new LockService(client, clusterService);
+        lockService = mock(LockService.class);
         doReturn(lockService).when(context).getLockService();
 
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description

This PR is a simple test refactor to remove calling the constructor of LockService directly. I plan to switch LockService to an interface and instruct plugins to get a handle of the LockService instantiated by JS through dependency injection.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
