### PR TITLE
Migrating from commons-lang2.6 to commons-lang3.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,6 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
     implementation group: 'com.yahoo.datasketches', name: 'sketches-core', version: '0.13.4'
     implementation group: 'com.yahoo.datasketches', name: 'memory', version: '0.12.2'
-    implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
     implementation group: 'org.apache.commons', name: 'commons-pool2', version: '2.12.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-serialization:4.3.0'
     implementation 'software.amazon.randomcutforest:randomcutforest-parkservices:4.3.0'
@@ -161,7 +160,7 @@ dependencies {
     implementation group: 'io.protostuff', name: 'protostuff-runtime', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-api', version: '1.8.0'
     implementation group: 'io.protostuff', name: 'protostuff-collectionschema', version: '1.8.0'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.17.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
 
 
     implementation "org.jacoco:org.jacoco.agent:0.8.12"

--- a/src/main/java/org/opensearch/ad/ml/ThresholdingResult.java
+++ b/src/main/java/org/opensearch/ad/ml/ThresholdingResult.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.ad.model.Rule;

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.settings.ADNumericSetting;
 import org.opensearch.common.unit.TimeValue;

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetectorExecutionInput.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetectorExecutionInput.java
@@ -16,7 +16,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import java.io.IOException;
 import java.time.Instant;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;

--- a/src/main/java/org/opensearch/ad/model/AnomalyResult.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyResult.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;

--- a/src/main/java/org/opensearch/ad/model/AnomalyResultBucket.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyResultBucket.java
@@ -14,7 +14,7 @@ package org.opensearch.ad.model;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/ad/model/Condition.java
+++ b/src/main/java/org/opensearch/ad/model/Condition.java
@@ -10,7 +10,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import java.io.IOException;
 import java.util.Locale;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/ad/model/ExpectedValueList.java
+++ b/src/main/java/org/opensearch/ad/model/ExpectedValueList.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/ad/model/Rule.java
+++ b/src/main/java/org/opensearch/ad/model/Rule.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.constant.ADCommonMessages;

--- a/src/main/java/org/opensearch/ad/rest/RestPreviewAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestPreviewAnomalyDetectorAction.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.constant.ADCommonMessages;

--- a/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/ForwardADTaskRequest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -26,7 +26,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;

--- a/src/main/java/org/opensearch/forecast/model/ForecastResult.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastResult.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/forecast/model/ForecastResultBucket.java
+++ b/src/main/java/org/opensearch/forecast/model/ForecastResultBucket.java
@@ -8,7 +8,7 @@ package org.opensearch.forecast.model;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/caching/CacheBuffer.java
+++ b/src/main/java/org/opensearch/timeseries/caching/CacheBuffer.java
@@ -21,8 +21,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.timeseries.ExpiringState;

--- a/src/main/java/org/opensearch/timeseries/caching/PriorityTracker.java
+++ b/src/main/java/org/opensearch/timeseries/caching/PriorityTracker.java
@@ -22,9 +22,9 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.timeseries.annotation.Generated;

--- a/src/main/java/org/opensearch/timeseries/dataprocessor/ImputationOption.java
+++ b/src/main/java/org/opensearch/timeseries/dataprocessor/ImputationOption.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/timeseries/feature/CompositeRetriever.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;

--- a/src/main/java/org/opensearch/timeseries/feature/Features.java
+++ b/src/main/java/org/opensearch/timeseries/feature/Features.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.timeseries.annotation.Generated;
 
 /**

--- a/src/main/java/org/opensearch/timeseries/ml/IntermediateResult.java
+++ b/src/main/java/org/opensearch/timeseries/ml/IntermediateResult.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.FeatureData;

--- a/src/main/java/org/opensearch/timeseries/ml/Sample.java
+++ b/src/main/java/org/opensearch/timeseries/ml/Sample.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.timeseries.annotation.Generated;

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;

--- a/src/main/java/org/opensearch/timeseries/model/ConfigProfile.java
+++ b/src/main/java/org/opensearch/timeseries/model/ConfigProfile.java
@@ -7,9 +7,9 @@ package org.opensearch.timeseries.model;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/model/DataByFeatureId.java
+++ b/src/main/java/org/opensearch/timeseries/model/DataByFeatureId.java
@@ -9,7 +9,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/model/DateRange.java
+++ b/src/main/java/org/opensearch/timeseries/model/DateRange.java
@@ -16,7 +16,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import java.io.IOException;
 import java.time.Instant;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/model/EntityProfile.java
+++ b/src/main/java/org/opensearch/timeseries/model/EntityProfile.java
@@ -14,9 +14,9 @@ package org.opensearch.timeseries.model;
 import java.io.IOException;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/model/Feature.java
+++ b/src/main/java/org/opensearch/timeseries/model/Feature.java
@@ -15,7 +15,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.common.UUIDs;
 import org.opensearch.core.common.io.stream.StreamInput;

--- a/src/main/java/org/opensearch/timeseries/model/FeatureData.java
+++ b/src/main/java/org/opensearch/timeseries/model/FeatureData.java
@@ -15,7 +15,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;

--- a/src/main/java/org/opensearch/timeseries/model/IndexableResult.java
+++ b/src/main/java/org/opensearch/timeseries/model/IndexableResult.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;

--- a/src/main/java/org/opensearch/timeseries/model/InitProgressProfile.java
+++ b/src/main/java/org/opensearch/timeseries/model/InitProgressProfile.java
@@ -13,9 +13,9 @@ package org.opensearch.timeseries.model;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/model/ModelProfile.java
+++ b/src/main/java/org/opensearch/timeseries/model/ModelProfile.java
@@ -13,9 +13,9 @@ package org.opensearch.timeseries.model;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/model/ModelProfileOnNode.java
+++ b/src/main/java/org/opensearch/timeseries/model/ModelProfileOnNode.java
@@ -13,9 +13,9 @@ package org.opensearch.timeseries.model;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;

--- a/src/main/java/org/opensearch/timeseries/transport/EntityProfileResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/EntityProfileResponse.java
@@ -14,9 +14,9 @@ package org.opensearch.timeseries.transport;
 import java.io.IOException;
 import java.util.Optional;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;

--- a/src/main/java/org/opensearch/timeseries/transport/StatsResponse.java
+++ b/src/main/java/org/opensearch/timeseries/transport/StatsResponse.java
@@ -14,9 +14,9 @@ package org.opensearch.timeseries.transport;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContent;

--- a/src/main/java/org/opensearch/timeseries/util/ExceptionUtil.java
+++ b/src/main/java/org/opensearch/timeseries/util/ExceptionUtil.java
@@ -14,7 +14,7 @@ package org.opensearch.timeseries.util;
 import java.util.EnumSet;
 import java.util.concurrent.RejectedExecutionException;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.core.util.Throwables;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
@@ -111,7 +111,7 @@ public class ExceptionUtil {
         } else if (e instanceof OpenSearchException) {
             return ((OpenSearchException) e).getDetailedMessage();
         } else {
-            return ExceptionUtils.getFullStackTrace(e);
+            return ExceptionUtils.getStackTrace(e);
         }
     }
 

--- a/src/main/java/org/opensearch/timeseries/util/RestHandlerUtils.java
+++ b/src/main/java/org/opensearch/timeseries/util/RestHandlerUtils.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchStatusException;

--- a/src/test/java/test/org/opensearch/ad/util/JsonDeserializer.java
+++ b/src/test/java/test/org/opensearch/ad/util/JsonDeserializer.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.ad.common.exception.JsonPathNotFoundException;
 
 import com.google.gson.JsonArray;


### PR DESCRIPTION
### Description
utilizing only lang3 over any lang2.6 uses and bumping to 3.18
Only 1 breaking change from using ExceptionUtils.getFullStackTrace() to ExceptionUtils.getStackTrace()

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
