### PR TITLE
Update delete_backport_branch workflow to use github-script with proper permissions

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -10,9 +10,16 @@ env:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`,
+            })


### PR DESCRIPTION
This PR updates the delete_backport_branch workflow to use the actions/github-script@v7 action with proper permissions instead of the SvanBoxel/delete-merged-branch@main action. This is a more modern approach that provides better security and control over the branch deletion process.