### PR TITLE
Adding skip-changelog to all depandabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "dependabot:"
+    labels:
+      - "skip-changelog"
     ignore:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "*"
@@ -16,3 +18,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "dependabot:"
+    labels:
+      - "skip-changelog"


### PR DESCRIPTION
### Description
Adding skip-changelog label to all depandabot PRs

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
