### PR TITLE
Ensure that user attributes are in expected format attrKey=attrVal for testing

### DIFF
--- a/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/org/opensearch/ad/util/ParseUtilsTests.java
@@ -161,7 +161,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         ParseUtils
             .addUserBackendRolesFilter(
-                new User(randomAlphaOfLength(5), null, ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of(randomAlphaOfLength(5))),
+                new User(randomAlphaOfLength(5), null, ImmutableList.of(randomAlphaOfLength(5)), ImmutableList.of("attrKey=attrVal")),
                 searchSourceBuilder
             );
         assertEquals(
@@ -180,7 +180,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
                     randomAlphaOfLength(5),
                     ImmutableList.of(),
                     ImmutableList.of(randomAlphaOfLength(5)),
-                    ImmutableList.of(randomAlphaOfLength(5))
+                    ImmutableList.of("attrKey=attrVal")
                 ),
                 searchSourceBuilder
             );
@@ -202,7 +202,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
                     randomAlphaOfLength(5),
                     ImmutableList.of(backendRole1, backendRole2),
                     ImmutableList.of(randomAlphaOfLength(5)),
-                    ImmutableList.of(randomAlphaOfLength(5))
+                    ImmutableList.of("attrKey=attrVal")
                 ),
                 searchSourceBuilder
             );
@@ -316,7 +316,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
             randomAlphaOfLength(5),
             ImmutableList.of(),
             ImmutableList.of("all_access"),
-            ImmutableList.of(randomAlphaOfLength(5))
+            ImmutableList.of("attrKey=attrVal")
         );
         assertTrue(isAdmin(user1));
     }
@@ -327,7 +327,7 @@ public class ParseUtilsTests extends OpenSearchTestCase {
             randomAlphaOfLength(5),
             ImmutableList.of(backendRole1),
             ImmutableList.of(randomAlphaOfLength(5)),
-            ImmutableList.of(randomAlphaOfLength(5))
+            ImmutableList.of("attrKey=attrVal")
         );
         assertFalse(isAdmin(user1));
     }


### PR DESCRIPTION
### Description

Many repos have a user attribute called `custom_attribute_names` that is in their system index mappings when storing a copy of the user. This field exists, but was never plumbed rendering this field as useless. 

There is a bugfix underway to fix an [issue in the alerting repo](https://github.com/opensearch-project/alerting/issues/1829) when an alerting monitor is created by a user that has DLS restrictions that have user attribute substitutions. As part of fixing the bug, the field `custom_attribute_names` will now be used and each entry in the list is expected to be in the `attrKey=attrVal` format. This PR ensures that test data that the security-analytics plugin creates conforms to this expected format.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
