### PR TITLE
Fix flaky ITs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Bug Fixes
 - Make frequency optional; fix STOPPED state; add ecommerce tests ([#1565](https://github.com/opensearch-project/anomaly-detection/pull/1565))
+- Fix flaky ITs ([#1571](https://github.com/opensearch-project/anomaly-detection/pull/1571))
 
 
 ### Infrastructure


### PR DESCRIPTION
### Description

This PR  

  - RealTimeFrequencySmokeIT: capture baseline ad_execute_request_count and use assertBusy to wait for a delta ≥ 2 via _local/stats; aggregate counts across nodes to tolerate parallel ITs on a shared cluster (ran via ./gradlew ':integTestRemote'). Added getLocalAdExecuteRequestCount helper and logging to aid diagnosis.
  - AnomalyDetectorRestApiIT: when resource sharing is enabled, allow _version ≥ previous+1 since Security’s ResourceSharingIndexHandler triggers an extra update to set all_shared_principals.

These changes reduce IT flakiness without altering production behavior.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/opensearch-build/issues/5693

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
