### PR TITLE
Fix tests by adding the new node setting for protected types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 
 ### Infrastructure
+- Fix tests by adding the new node setting for protected types ([#1572](https://github.com/opensearch-project/anomaly-detection/pull/1572))
 
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -575,6 +575,7 @@ def configureClusterPlugins(cluster, jobSchedulerFile, securityPluginFile, secur
                 node.setting("plugins.security.system_indices.enabled", "true")
                 if (System.getProperty("resource_sharing.enabled") == "true") {
                     node.setting("plugins.security.experimental.resource_sharing.enabled", "true")
+                    node.setting("plugins.security.experimental.resource_sharing.protected_types", "[\"anomaly-detector\", \"forecaster\"]")
                 }
             }
         }


### PR DESCRIPTION
Post https://github.com/opensearch-project/security/pull/5671, we require explicit setting of protected resource types. This PR adds that to the test setup.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
