### PR TITLE
Exclude long-running tests from integTestRemote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Bug Fixes
 - Make frequency optional; fix STOPPED state; add ecommerce tests ([#1565](https://github.com/opensearch-project/anomaly-detection/pull/1565))
-- Fix flaky ITs ([#1571](https://github.com/opensearch-project/anomaly-detection/pull/1571))
 
 
 ### Infrastructure
 - Fix tests by adding the new node setting for protected types ([#1572](https://github.com/opensearch-project/anomaly-detection/pull/1572))
+- Fix flaky ITs ([#1571](https://github.com/opensearch-project/anomaly-detection/pull/1571))
+- Exclude long-running tests from integTestRemote ([#1579](https://github.com/opensearch-project/anomaly-detection/pull/1579))
 
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -763,6 +763,26 @@ task integTestRemote(type: RestIntegTestTask) {
             excludeTestsMatching "org.opensearch.forecast.rest.SecureForecastRestIT"
         }
     }
+
+    if (System.getProperty("model-benchmark") == null || System.getProperty("model-benchmark") == "false") {
+        filter {
+            excludeTestsMatching "org.opensearch.ad.e2e.*ModelPerfIT"
+        }
+    }
+
+    if (System.getProperty("long-running") == null || System.getProperty("long-running") == "false") {
+        filter {
+            excludeTestsMatching "org.opensearch.ad.e2e.SingleStreamSmokeIT"
+            excludeTestsMatching "org.opensearch.ad.e2e.RealTimeFrequencySmokeIT"
+            excludeTestsMatching "org.opensearch.forecast.rest.LongRunningForecastRestApiIT"
+        }
+    }
+
+    if (System.getProperty("perf") == null || System.getProperty("perf") == "false") {
+        filter {
+            excludeTestsMatching "org.opensearch.ad.e2e.BatchADSchedulingCheckpointIT"
+        }
+    }
 }
 
 configurations {


### PR DESCRIPTION
### Description
Long-running tests such as RealTimeRuleModelPerfIT may exceed the default 1200-second timeout and fail to complete within the integTestRemote run. Exclude these tests to prevent timeouts. They are covered by separate CI jobs that run long-running tests during PR validation.

### Related Issues
Resolves #[1568]

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
