### PR TITLE
Test: Prevent oversized bulk requests in synthetic data test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,19 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 3.x](https://github.com/opensearch-project/anomaly-detection/compare/3.0...HEAD)
 ### Features
 ### Enhancements
-- feat: add frequency scheduling in real time ([#1562](https://github.com/opensearch-project/anomaly-detection/pull/1562))
-- adding AD suggest API ([#1563](https://github.com/opensearch-project/anomaly-detection/pull/1563))
 - Adds capability to automatically switch to old access-control if model-group is excluded from protected resources setting ([#1569](https://github.com/opensearch-project/anomaly-detection/pull/1569))
 
 
 ### Bug Fixes
-- Make frequency optional; fix STOPPED state; add ecommerce tests ([#1565](https://github.com/opensearch-project/anomaly-detection/pull/1565))
 
 
 ### Infrastructure
-- Fix tests by adding the new node setting for protected types ([#1572](https://github.com/opensearch-project/anomaly-detection/pull/1572))
-- Fix flaky ITs ([#1571](https://github.com/opensearch-project/anomaly-detection/pull/1571))
-- Exclude long-running tests from integTestRemote ([#1579](https://github.com/opensearch-project/anomaly-detection/pull/1579))
+- Test: Prevent oversized bulk requests in synthetic data test ([#1603](https://github.com/opensearch-project/anomaly-detection/pull/1603))
 
 ### Documentation
 ### Maintenance
 
 ### Refactoring
-- Updates search handler to consume resource authz and updates resource authz related tests ([#1546](https://github.com/opensearch-project/anomaly-detection/pull/1546))
-- Adds resource types to DocRequests ([#1566](https://github.com/opensearch-project/anomaly-detection/pull/1566))
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/anomaly-detection/compare/2.19...2.x)
 ### Features


### PR DESCRIPTION
### Description
The `ingestSyntheticData` method previously created a single bulk request for the entire dataset. This could fail for large datasets by exceeding the 10MB request size limit.

This change modifies the ingestion logic to send bulk requests in batches of 1000 documents, ensuring each request stays well below the size limit and preventing ingestion failures.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
