### PR TITLE
Adding create and start to AD node client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Adds capability to automatically switch to old access-control if model-group is excluded from protected resources setting ([#1569](https://github.com/opensearch-project/anomaly-detection/pull/1569))
 - Adding suggest and validate transport actions to node client ([#1605](https://github.com/opensearch-project/anomaly-detection/pull/1605))
 - Adding auto create as an optional field on detectors ([#1602](https://github.com/opensearch-project/anomaly-detection/pull/1602))
+- Adding create and start to AD node client ([#1611](https://github.com/opensearch-project/anomaly-detection/pull/1611))
 
 ### Bug Fixes
 - fix(forecast): auto-expand replicas for default results index on 3AZ domains ([#1615](https://github.com/opensearch-project/anomaly-detection/pull/1615))

--- a/build.gradle
+++ b/build.gradle
@@ -192,9 +192,6 @@ dependencies {
     testImplementation 'org.reflections:reflections:0.10.2'
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
-
-    zipArchive("org.opensearch.plugin:opensearch-ml-plugin:${opensearch_build}")
-
 }
 
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,9 @@ dependencies {
     testImplementation 'org.reflections:reflections:0.10.2'
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
+
+    zipArchive("org.opensearch.plugin:opensearch-ml-plugin:${opensearch_build}")
+
 }
 
 apply plugin: 'java'

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -116,7 +116,7 @@ public interface AnomalyDetectionClient {
     void suggestAnomalyDetector(SuggestConfigParamRequest suggestRequest, ActionListener<SuggestConfigParamResponse> listener);
 
     /**
-     * Create anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#create-detector
+     * Create anomaly detector - refer to https://docs.opensearch.org/latest/observing-your-data/ad/api/#create-anomaly-detector
      * @param createRequest request to create the detector
      * @return ActionFuture of IndexAnomalyDetectorResponse
      */
@@ -127,14 +127,14 @@ public interface AnomalyDetectionClient {
     }
 
     /**
-     * Create anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#create-detector
+     * Create anomaly detector - refer to https://docs.opensearch.org/latest/observing-your-data/ad/api/#create-anomaly-detector
      * @param createRequest request to create the detector
      * @param listener a listener to be notified of the result
      */
     void createAnomalyDetector(IndexAnomalyDetectorRequest createRequest, ActionListener<IndexAnomalyDetectorResponse> listener);
 
     /**
-     * Start anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#start-detector
+     * Start anomaly detector - refer to https://docs.opensearch.org/latest/observing-your-data/ad/api/#start-detector-job
      * @param startRequest request to start the detector
      * @return ActionFuture of JobResponse
      */
@@ -145,7 +145,7 @@ public interface AnomalyDetectionClient {
     }
 
     /**
-     * Start anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#start-detector
+     * Start anomaly detector - refer to https://docs.opensearch.org/latest/observing-your-data/ad/api/#start-detector-job
      * @param startRequest request to start the detector
      * @param listener a listener to be notified of the result
      */

--- a/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
+++ b/src/main/java/org/opensearch/ad/client/AnomalyDetectionClient.java
@@ -9,9 +9,13 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.ad.transport.IndexAnomalyDetectorRequest;
+import org.opensearch.ad.transport.IndexAnomalyDetectorResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.timeseries.transport.GetConfigRequest;
+import org.opensearch.timeseries.transport.JobRequest;
+import org.opensearch.timeseries.transport.JobResponse;
 import org.opensearch.timeseries.transport.SuggestConfigParamRequest;
 import org.opensearch.timeseries.transport.SuggestConfigParamResponse;
 import org.opensearch.timeseries.transport.ValidateConfigRequest;
@@ -110,4 +114,40 @@ public interface AnomalyDetectionClient {
      * @param listener a listener to be notified of the result
      */
     void suggestAnomalyDetector(SuggestConfigParamRequest suggestRequest, ActionListener<SuggestConfigParamResponse> listener);
+
+    /**
+     * Create anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#create-detector
+     * @param createRequest request to create the detector
+     * @return ActionFuture of IndexAnomalyDetectorResponse
+     */
+    default ActionFuture<IndexAnomalyDetectorResponse> createAnomalyDetector(IndexAnomalyDetectorRequest createRequest) {
+        PlainActionFuture<IndexAnomalyDetectorResponse> actionFuture = PlainActionFuture.newFuture();
+        createAnomalyDetector(createRequest, actionFuture);
+        return actionFuture;
+    }
+
+    /**
+     * Create anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#create-detector
+     * @param createRequest request to create the detector
+     * @param listener a listener to be notified of the result
+     */
+    void createAnomalyDetector(IndexAnomalyDetectorRequest createRequest, ActionListener<IndexAnomalyDetectorResponse> listener);
+
+    /**
+     * Start anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#start-detector
+     * @param startRequest request to start the detector
+     * @return ActionFuture of JobResponse
+     */
+    default ActionFuture<JobResponse> startAnomalyDetector(JobRequest startRequest) {
+        PlainActionFuture<JobResponse> actionFuture = PlainActionFuture.newFuture();
+        startAnomalyDetector(startRequest, actionFuture);
+        return actionFuture;
+    }
+
+    /**
+     * Start anomaly detector - refer to https://opensearch.org/docs/latest/observing-your-data/ad/api/#start-detector
+     * @param startRequest request to start the detector
+     * @param listener a listener to be notified of the result
+     */
+    void startAnomalyDetector(JobRequest startRequest, ActionListener<JobResponse> listener);
 }

--- a/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -32,6 +32,7 @@ import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.timeseries.transport.BaseJobTransportAction;
 import org.opensearch.transport.TransportService;
@@ -47,7 +48,8 @@ public class AnomalyDetectorJobTransportAction extends
         ClusterService clusterService,
         Settings settings,
         NamedXContentRegistry xContentRegistry,
-        ADIndexJobActionHandler adIndexJobActionHandler
+        ADIndexJobActionHandler adIndexJobActionHandler,
+        NamedWriteableRegistry namedWriteableRegistry
     ) {
         super(
             transportService,
@@ -64,7 +66,8 @@ public class AnomalyDetectorJobTransportAction extends
             AnomalyDetector.class,
             adIndexJobActionHandler,
             Clock.systemUTC(), // inject cannot find clock due to OS limitation
-            AnomalyDetector.class
+            AnomalyDetector.class,
+            namedWriteableRegistry
         );
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorResponse.java
@@ -11,10 +11,17 @@
 
 package org.opensearch.ad.transport;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.rest.RestStatus;
@@ -80,5 +87,26 @@ public class IndexAnomalyDetectorResponse extends ActionResponse implements ToXC
             .field(RestHandlerUtils.ANOMALY_DETECTOR, detector)
             .field(RestHandlerUtils._PRIMARY_TERM, primaryTerm)
             .endObject();
+    }
+
+    public static IndexAnomalyDetectorResponse fromActionResponse(
+        ActionResponse actionResponse,
+        NamedWriteableRegistry namedWriteableRegistry
+    ) {
+        if (actionResponse instanceof IndexAnomalyDetectorResponse) {
+            return (IndexAnomalyDetectorResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (
+                StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()));
+                NamedWriteableAwareStreamInput namedWriteableAwareInput = new NamedWriteableAwareStreamInput(input, namedWriteableRegistry)
+            ) {
+                return new IndexAnomalyDetectorResponse(namedWriteableAwareInput);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into IndexAnomalyDetectorResponse", e);
+        }
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/IndexAnomalyDetectorTransportAction.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -32,6 +33,7 @@ import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.indices.ADIndexManagement;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.rest.handler.IndexAnomalyDetectorActionHandler;
+import org.opensearch.ad.settings.ADNumericSetting;
 import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.task.ADTaskManager;
 import org.opensearch.cluster.service.ClusterService;
@@ -41,6 +43,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestRequest;
@@ -54,7 +57,7 @@ import org.opensearch.timeseries.util.SecurityClientUtil;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
-public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<IndexAnomalyDetectorRequest, IndexAnomalyDetectorResponse> {
+public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<ActionRequest, IndexAnomalyDetectorResponse> {
     private static final Logger LOG = LogManager.getLogger(IndexAnomalyDetectorTransportAction.class);
     private final Client client;
     private final SecurityClientUtil clientUtil;
@@ -66,6 +69,11 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
     private volatile Boolean filterByEnabled;
     private final SearchFeatureDao searchFeatureDao;
     private final Settings settings;
+    protected final NamedWriteableRegistry namedWriteableRegistry;
+    private volatile Integer maxSingleEntityAnomalyDetectors;
+    private volatile Integer maxMultiEntityAnomalyDetectors;
+    private volatile Integer maxAnomalyFeatures;
+    private volatile Integer maxCategoricalFields;
 
     @Inject
     public IndexAnomalyDetectorTransportAction(
@@ -78,7 +86,8 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         ADIndexManagement anomalyDetectionIndices,
         NamedXContentRegistry xContentRegistry,
         ADTaskManager adTaskManager,
-        SearchFeatureDao searchFeatureDao
+        SearchFeatureDao searchFeatureDao,
+        NamedWriteableRegistry namedWriteableRegistry
     ) {
         super(IndexAnomalyDetectorAction.NAME, transportService, actionFilters, IndexAnomalyDetectorRequest::new);
         this.client = client;
@@ -92,10 +101,42 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         filterByEnabled = AnomalyDetectorSettings.AD_FILTER_BY_BACKEND_ROLES.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(AD_FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
         this.settings = settings;
+        this.namedWriteableRegistry = namedWriteableRegistry;
+
+        // Initialize cluster settings for node client requests
+        this.maxSingleEntityAnomalyDetectors = AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings);
+        this.maxMultiEntityAnomalyDetectors = AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS.get(settings);
+        this.maxAnomalyFeatures = AnomalyDetectorSettings.MAX_ANOMALY_FEATURES.get(settings);
+        this.maxCategoricalFields = ADNumericSetting.maxCategoricalFields();
+
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(
+                AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS,
+                it -> maxSingleEntityAnomalyDetectors = it
+            );
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS, it -> maxMultiEntityAnomalyDetectors = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(AnomalyDetectorSettings.MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
     }
 
     @Override
-    protected void doExecute(Task task, IndexAnomalyDetectorRequest request, ActionListener<IndexAnomalyDetectorResponse> actionListener) {
+    protected void doExecute(Task task, ActionRequest actionRequest, ActionListener<IndexAnomalyDetectorResponse> actionListener) {
+        IndexAnomalyDetectorRequest request = IndexAnomalyDetectorRequest.fromActionRequest(actionRequest, namedWriteableRegistry);
+
+        // Use cached settings if request has nulls (request directly from AD Node Client)
+        Integer maxSingle = request.getMaxSingleEntityAnomalyDetectors() != null
+            ? request.getMaxSingleEntityAnomalyDetectors()
+            : maxSingleEntityAnomalyDetectors;
+        Integer maxMulti = request.getMaxMultiEntityAnomalyDetectors() != null
+            ? request.getMaxMultiEntityAnomalyDetectors()
+            : maxMultiEntityAnomalyDetectors;
+        Integer maxFeatures = request.getMaxAnomalyFeatures() != null ? request.getMaxAnomalyFeatures() : maxAnomalyFeatures;
+        Integer maxCategorical = request.getMaxCategoricalFields() != null ? request.getMaxCategoricalFields() : maxCategoricalFields;
+
         User user = ParseUtils.getUserContext(client);
         String detectorId = request.getDetectorID();
         RestRequest.Method method = request.getMethod();
@@ -105,13 +146,19 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             verifyResourceAccessAndProcessRequest(
                 ADCommonName.AD_RESOURCE_TYPE,
-                () -> indexDetector(user, detectorId, method, listener, detector -> adExecute(request, user, detector, context, listener)),
+                () -> indexDetector(
+                    user,
+                    detectorId,
+                    method,
+                    listener,
+                    detector -> adExecute(request, user, detector, context, listener, maxSingle, maxMulti, maxFeatures, maxCategorical)
+                ),
                 () -> resolveUserAndExecute(
                     user,
                     detectorId,
                     method,
                     listener,
-                    (detector) -> adExecute(request, user, detector, context, listener)
+                    (detector) -> adExecute(request, user, detector, context, listener, maxSingle, maxMulti, maxFeatures, maxCategorical)
                 )
             );
 
@@ -181,7 +228,11 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         User user,
         AnomalyDetector currentDetector,
         ThreadContext.StoredContext storedContext,
-        ActionListener<IndexAnomalyDetectorResponse> listener
+        ActionListener<IndexAnomalyDetectorResponse> listener,
+        Integer maxSingleEntityAnomalyDetectors,
+        Integer maxMultiEntityAnomalyDetectors,
+        Integer maxAnomalyFeatures,
+        Integer maxCategoricalFields
     ) {
         anomalyDetectionIndices.update();
         String detectorId = request.getDetectorID();
@@ -191,10 +242,6 @@ public class IndexAnomalyDetectorTransportAction extends HandledTransportAction<
         AnomalyDetector detector = request.getDetector();
         RestRequest.Method method = request.getMethod();
         TimeValue requestTimeout = request.getRequestTimeout();
-        Integer maxSingleEntityAnomalyDetectors = request.getMaxSingleEntityAnomalyDetectors();
-        Integer maxMultiEntityAnomalyDetectors = request.getMaxMultiEntityAnomalyDetectors();
-        Integer maxAnomalyFeatures = request.getMaxAnomalyFeatures();
-        Integer maxCategoricalFields = request.getMaxCategoricalFields();
 
         storedContext.restore();
         checkIndicesAndExecute(detector.getIndices(), () -> {

--- a/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportAction.java
@@ -73,7 +73,15 @@ public class ValidateAnomalyDetectorTransportAction extends BaseValidateConfigTr
     }
 
     @Override
-    protected Processor<ValidateConfigResponse> createProcessor(Config detector, ValidateConfigRequest request, User user) {
+    protected Processor<ValidateConfigResponse> createProcessor(
+        Config detector,
+        ValidateConfigRequest request,
+        User user,
+        Integer maxSingleStreamConfigs,
+        Integer maxHCConfigs,
+        Integer maxFeatures,
+        Integer maxCategoricalFields
+    ) {
         return new ValidateAnomalyDetectorActionHandler(
             clusterService,
             client,
@@ -81,10 +89,10 @@ public class ValidateAnomalyDetectorTransportAction extends BaseValidateConfigTr
             indexManagement,
             detector,
             request.getRequestTimeout(),
-            request.getMaxSingleEntityAnomalyDetectors(),
-            request.getMaxMultiEntityAnomalyDetectors(),
-            request.getMaxAnomalyFeatures(),
-            request.getMaxCategoricalFields(),
+            maxSingleStreamConfigs,
+            maxHCConfigs,
+            maxFeatures,
+            maxCategoricalFields,
             RestRequest.Method.POST,
             xContentRegistry,
             user,

--- a/src/main/java/org/opensearch/forecast/transport/ForecasterJobTransportAction.java
+++ b/src/main/java/org/opensearch/forecast/transport/ForecasterJobTransportAction.java
@@ -16,6 +16,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.forecast.ExecuteForecastResultResponseRecorder;
 import org.opensearch.forecast.indices.ForecastIndex;
@@ -42,7 +43,8 @@ public class ForecasterJobTransportAction extends
         ClusterService clusterService,
         Settings settings,
         NamedXContentRegistry xContentRegistry,
-        ForecastIndexJobActionHandler forecastIndexJobActionHandler
+        ForecastIndexJobActionHandler forecastIndexJobActionHandler,
+        NamedWriteableRegistry namedWriteableRegistry
     ) {
         super(
             transportService,
@@ -59,7 +61,8 @@ public class ForecasterJobTransportAction extends
             Forecaster.class,
             forecastIndexJobActionHandler,
             Clock.systemUTC(), // inject cannot find clock due to OS limitation
-            Forecaster.class
+            Forecaster.class,
+            namedWriteableRegistry
         );
     }
 }

--- a/src/main/java/org/opensearch/forecast/transport/ValidateForecasterTransportAction.java
+++ b/src/main/java/org/opensearch/forecast/transport/ValidateForecasterTransportAction.java
@@ -68,7 +68,15 @@ public class ValidateForecasterTransportAction extends
     }
 
     @Override
-    protected Processor<ValidateConfigResponse> createProcessor(Config forecaster, ValidateConfigRequest request, User user) {
+    protected Processor<ValidateConfigResponse> createProcessor(
+        Config forecaster,
+        ValidateConfigRequest request,
+        User user,
+        Integer maxSingleStreamConfigs,
+        Integer maxHCConfigs,
+        Integer maxFeatures,
+        Integer maxCategoricalFields
+    ) {
         return new ValidateForecasterActionHandler(
             clusterService,
             client,
@@ -76,10 +84,10 @@ public class ValidateForecasterTransportAction extends
             indexManagement,
             forecaster,
             request.getRequestTimeout(),
-            request.getMaxSingleEntityAnomalyDetectors(),
-            request.getMaxMultiEntityAnomalyDetectors(),
-            request.getMaxAnomalyFeatures(),
-            request.getMaxCategoricalFields(),
+            maxSingleStreamConfigs,
+            maxHCConfigs,
+            maxFeatures,
+            maxCategoricalFields,
             RestRequest.Method.POST,
             xContentRegistry,
             user,

--- a/src/main/java/org/opensearch/timeseries/transport/BaseJobTransportAction.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BaseJobTransportAction.java
@@ -14,6 +14,7 @@ import java.time.Clock;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -24,6 +25,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.tasks.Task;
 import org.opensearch.timeseries.ExecuteResultResponseRecorder;
@@ -43,7 +45,7 @@ import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
 public abstract class BaseJobTransportAction<IndexType extends Enum<IndexType> & TimeSeriesIndex, IndexManagementType extends IndexManagement<IndexType>, TaskCacheManagerType extends TaskCacheManager, TaskTypeEnum extends TaskType, TaskClass extends TimeSeriesTask, TaskManagerType extends TaskManager<TaskCacheManagerType, TaskTypeEnum, TaskClass, IndexType, IndexManagementType>, IndexableResultType extends IndexableResult, ProfileActionType extends ActionType<ProfileResponse>, ExecuteResultResponseRecorderType extends ExecuteResultResponseRecorder<IndexType, IndexManagementType, TaskCacheManagerType, TaskTypeEnum, TaskClass, TaskManagerType, IndexableResultType, ProfileActionType>, IndexJobActionHandlerType extends IndexJobActionHandler<IndexType, IndexManagementType, TaskCacheManagerType, TaskTypeEnum, TaskClass, TaskManagerType, IndexableResultType, ProfileActionType, ExecuteResultResponseRecorderType>, ConfigType extends Config>
-    extends HandledTransportAction<JobRequest, JobResponse> {
+    extends HandledTransportAction<ActionRequest, JobResponse> {
     private final Logger logger = LogManager.getLogger(BaseJobTransportAction.class);
 
     private final Client client;
@@ -59,6 +61,7 @@ public abstract class BaseJobTransportAction<IndexType extends Enum<IndexType> &
     private final IndexJobActionHandlerType indexJobActionHandlerType;
     private final Clock clock;
     private final Class<ConfigType> configTypeClass;
+    protected final NamedWriteableRegistry namedWriteableRegistry;
 
     public BaseJobTransportAction(
         TransportService transportService,
@@ -75,7 +78,8 @@ public abstract class BaseJobTransportAction<IndexType extends Enum<IndexType> &
         Class<? extends Config> configClass,
         IndexJobActionHandlerType indexJobActionHandlerType,
         Clock clock,
-        Class<ConfigType> configTypeClass
+        Class<ConfigType> configTypeClass,
+        NamedWriteableRegistry namedWriteableRegistry
     ) {
         super(jobActionName, transportService, actionFilters, JobRequest::new);
         this.transportService = transportService;
@@ -92,10 +96,12 @@ public abstract class BaseJobTransportAction<IndexType extends Enum<IndexType> &
         this.indexJobActionHandlerType = indexJobActionHandlerType;
         this.clock = clock;
         this.configTypeClass = configTypeClass;
+        this.namedWriteableRegistry = namedWriteableRegistry;
     }
 
     @Override
-    protected void doExecute(Task task, JobRequest request, ActionListener<JobResponse> actionListener) {
+    protected void doExecute(Task task, ActionRequest actionRequest, ActionListener<JobResponse> actionListener) {
+        JobRequest request = JobRequest.fromActionRequest(actionRequest, namedWriteableRegistry);
         String configId = request.getConfigID();
         DateRange dateRange = request.getDateRange();
         boolean historical = request.isHistorical();

--- a/src/main/java/org/opensearch/timeseries/transport/BaseValidateConfigTransportAction.java
+++ b/src/main/java/org/opensearch/timeseries/transport/BaseValidateConfigTransportAction.java
@@ -18,6 +18,8 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.ad.settings.ADNumericSetting;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -64,6 +66,10 @@ public abstract class BaseValidateConfigTransportAction<IndexType extends Enum<I
     protected Settings settings;
     protected ValidationAspect validationAspect;
     private final Class<ConfigType> configTypeClass;
+    private volatile Integer maxSingleEntityAnomalyDetectors;
+    private volatile Integer maxMultiEntityAnomalyDetectors;
+    private volatile Integer maxAnomalyFeatures;
+    private volatile Integer maxCategoricalFields;
 
     public BaseValidateConfigTransportAction(
         String actionName,
@@ -95,6 +101,25 @@ public abstract class BaseValidateConfigTransportAction<IndexType extends Enum<I
         this.settings = settings;
         this.validationAspect = validationAspect;
         this.configTypeClass = configTypeClass;
+
+        // Initialize cluster settings for node client requests
+        this.maxSingleEntityAnomalyDetectors = AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS.get(settings);
+        this.maxMultiEntityAnomalyDetectors = AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS.get(settings);
+        this.maxAnomalyFeatures = AnomalyDetectorSettings.MAX_ANOMALY_FEATURES.get(settings);
+        this.maxCategoricalFields = ADNumericSetting.maxCategoricalFields();
+
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(
+                AnomalyDetectorSettings.AD_MAX_SINGLE_ENTITY_ANOMALY_DETECTORS,
+                it -> maxSingleEntityAnomalyDetectors = it
+            );
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(AnomalyDetectorSettings.AD_MAX_HC_ANOMALY_DETECTORS, it -> maxMultiEntityAnomalyDetectors = it);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(AnomalyDetectorSettings.MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
     }
 
     @Override
@@ -216,6 +241,17 @@ public abstract class BaseValidateConfigTransportAction<IndexType extends Enum<I
         ActionListener<ValidateConfigResponse> listener
     ) {
         storedContext.restore();
+
+        // Resolve settings (from request or cached values)
+        Integer maxSingleEntity = request.getMaxSingleEntityAnomalyDetectors() != null
+            ? request.getMaxSingleEntityAnomalyDetectors()
+            : maxSingleEntityAnomalyDetectors;
+        Integer maxMultiEntity = request.getMaxMultiEntityAnomalyDetectors() != null
+            ? request.getMaxMultiEntityAnomalyDetectors()
+            : maxMultiEntityAnomalyDetectors;
+        Integer maxFeatures = request.getMaxAnomalyFeatures() != null ? request.getMaxAnomalyFeatures() : maxAnomalyFeatures;
+        Integer maxCategorical = request.getMaxCategoricalFields() != null ? request.getMaxCategoricalFields() : maxCategoricalFields;
+
         Config config = request.getConfig();
         ActionListener<ValidateConfigResponse> validateListener = ActionListener.wrap(response -> {
             // forcing response to be empty
@@ -232,7 +268,8 @@ public abstract class BaseValidateConfigTransportAction<IndexType extends Enum<I
         });
         checkIndicesAndExecute(config.getIndices(), () -> {
             try {
-                createProcessor(config, request, user).start(validateListener);
+                createProcessor(config, request, user, maxSingleEntity, maxMultiEntity, maxFeatures, maxCategorical)
+                    .start(validateListener);
             } catch (Exception exception) {
                 String errorMessage = String
                     .format(Locale.ROOT, "Unknown exception caught while validating config %s", request.getConfig());
@@ -242,5 +279,13 @@ public abstract class BaseValidateConfigTransportAction<IndexType extends Enum<I
         }, listener);
     }
 
-    protected abstract Processor<ValidateConfigResponse> createProcessor(Config config, ValidateConfigRequest request, User user);
+    protected abstract Processor<ValidateConfigResponse> createProcessor(
+        Config config,
+        ValidateConfigRequest request,
+        User user,
+        Integer maxSingleStreamConfigs,
+        Integer maxHCConfigs,
+        Integer maxFeatures,
+        Integer maxCategoricalFields
+    );
 }

--- a/src/main/java/org/opensearch/timeseries/transport/JobRequest.java
+++ b/src/main/java/org/opensearch/timeseries/transport/JobRequest.java
@@ -121,4 +121,32 @@ public class JobRequest extends ActionRequest implements DocRequest {
     public String id() {
         return configID;
     }
+
+    public static JobRequest fromActionRequest(
+        final ActionRequest actionRequest,
+        org.opensearch.core.common.io.stream.NamedWriteableRegistry namedWriteableRegistry
+    ) {
+        if (actionRequest instanceof JobRequest) {
+            return (JobRequest) actionRequest;
+        }
+
+        try (
+            java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+            org.opensearch.core.common.io.stream.OutputStreamStreamOutput osso =
+                new org.opensearch.core.common.io.stream.OutputStreamStreamOutput(baos)
+        ) {
+            actionRequest.writeTo(osso);
+            try (
+                org.opensearch.core.common.io.stream.StreamInput input = new org.opensearch.core.common.io.stream.InputStreamStreamInput(
+                    new java.io.ByteArrayInputStream(baos.toByteArray())
+                );
+                org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput namedInput =
+                    new org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput(input, namedWriteableRegistry)
+            ) {
+                return new JobRequest(namedInput);
+            }
+        } catch (java.io.IOException e) {
+            throw new IllegalArgumentException("failed to parse ActionRequest into JobRequest", e);
+        }
+    }
 }

--- a/src/main/java/org/opensearch/timeseries/transport/ValidateConfigRequest.java
+++ b/src/main/java/org/opensearch/timeseries/transport/ValidateConfigRequest.java
@@ -54,11 +54,11 @@ public class ValidateConfigRequest extends ActionRequest {
         }
 
         validationType = in.readString();
-        maxSingleStreamConfigs = in.readInt();
-        maxHCConfigs = in.readInt();
-        maxFeatures = in.readInt();
+        maxSingleStreamConfigs = in.readOptionalInt();
+        maxHCConfigs = in.readOptionalInt();
+        maxFeatures = in.readOptionalInt();
         requestTimeout = in.readTimeValue();
-        maxCategoricalFields = in.readInt();
+        maxCategoricalFields = in.readOptionalInt();
     }
 
     public ValidateConfigRequest(
@@ -81,17 +81,21 @@ public class ValidateConfigRequest extends ActionRequest {
         this.maxCategoricalFields = maxCategoricalFields;
     }
 
+    public ValidateConfigRequest(AnalysisType context, Config config, String validationType) {
+        this(context, config, validationType, null, null, null, TimeValue.timeValueSeconds(60), null);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(context);
         config.writeTo(out);
         out.writeString(validationType);
-        out.writeInt(maxSingleStreamConfigs);
-        out.writeInt(maxHCConfigs);
-        out.writeInt(maxFeatures);
+        out.writeOptionalInt(maxSingleStreamConfigs);
+        out.writeOptionalInt(maxHCConfigs);
+        out.writeOptionalInt(maxFeatures);
         out.writeTimeValue(requestTimeout);
-        out.writeInt(maxCategoricalFields);
+        out.writeOptionalInt(maxCategoricalFields);
     }
 
     @Override
@@ -134,7 +138,6 @@ public class ValidateConfigRequest extends ActionRequest {
         if (actionRequest instanceof ValidateConfigRequest) {
             return (ValidateConfigRequest) actionRequest;
         }
-
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
             actionRequest.writeTo(osso);
             try (

--- a/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
+++ b/src/test/java/org/opensearch/ad/client/AnomalyDetectionClientTests.java
@@ -15,9 +15,13 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.indices.ADIndex;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.ad.transport.IndexAnomalyDetectorRequest;
+import org.opensearch.ad.transport.IndexAnomalyDetectorResponse;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.timeseries.transport.GetConfigRequest;
+import org.opensearch.timeseries.transport.JobRequest;
+import org.opensearch.timeseries.transport.JobResponse;
 import org.opensearch.timeseries.transport.SuggestConfigParamRequest;
 import org.opensearch.timeseries.transport.SuggestConfigParamResponse;
 import org.opensearch.timeseries.transport.ValidateConfigRequest;
@@ -41,6 +45,12 @@ public class AnomalyDetectionClientTests {
 
     @Mock
     SuggestConfigParamResponse suggestResponse;
+
+    @Mock
+    IndexAnomalyDetectorResponse createResponse;
+
+    @Mock
+    JobResponse startResponse;
 
     @Before
     public void setUp() {
@@ -74,6 +84,19 @@ public class AnomalyDetectionClientTests {
                 ActionListener<SuggestConfigParamResponse> listener
             ) {
                 listener.onResponse(suggestResponse);
+            }
+
+            @Override
+            public void createAnomalyDetector(
+                IndexAnomalyDetectorRequest createRequest,
+                ActionListener<IndexAnomalyDetectorResponse> listener
+            ) {
+                listener.onResponse(createResponse);
+            }
+
+            @Override
+            public void startAnomalyDetector(JobRequest startRequest, ActionListener<JobResponse> listener) {
+                listener.onResponse(startResponse);
             }
         };
     }
@@ -128,6 +151,34 @@ public class AnomalyDetectionClientTests {
             org.opensearch.common.unit.TimeValue.timeValueSeconds(30)
         );
         assertEquals(suggestResponse, anomalyDetectionClient.suggestAnomalyDetector(suggestRequest).actionGet());
+    }
+
+    @Test
+    public void createAnomalyDetector() {
+        IndexAnomalyDetectorRequest createRequest = new IndexAnomalyDetectorRequest(
+            "test-detector-id",
+            1L,
+            1L,
+            org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE,
+            null,
+            org.opensearch.rest.RestRequest.Method.POST,
+            org.opensearch.common.unit.TimeValue.timeValueSeconds(30),
+            10,
+            10,
+            5,
+            2
+        );
+        assertEquals(createResponse, anomalyDetectionClient.createAnomalyDetector(createRequest).actionGet());
+    }
+
+    @Test
+    public void startAnomalyDetector() {
+        JobRequest startRequest = new JobRequest(
+            "test-detector-id",
+            ADIndex.CONFIG.getIndexName(),
+            "/_plugins/_anomaly_detection/detectors/test-detector-id/_start"
+        );
+        assertEquals(startResponse, anomalyDetectionClient.startAnomalyDetector(startRequest).actionGet());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/IndexAnomalyDetectorActionTests.java
@@ -23,6 +23,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -83,5 +84,82 @@ public class IndexAnomalyDetectorActionTests extends OpenSearchSingleNodeTestCas
 
         Map<String, Object> map = TestHelpers.XContentBuilderToMap(builder);
         Assert.assertEquals(map.get(RestHandlerUtils._ID), "1234");
+    }
+
+    @Test
+    public void testIndexRequestFromActionRequest_SameType() throws Exception {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        IndexAnomalyDetectorRequest request = new IndexAnomalyDetectorRequest(
+            "1234",
+            4321,
+            5678,
+            WriteRequest.RefreshPolicy.NONE,
+            detector,
+            RestRequest.Method.PUT,
+            TimeValue.timeValueSeconds(60),
+            1000,
+            10,
+            5,
+            10
+        );
+        IndexAnomalyDetectorRequest result = IndexAnomalyDetectorRequest.fromActionRequest(request, writableRegistry());
+        Assert.assertSame(request, result);
+    }
+
+    @Test
+    public void testIndexRequestFromActionRequest_DifferentType() throws Exception {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        IndexAnomalyDetectorRequest original = new IndexAnomalyDetectorRequest(
+            "1234",
+            4321,
+            5678,
+            WriteRequest.RefreshPolicy.NONE,
+            detector,
+            RestRequest.Method.PUT,
+            TimeValue.timeValueSeconds(60),
+            1000,
+            10,
+            5,
+            10
+        );
+
+        org.opensearch.action.ActionRequest actionRequest = new org.opensearch.action.ActionRequest() {
+            @Override
+            public org.opensearch.action.ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws java.io.IOException {
+                original.writeTo(out);
+            }
+        };
+
+        IndexAnomalyDetectorRequest result = IndexAnomalyDetectorRequest.fromActionRequest(actionRequest, writableRegistry());
+        Assert.assertEquals(original.getDetectorID(), result.getDetectorID());
+    }
+
+    @Test
+    public void testIndexResponseFromActionResponse_SameType() throws Exception {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        IndexAnomalyDetectorResponse response = new IndexAnomalyDetectorResponse("1234", 2, 2, 2, detector, RestStatus.OK);
+        IndexAnomalyDetectorResponse result = IndexAnomalyDetectorResponse.fromActionResponse(response, writableRegistry());
+        Assert.assertSame(response, result);
+    }
+
+    @Test
+    public void testIndexResponseFromActionResponse_DifferentType() throws Exception {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        IndexAnomalyDetectorResponse original = new IndexAnomalyDetectorResponse("1234", 2, 2, 2, detector, RestStatus.OK);
+
+        org.opensearch.core.action.ActionResponse actionResponse = new org.opensearch.core.action.ActionResponse() {
+            @Override
+            public void writeTo(StreamOutput out) throws java.io.IOException {
+                original.writeTo(out);
+            }
+        };
+
+        IndexAnomalyDetectorResponse result = IndexAnomalyDetectorResponse.fromActionResponse(actionResponse, writableRegistry());
+        Assert.assertEquals(original.getId(), result.getId());
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorRequestTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorRequestTests.java
@@ -47,8 +47,29 @@ public class ValidateAnomalyDetectorRequestTests extends OpenSearchSingleNodeTes
         request1.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         ValidateConfigRequest request2 = new ValidateConfigRequest(input);
+    }
+
+    @Test
+    public void testValidateAnomalyDetectorRequestWithNullValues() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        String typeStr = "model";
+
+        // Test convenience constructor with null cluster settings
+        ValidateConfigRequest request1 = new ValidateConfigRequest(AnalysisType.AD, detector, typeStr);
+
+        // Test serialization with null values
+        BytesStreamOutput output = new BytesStreamOutput();
+        request1.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ValidateConfigRequest request2 = new ValidateConfigRequest(input);
+
         assertEquals("serialization has the wrong detector", request2.getConfig(), detector);
+        assertEquals("serialization has the wrong validation type", request2.getValidationType(), typeStr);
+        assertNull("maxSingleStreamConfigs should be null", request2.getMaxSingleEntityAnomalyDetectors());
+        assertNull("maxHCConfigs should be null", request2.getMaxMultiEntityAnomalyDetectors());
+        assertNull("maxFeatures should be null", request2.getMaxAnomalyFeatures());
+
         assertEquals("serialization has the wrong typeStr", request2.getValidationType(), typeStr);
-        assertEquals("serialization has the wrong requestTimeout", request2.getRequestTimeout(), requestTimeout);
+        assertEquals("serialization has the wrong requestTimeout", request2.getRequestTimeout(), TimeValue.timeValueSeconds(60));
     }
 }

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -548,4 +548,23 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
         assertNull(response.getIssue());
     }
 
+    @Test
+    public void testValidateAnomalyDetectorWithNullSettings() throws IOException {
+        AnomalyDetector anomalyDetector = TestHelpers
+            .randomAnomalyDetector(timeField, "test-index", ImmutableList.of(sumValueFeature(nameField, ipField + ".is_error", "test-3")));
+        ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
+        ValidateConfigRequest request = new ValidateConfigRequest(
+            AnalysisType.AD,
+            anomalyDetector,
+            ValidationAspect.DETECTOR.getName(),
+            null,
+            null,
+            null,
+            new TimeValue(5_000L),
+            null
+        );
+        ValidateConfigResponse response = client().execute(ValidateAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+        assertNull(response.getIssue());
+    }
+
 }

--- a/src/test/java/org/opensearch/timeseries/transport/AnomalyDetectorJobActionTests.java
+++ b/src/test/java/org/opensearch/timeseries/transport/AnomalyDetectorJobActionTests.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,7 +38,14 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -49,6 +58,7 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
     private Task task;
     private JobRequest request;
     private ActionListener<JobResponse> response;
+    private NamedWriteableRegistry registry;
 
     @Override
     @Before
@@ -68,7 +78,19 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
         org.opensearch.threadpool.ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(client.threadPool()).thenReturn(mockThreadPool);
         when(mockThreadPool.getThreadContext()).thenReturn(threadContext);
-
+        List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
+        namedWriteables.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, BoolQueryBuilder.NAME, BoolQueryBuilder::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, TermQueryBuilder.NAME, TermQueryBuilder::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, RangeQueryBuilder.NAME, RangeQueryBuilder::new));
+        namedWriteables
+            .add(
+                new NamedWriteableRegistry.Entry(
+                    AggregationBuilder.class,
+                    ValueCountAggregationBuilder.NAME,
+                    ValueCountAggregationBuilder::new
+                )
+            );
+        registry = new NamedWriteableRegistry(namedWriteables);
         action = new AnomalyDetectorJobTransportAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
@@ -76,7 +98,8 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
             clusterService,
             indexSettings(),
             xContentRegistry(),
-            mock(ADIndexJobActionHandler.class)
+            mock(ADIndexJobActionHandler.class),
+            registry
         );
         task = mock(Task.class);
         request = new JobRequest(
@@ -155,5 +178,54 @@ public class AnomalyDetectorJobActionTests extends OpenSearchIntegTestCase {
         StreamInput input = out.bytes().streamInput();
         JobResponse newResponse = new JobResponse(input);
         Assert.assertEquals(response.getId(), newResponse.getId());
+    }
+
+    @Test
+    public void testJobRequestFromActionRequest_SameType() {
+        JobRequest request = new JobRequest("1234", ADIndex.CONFIG.getIndexName(), "_start");
+        JobRequest result = JobRequest.fromActionRequest(request, registry);
+        Assert.assertSame(request, result);
+    }
+
+    @Test
+    public void testJobRequestFromActionRequest_DifferentType() {
+        JobRequest original = new JobRequest("1234", ADIndex.CONFIG.getIndexName(), "_start");
+
+        org.opensearch.action.ActionRequest actionRequest = new org.opensearch.action.ActionRequest() {
+            @Override
+            public org.opensearch.action.ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(org.opensearch.core.common.io.stream.StreamOutput out) throws java.io.IOException {
+                original.writeTo(out);
+            }
+        };
+
+        JobRequest result = JobRequest.fromActionRequest(actionRequest, registry);
+        Assert.assertEquals(original.getConfigID(), result.getConfigID());
+    }
+
+    @Test
+    public void testJobResponseFromActionResponse_SameType() {
+        JobResponse response = new JobResponse("1234");
+        JobResponse result = JobResponse.fromActionResponse(response, registry);
+        Assert.assertSame(response, result);
+    }
+
+    @Test
+    public void testJobResponseFromActionResponse_DifferentType() {
+        JobResponse original = new JobResponse("1234");
+
+        org.opensearch.core.action.ActionResponse actionResponse = new org.opensearch.core.action.ActionResponse() {
+            @Override
+            public void writeTo(org.opensearch.core.common.io.stream.StreamOutput out) throws java.io.IOException {
+                original.writeTo(out);
+            }
+        };
+
+        JobResponse result = JobResponse.fromActionResponse(actionResponse, registry);
+        Assert.assertEquals(original.getId(), result.getId());
     }
 }


### PR DESCRIPTION
### Description
Adding create and start to AD node client.

Involves creating new constructor for a few request types were we pass AD cluster settings from rest layer and utilizing cluster setting fetching in transport layer instead for plugin to plugin communication. 

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
