### PR TITLE
Update macOS GitHub runners to macos-15-intel

### DIFF
--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
 
     name: Build and Test Anomaly detection Plugin on MacOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       JENKINS_URL: build.ci.opensearch.org
 


### PR DESCRIPTION
### Description

GitHub actions are currently not running on macOS as the `macos-13` runners have been retired.

Based on [this comment](https://github.com/opensearch-project/anomaly-detection/pull/1197#issuecomment-2086602009), we previously had failures on ARM runners.

Bumping to `macos-15-intel`.

### Related Issues

> The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
