### PR TITLE
Serialize integTestRemote on remote clusters to avoid index wipe races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Enhancements
 ### Bug Fixes
+- Fix remote integ test flakiness from shared index cleanup ([#1654](https://github.com/opensearch-project/anomaly-detection/pull/1654))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -750,6 +750,9 @@ task integTestRemote(type: Test) {
 
     // Only rest case can run with remote cluster
     if (System.getProperty("tests.rest.cluster") != null) {
+        // Remote clusters are shared across test JVMs; serialize to avoid cross-test index wipes.
+        maxParallelForks = 1
+        forkEvery = 0
         filter {
             includeTestsMatching "org.opensearch.ad.rest.*IT"
             includeTestsMatching "org.opensearch.ad.e2e.*IT"


### PR DESCRIPTION
### Description

integTestRemote can run multiple forks against a shared remote cluster, so @After cleanup in ODFERestTestCase deletes .opendistro-anomaly-detectors while other tests are mid‑request, causing 404s in SecureADRestIT and other REST ITs. This PR fixes the problem. When tests.rest.cluster is set, force integTestRemote to run serially (maxParallelForks=1, forkEvery=0) to avoid cross‑test index wipe races.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
