### PR TITLE
[2.19] Update urllib3 to 2.6.3 to resolve CVEs

### DIFF
--- a/dataGeneration/requirements.txt
+++ b/dataGeneration/requirements.txt
@@ -3,4 +3,4 @@ numpy==1.26.4
 opensearch_py==3.0.0
 retry==0.9.2
 scipy==1.16.1
-urllib3==2.5.0
+urllib3==2.6.3


### PR DESCRIPTION


### Description

Bumps urllib3 to 2.6.3.

### Related Issues

Fixes CVE-2026-21441
Fixes CVE-2025-66418 
Fixes CVE-2025-66471

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
