### PR TITLE
feat(terraform): add AD detector provisioning and lifecycle automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ out/
 bin/
 ._.DS_Store
 src/test/resources/job-scheduler/
+
+# Terraform local artifacts and secrets
+.terraform/
+*.tfstate*
+*.tfvars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Introduce Insights API ([1610](https://github.com/opensearch-project/anomaly-detection/pull/1610))
 
 ### Enhancements
+- feat(terraform): add AD detector provisioning and lifecycle automation ([1680](https://github.com/opensearch-project/anomaly-detection/pull/1680))
+
 ### Bug Fixes
 ### Infrastructure
 - Add integTest coverage reporting and README badge ([1679](https://github.com/opensearch-project/anomaly-detection/pull/1679))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![AD Test](https://github.com/opensearch-project/anomaly-detection/workflows/Build%20and%20Test%20Anomaly%20detection/badge.svg)](https://github.com/opensearch-project/anomaly-detection/actions?query=workflow%3A%22Build+and+Test+Anomaly+detection%22+branch%3A%22main%22)
-[![codecov](https://codecov.io/gh/opensearch-project/anomaly-detection/branch/main/graph/badge.svg?flag=plugin)](https://codecov.io/gh/opensearch-project/anomaly-detection)
-[![codecov integTest](https://codecov.io/gh/opensearch-project/anomaly-detection/branch/main/graph/badge.svg?flag=plugin_integtest)](https://codecov.io/gh/opensearch-project/anomaly-detection)
+[![Plugin Coverage](https://img.shields.io/codecov/c/github/opensearch-project/anomaly-detection/main?flag=plugin&label=Plugin%20coverage)](https://codecov.io/gh/opensearch-project/anomaly-detection)
+[![IntegTest Coverage](https://img.shields.io/codecov/c/github/opensearch-project/anomaly-detection/main?flag=plugin_integtest&label=IntegTest%20coverage)](https://codecov.io/gh/opensearch-project/anomaly-detection)
 [![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/monitoring-plugins/ad/index/)
 [![Forum](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)

--- a/scripts/terraform/README.md
+++ b/scripts/terraform/README.md
@@ -37,7 +37,40 @@ Defaults in [`main.tf`](main.tf) target local development:
 
 You can change `opensearch_url` to your remote OpenSearch endpoint, for example `https://your-cluster.example.com:9200`.
 
-If your cluster has security enabled, set username/password via `terraform.tfvars` or CLI flags.
+If your cluster has security enabled, prefer environment variables for credentials in production. `terraform.tfvars` and CLI flags also work, but they are less suitable for secrets.
+
+Preferred example: environment variables
+
+```bash
+export TF_VAR_opensearch_url='https://your-cluster.example.com:9200'
+export TF_VAR_opensearch_username='admin'
+export TF_VAR_opensearch_password='myStrongPassword123!'
+
+terraform plan
+```
+
+Example `terraform.tfvars`:
+
+```hcl
+opensearch_url      = "https://your-cluster.example.com:9200"
+opensearch_username = "admin"
+opensearch_password = "myStrongPassword123!"
+```
+
+Example CLI flags:
+
+```bash
+terraform plan \
+  -var='opensearch_url=https://your-cluster.example.com:9200' \
+  -var='opensearch_username=admin' \
+  -var='opensearch_password=myStrongPassword123!'
+```
+
+Avoid `-var` for passwords in production when possible, since command-line arguments can leak into shell history or CI logs.
+
+If you use `terraform.tfvars`, make sure it is excluded from version control.
+
+Important: this configuration currently stores connection settings in `null_resource` triggers so the destroy-time provisioner can stop the detector job. That means credentials may still be written to Terraform state even when provided via `TF_VAR_...` environment variables.
 
 Common detector variables:
 

--- a/scripts/terraform/README.md
+++ b/scripts/terraform/README.md
@@ -1,0 +1,107 @@
+# OpenSearch Anomaly Detection with Terraform
+
+## Purpose
+
+This project uses Terraform to manage an OpenSearch Anomaly Detection detector and its job lifecycle.
+
+It does two things:
+
+- Creates or updates a detector via `opensearch_anomaly_detection`.
+- Automatically stops and restarts the detector job on apply (and stops it on destroy) using `null_resource` + `local-exec` calls to the OpenSearch AD APIs.
+
+## What This Configuration Creates
+
+- 1 anomaly detector with:
+  - configurable index pattern (`indices`)
+  - configurable time field (`time_field`)
+  - one feature using `max(<feature_field>)`
+  - configurable detection interval and window delay
+  - configurable result index
+- Output:
+  - `detector_id`
+
+## Prerequisites
+
+- Terraform `>= 1.5.0`
+- OpenSearch cluster reachable from your machine
+- OpenSearch Anomaly Detection plugin/API available
+- `curl` installed (used by `local-exec` provisioners)
+
+## Configuration
+
+Defaults in [`main.tf`](main.tf) target local development:
+
+- `opensearch_url = "http://localhost:9200"`
+- `opensearch_username = ""`
+- `opensearch_password = ""`
+
+You can change `opensearch_url` to your remote OpenSearch endpoint, for example `https://your-cluster.example.com:9200`.
+
+If your cluster has security enabled, set username/password via `terraform.tfvars` or CLI flags.
+
+Common detector variables:
+
+- `detector_name`
+- `indices`
+- `time_field`
+- `feature_field`
+- `detection_interval_minutes`
+- `window_delay_minutes`
+- `result_index`
+
+## How To Use
+
+1. Initialize providers:
+
+```bash
+terraform init
+```
+
+2. (Optional) Create `terraform.tfvars`:
+
+```hcl
+opensearch_url      = "http://localhost:9200"
+opensearch_username = ""
+opensearch_password = ""
+
+detector_name                = "tf-detector"
+indices                      = ["server-metrics"]
+time_field                   = "@timestamp"
+feature_field                = "deny"
+detection_interval_minutes   = 1
+window_delay_minutes         = 1
+result_index                 = "opensearch-ad-plugin-result-tf"
+```
+
+3. Review the plan:
+
+```bash
+terraform plan
+```
+
+4. Apply:
+
+```bash
+terraform apply
+```
+
+5. Get the detector ID:
+
+```bash
+terraform output detector_id
+```
+
+## Destroy
+
+To remove resources:
+
+```bash
+terraform destroy
+```
+
+The configuration attempts to stop the detector job before deletion.
+
+## Notes
+
+- `null_resource.start_detector_job` is trigger-based and re-runs when detector config or connection settings change.
+- Credentials are optional for unsecured local clusters; provide them for secured clusters.

--- a/scripts/terraform/main.tf
+++ b/scripts/terraform/main.tf
@@ -1,0 +1,198 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = "~> 2.3.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+############################
+# Connection (localhost)
+############################
+variable "opensearch_url" {
+  type    = string
+  default = "http://localhost:9200"
+}
+
+# Leave these empty if your local cluster has security disabled.
+variable "opensearch_username" {
+  type    = string
+  default = "" # e.g., "admin"
+}
+
+variable "opensearch_password" {
+  type      = string
+  default   = "" # e.g., "admin" or your configured password
+  sensitive = true
+}
+
+provider "opensearch" {
+  url      = var.opensearch_url
+  username = var.opensearch_username
+  password = var.opensearch_password
+}
+
+############################
+# Detector config
+############################
+variable "detector_name" {
+  type    = string
+  default = "tf-detector"
+}
+
+variable "indices" {
+  type    = list(string)
+  default = ["server-metrics"] # <-- change to your index / pattern
+}
+
+variable "time_field" {
+  type    = string
+  default = "@timestamp" # <-- change to your time field
+}
+
+variable "feature_field" {
+  type    = string
+  default = "deny" # <-- change to your numeric field
+}
+
+variable "detection_interval_minutes" {
+  type    = number
+  default = 1
+}
+
+variable "window_delay_minutes" {
+  type    = number
+  default = 1
+}
+
+variable "result_index" {
+  type    = string
+  default = "opensearch-ad-plugin-result-tf"
+}
+
+locals {
+  detector_body = {
+    name        = var.detector_name
+    description = "Detector created by Terraform"
+    time_field  = var.time_field
+    indices     = var.indices
+
+    feature_attributes = [
+      {
+        feature_name    = "feature_1"
+        feature_enabled = true
+        aggregation_query = {
+          feature_1 = {
+            max = { field = var.feature_field }
+          }
+        }
+      }
+    ]
+
+    detection_interval = {
+      period = {
+        interval = var.detection_interval_minutes
+        unit     = "Minutes"
+      }
+    }
+
+    window_delay = {
+      period = {
+        interval = var.window_delay_minutes
+        unit     = "Minutes"
+      }
+    }
+
+    result_index = var.result_index
+  }
+
+  detector_body_json = jsonencode(local.detector_body)
+  detector_body_sha  = sha256(local.detector_body_json)
+}
+
+resource "opensearch_anomaly_detection" "detector" {
+  body = local.detector_body_json
+}
+
+############################
+# Start / stop the job
+############################
+resource "null_resource" "start_detector_job" {
+  # Re-run if the detector is recreated OR its config changes.
+  triggers = {
+    detector_id       = opensearch_anomaly_detection.detector.id
+    detector_body_sha = local.detector_body_sha
+    opensearch_url    = var.opensearch_url
+    opensearch_user   = var.opensearch_username
+    opensearch_pass   = var.opensearch_password
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      OPENSEARCH_URL      = var.opensearch_url
+      OPENSEARCH_USERNAME = var.opensearch_username
+      OPENSEARCH_PASSWORD = var.opensearch_password
+      DETECTOR_ID         = self.triggers.detector_id
+    }
+
+    command = <<EOT
+set -eo pipefail
+
+# Make apply idempotent across re-runs/config updates:
+if [ -n "$OPENSEARCH_USERNAME" ] || [ -n "$OPENSEARCH_PASSWORD" ]; then
+  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_stop" \
+    -H 'Content-Type: application/json' \
+    --user "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" >/dev/null || true
+
+  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_start" \
+    -H 'Content-Type: application/json' \
+    --user "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" >/dev/null
+else
+  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_stop" \
+    -H 'Content-Type: application/json' >/dev/null || true
+
+  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_start" \
+    -H 'Content-Type: application/json' >/dev/null
+fi
+EOT
+  }
+
+  # Stop before the detector is deleted (destroy order is reverse of depends_on).
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      OPENSEARCH_URL      = self.triggers.opensearch_url
+      OPENSEARCH_USERNAME = self.triggers.opensearch_user
+      OPENSEARCH_PASSWORD = self.triggers.opensearch_pass
+      DETECTOR_ID         = self.triggers.detector_id
+    }
+
+    command = <<EOT
+set -eo pipefail
+
+if [ -n "$OPENSEARCH_USERNAME" ] || [ -n "$OPENSEARCH_PASSWORD" ]; then
+  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_stop" \
+    -H 'Content-Type: application/json' \
+    --user "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" >/dev/null || true
+else
+  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_stop" \
+    -H 'Content-Type: application/json' >/dev/null || true
+fi
+EOT
+  }
+
+  depends_on = [opensearch_anomaly_detection.detector]
+}
+
+output "detector_id" {
+  value = opensearch_anomaly_detection.detector.id
+}

--- a/scripts/terraform/main.tf
+++ b/scripts/terraform/main.tf
@@ -152,14 +152,14 @@ if [ -n "$OPENSEARCH_USERNAME" ] || [ -n "$OPENSEARCH_PASSWORD" ]; then
     -H 'Content-Type: application/json' \
     --user "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" >/dev/null || true
 
-  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_start" \
+  curl -sSf -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_start" \
     -H 'Content-Type: application/json' \
     --user "$OPENSEARCH_USERNAME:$OPENSEARCH_PASSWORD" >/dev/null
 else
   curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_stop" \
     -H 'Content-Type: application/json' >/dev/null || true
 
-  curl -sS -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_start" \
+  curl -sSf -XPOST "$OPENSEARCH_URL/_plugins/_anomaly_detection/detectors/$DETECTOR_ID/_start" \
     -H 'Content-Type: application/json' >/dev/null
 fi
 EOT

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -199,9 +200,9 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             detectorId,
             RequestPriority.MEDIUM,
             new double[] { 0 },
-            // important: use time relative to the model's last input timestamp so that the time
-            // gap is not too large and won't trigger cold start.
-            ModelUtil.getLastInputTimestampSeconds(state.getModel().get()) * 1000,
+            // Align with both model state and queued checkpoint samples to avoid duplicate
+            // second-level timestamps when scoring.
+            getSafeDataStartTimeMillis(state),
             entity,
             null
         );
@@ -211,9 +212,9 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             detectorId,
             RequestPriority.MEDIUM,
             new double[] { 0 },
-            // important: use time relative to the model's last input timestamp so that the time
-            // gap is not too large and won't trigger cold start.
-            ModelUtil.getLastInputTimestampSeconds(state.getModel().get()) * 1000,
+            // Align with both model state and queued checkpoint samples to avoid duplicate
+            // second-level timestamps when scoring.
+            getSafeDataStartTimeMillis(state),
             entity2,
             null
         );
@@ -223,12 +224,23 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             detectorId,
             RequestPriority.MEDIUM,
             new double[] { 0 },
-            // important: use time relative to the model's last input timestamp so that the time
-            // gap is not too large and won't trigger cold start.
-            ModelUtil.getLastInputTimestampSeconds(state.getModel().get()) * 1000,
+            // Align with both model state and queued checkpoint samples to avoid duplicate
+            // second-level timestamps when scoring.
+            getSafeDataStartTimeMillis(state),
             entity3,
             null
         );
+    }
+
+    private long getSafeDataStartTimeMillis(ModelState<ThresholdedRandomCutForest> modelState) {
+        long lastInputTimestampMillis = modelState.getModel().map(ModelUtil::getLastInputTimestampSeconds).orElse(0L) * 1000;
+
+        Deque<org.opensearch.timeseries.ml.Sample> samples = modelState.getSamples();
+        long lastQueuedDataEndTimeMillis = samples == null || samples.isEmpty()
+            ? Long.MIN_VALUE
+            : samples.peekLast().getDataEndTime().toEpochMilli();
+
+        return Math.max(lastInputTimestampMillis, lastQueuedDataEndTimeMillis);
     }
 
     static class RegularSetUpConfig {
@@ -289,14 +301,17 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         List<FeatureRequest> requests = new ArrayList<>();
 
         if (!config.fullModel) {
+            long dataStartTimeMillis = state.getSamples().isEmpty()
+                ? clock.millis()
+                : state.getSamples().peekLast().getDataStartTime().toEpochMilli();
             request = new FeatureRequest(
                 clock.millis() + TimeUnit.MINUTES.toMillis(10),
                 detectorId,
                 RequestPriority.MEDIUM,
                 new double[] { 0 },
-                // align model's last input timestamp with the request time so RealTimeInferencer processes
-                // the queued sample instead of triggering cold start due to a large time gap.
-                state.getSamples().peekLast().getDataStartTime().toEpochMilli(),
+                // align request time with queued samples when present; fallback avoids flaky NPE
+                // when random test setup creates an empty sample queue.
+                dataStartTimeMillis,
                 entity,
                 null
             );
@@ -306,7 +321,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
                 detectorId,
                 RequestPriority.MEDIUM,
                 new double[] { 0 },
-                ModelUtil.getLastInputTimestampSeconds(state.getModel().get()) * 1000,
+                getSafeDataStartTimeMillis(state),
                 entity,
                 null
             );
@@ -794,9 +809,9 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             detectorId2,
             RequestPriority.MEDIUM,
             new double[] { 0 },
-            // important: use time relative to the model's last input timestamp so that the time
-            // gap is not too large and won't trigger cold start.
-            ModelUtil.getLastInputTimestampSeconds(state.getModel().get()) * 1000,
+            // Align with both model state and queued checkpoint samples to avoid duplicate
+            // second-level timestamps when scoring.
+            getSafeDataStartTimeMillis(state),
             entity4,
             null
         );
@@ -887,7 +902,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
             detectorId,
             RequestPriority.MEDIUM,
             new double[] { 0 },
-            ModelUtil.getLastInputTimestampSeconds(state.getModel().get()) * 1000,
+            getSafeDataStartTimeMillis(state),
             entity,
             null
         );

--- a/src/test/java/org/opensearch/timeseries/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/org/opensearch/timeseries/transport/AnomalyDetectorJobTransportActionTests.java
@@ -185,7 +185,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalAnalysisIn
         }
     }
 
-    public void testStartHistoricalAnalysisForMultiCategoryHCWithUser() throws IOException, InterruptedException {
+    public void testStartHistoricalAnalysisForMultiCategoryHCWithUser() throws Exception {
         ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type + "1", DEFAULT_IP, 2000, false);
         ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type + "2", DEFAULT_IP, 2000, false);
         ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type + "3", "127.0.0.2", 2000, false);
@@ -207,14 +207,13 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalAnalysisIn
             JobResponse response = nodeClient.execute(MockAnomalyDetectorJobAction.INSTANCE, request).actionGet(100_000);
             String taskId = response.getId();
 
-            waitUntil(() -> {
-                try {
-                    ADTask task = getADTask(taskId);
-                    return HISTORICAL_ANALYSIS_FINISHED_FAILED_STATS.contains(task.getState());
-                } catch (IOException e) {
-                    return false;
-                }
-            }, 90, TimeUnit.SECONDS);
+            assertBusy(() -> {
+                ADTask task = getADTask(taskId);
+                assertTrue(
+                    "Historical task [" + taskId + "] should finish or fail, but current state is [" + task.getState() + "]",
+                    HISTORICAL_ANALYSIS_FINISHED_FAILED_STATS.contains(task.getState())
+                );
+            }, 3, TimeUnit.MINUTES);
             ADTask adTask = getADTask(taskId);
             assertEquals(ADTaskType.HISTORICAL_HC_DETECTOR.toString(), adTask.getTaskType());
             // Task may fail if memory circuit breaker triggered


### PR DESCRIPTION
### Description
- add scripts/terraform/main.tf to configure OpenSearch provider and detector variables
- create detector via opensearch_anomaly_detection and output detector_id
- add local-exec start/stop hooks to make detector job handling idempotent on apply/destroy
- add scripts/terraform/README.md with prerequisites, configuration, and usage steps

Testing done:
- Verified Terraform can create and start the detector.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
