### PR TITLE
Clean up CI: remove redundant Gradle tasks, fix fail-fast consistency

### DIFF
--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -28,6 +28,7 @@ jobs:
   Build-ad-windows:
     needs: spotless
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
     name: Build and Test Anomaly Detection Plugin on Windows
@@ -46,9 +47,6 @@ jobs:
       - name: Build and Run Tests
         run: |
           ./gradlew build -x spotlessJava
-      - name: Publish to Maven Local
-        run: |
-          ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
           ./gradlew integTest -PnumNodes=3
@@ -83,12 +81,10 @@ jobs:
       - name: Checkout AD
         uses: actions/checkout@v6
 
-      - name: Assemble / build / mavenlocal / integTest
+      - name: Build and Run Tests
         run: |
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./gradlew assemble &&
-                               ./gradlew build -x spotlessJava &&
-                               ./gradlew publishToMavenLocal &&
+          su `id -un 1000` -c "./gradlew build -x spotlessJava &&
                                ./gradlew integTest -PnumNodes=3"
 
   Build-ad-macos:
@@ -113,9 +109,6 @@ jobs:
       - name: Checkout AD
         uses: actions/checkout@v6
 
-      - name: Assemble anomaly-detection
-        run: |
-          ./gradlew assemble
       - name: Build and Run Tests
         run: |
           ./gradlew build -x spotlessJava
@@ -168,9 +161,6 @@ jobs:
           files: ./build/reports/jacoco/integTest/jacocoIntegTestReport.xml
           disable_search: true
           flags: plugin_integtest
-      - name: Publish to Maven Local
-        run: |
-          ./gradlew publishToMavenLocal
       - name: Multi Nodes Integration Testing
         run: |
           ./gradlew integTest -PnumNodes=3

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -22,6 +22,7 @@ jobs:
       options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     strategy:
+      fail-fast: false
       matrix:
         # empty string = disabled, flag = enabled
         resource_sharing_flag: ["", "-Dresource_sharing.enabled=true"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 ### Infrastructure
 - Add integTest coverage reporting and README badge ([1679](https://github.com/opensearch-project/anomaly-detection/pull/1679))
+- Clean up CI: remove redundant Gradle tasks, fix fail-fast consistency ([#1693](https://github.com/opensearch-project/anomaly-detection/pull/1693))
 
 ### Documentation
 ### Maintenance


### PR DESCRIPTION
### Description

Removes redundant Gradle tasks and fixes inconsistent `fail-fast` settings across CI workflows.

### Changes

**Remove redundant Gradle tasks** (`test_build_multi_platform.yml`):
- Remove `./gradlew assemble` on Linux and macOS — `build` already includes `assemble` as a dependency
- Remove `./gradlew publishToMavenLocal` on all 3 OSes — no downstream job consumes the artifacts; integ tests use the zip from `build/distributions/` directly

**Fix `fail-fast` consistency**:
- Add `fail-fast: false` to Windows matrix in `test_build_multi_platform.yml` — Linux and macOS already had it
- Add `fail-fast: false` to security test matrix in `test_security.yml`

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).