### PR TITLE
Fix CVE-2026-25645: Bump requests from >=2.32.4 to >=2.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
+### Security
+- Bump requests from >=2.32.4 to >=2.33.0 to address CVE-2026-25645 ([#1713](https://github.com/opensearch-project/anomaly-detection/pull/1713))
 ### Refactoring

--- a/dataGeneration/requirements.txt
+++ b/dataGeneration/requirements.txt
@@ -1,5 +1,5 @@
-# indirect dependency of opensearch_py. Lower than 2.30 can cause CVE-2024-35195.
-requests>=2.32.4
+# indirect dependency of opensearch_py. Lower than 2.33 can cause CVE-2026-25645.
+requests>=2.33.0
 numpy==1.26.4
 opensearch_py==3.1.0
 retry2==0.9.2


### PR DESCRIPTION
### Description
Addresses CVE-2026-25645 by upgrading the `requests` dependency minimum version.

### Issues Resolved
- CVE-2026-25645: requests <2.33.0 path traversal in `extract_zipped_paths()` ([advisory](https://nvd.nist.gov/vuln/detail/CVE-2026-25645))

### Remediation Details
| CVE | Package | Old Version | New Version | Method |
|-----|---------|-------------|-------------|--------|
| CVE-2026-25645 | requests | >=2.32.4 | >=2.33.0 | Direct version bump |

### Testing
- [x] Change is in `dataGeneration/requirements.txt` (test utility, not runtime)
- [x] No build/test impact — this file is not used by Gradle build

### Risk
Low — only affects a data generation utility script, not the plugin runtime.