### PR TITLE
Add runtime support for Prometheus and PPL-backed detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 3.x](https://github.com/opensearch-project/anomaly-detection/compare/3.6...HEAD)
 
 ### Features
+- Add Prometheus-backed detector execution, preview support, and datasource auth handling ([1669] (https://github.com/opensearch-project/anomaly-detection/pull/1699))
+
 ### Enhancements
 - feat(terraform): add AD detector provisioning and lifecycle automation ([1680](https://github.com/opensearch-project/anomaly-detection/pull/1680))
 - Support Jackson 3.x release line ([1701](https://github.com/opensearch-project/anomaly-detection/issues/1701))

--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,7 @@ dependencies {
 
     opensearchPlugin "org.opensearch.plugin:opensearch-job-scheduler:${opensearch_build}@zip"
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${opensearch_build}@zip"
+    opensearchPlugin "org.opensearch.plugin:opensearch-sql-plugin:${opensearch_build}@zip"
     testImplementation 'org.reflections:reflections:0.10.2'
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -473,6 +474,7 @@ ext.resolvePluginFile = { pluginId ->
 }
 def jobSchedulerFile = resolvePluginFile("opensearch-job-scheduler")
 def securityPluginFile = resolvePluginFile("opensearch-security")
+def sqlPluginFile = resolvePluginFile("opensearch-sql-plugin")
 
 // === Setup security test ===
 // This flag indicates the existence of security plugin
@@ -483,6 +485,7 @@ testClusters.integTest {
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
     configureClusterPlugins(delegate, jobSchedulerFile, securityPluginFile, securityEnabled)
+    plugin(provider(sqlPluginFile))
     nodes.each { it.jvmArgs("-Xms1g", "-Xmx1g") }
 }
 

--- a/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorRunner.java
@@ -72,6 +72,17 @@ public final class AnomalyDetectorRunner {
         ThreadContext.StoredContext context,
         ActionListener<List<AnomalyResult>> listener
     ) throws IOException {
+        executeDetector(detector, startTime, endTime, context, null, listener);
+    }
+
+    public void executeDetector(
+        AnomalyDetector detector,
+        Instant startTime,
+        Instant endTime,
+        ThreadContext.StoredContext context,
+        Integer minPreviewSize,
+        ActionListener<List<AnomalyResult>> listener
+    ) throws IOException {
         context.restore();
         List<String> categoryField = detector.getCategoryFields();
         if (categoryField != null && !categoryField.isEmpty()) {
@@ -102,7 +113,9 @@ public final class AnomalyDetectorRunner {
                             startTime.toEpochMilli(),
                             endTime.toEpochMilli(),
                             ActionListener.wrap(features -> {
-                                List<ThresholdingResult> entityResults = modelManager.getPreviewResults(features, detector);
+                                List<ThresholdingResult> entityResults = minPreviewSize == null
+                                    ? modelManager.getPreviewResults(features, detector)
+                                    : modelManager.getPreviewResults(features, detector, minPreviewSize);
                                 List<AnomalyResult> sampledEntityResults = sample(
                                     parsePreviewResult(detector, features, entityResults, entity),
                                     maxPreviewResults
@@ -115,7 +128,9 @@ public final class AnomalyDetectorRunner {
         } else {
             featureManager.getPreviewFeatures(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(features -> {
                 try {
-                    List<ThresholdingResult> results = modelManager.getPreviewResults(features, detector);
+                    List<ThresholdingResult> results = minPreviewSize == null
+                        ? modelManager.getPreviewResults(features, detector)
+                        : modelManager.getPreviewResults(features, detector, minPreviewSize);
                     listener.onResponse(sample(parsePreviewResult(detector, features, results, null), maxPreviewResults));
                 } catch (Exception e) {
                     onFailure(e, listener, detector.getId());

--- a/src/main/java/org/opensearch/ad/ml/ADModelManager.java
+++ b/src/main/java/org/opensearch/ad/ml/ADModelManager.java
@@ -465,9 +465,22 @@ public class ADModelManager extends
      * @throws IllegalArgumentException when preview data points are not valid
      */
     public List<ThresholdingResult> getPreviewResults(Features features, AnomalyDetector detector) {
+        return getPreviewResults(features, detector, null);
+    }
+
+    /**
+     * Returns computed anomaly results for preview data points.
+     *
+     * @param features features of preview data points
+     * @param detector Anomaly detector
+     * @param minPreviewSizeOverride optional request-scoped minimum preview size override
+     * @throws IllegalArgumentException when preview data points are not valid
+     */
+    public List<ThresholdingResult> getPreviewResults(Features features, AnomalyDetector detector, Integer minPreviewSizeOverride) {
         double[][] dataPoints = features.getUnprocessedFeatures();
-        if (dataPoints.length < minPreviewSize) {
-            throw new IllegalArgumentException("Insufficient data for preview results. Minimum required: " + minPreviewSize);
+        int effectiveMinPreviewSize = minPreviewSizeOverride == null ? minPreviewSize : minPreviewSizeOverride;
+        if (dataPoints.length < effectiveMinPreviewSize) {
+            throw new IllegalArgumentException("Insufficient data for preview results. Minimum required: " + effectiveMinPreviewSize);
         }
         List<Entry<Long, Long>> timeRanges = features.getTimeRanges();
         if (timeRanges.size() != dataPoints.length) {

--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -348,7 +348,10 @@ public class ADTask extends TimeSeriesTask {
                 detector.getFlattenResultIndexMapping(),
                 detector.getLastBreakingUIChangeTime(),
                 detector.getFrequency(),
-                detector.getAutoCreated()
+                detector.getAutoCreated(),
+                detector.getSourceType(),
+                detector.getPrometheusSource(),
+                detector.getPPLSource()
             );
         return new Builder()
             .taskId(parsedTaskId)

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -51,6 +52,8 @@ import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.DateRange;
 import org.opensearch.timeseries.model.Feature;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.model.PPLSource;
+import org.opensearch.timeseries.model.PrometheusSource;
 import org.opensearch.timeseries.model.ShingleGetter;
 import org.opensearch.timeseries.model.TimeConfiguration;
 import org.opensearch.timeseries.model.ValidationAspect;
@@ -189,6 +192,145 @@ public class AnomalyDetector extends Config {
         TimeConfiguration frequency,
         Boolean autoCreated
     ) {
+        this(
+            detectorId,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            detectionInterval,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            categoryFields,
+            user,
+            resultIndex,
+            imputationOption,
+            recencyEmphasis,
+            seasonIntervals,
+            historyIntervals,
+            rules,
+            customResultIndexMinSize,
+            customResultIndexMinAge,
+            customResultIndexTTL,
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime,
+            frequency,
+            autoCreated,
+            null,
+            null,
+            null
+        );
+    }
+
+    public AnomalyDetector(
+        String detectorId,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration detectionInterval,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime,
+        List<String> categoryFields,
+        User user,
+        String resultIndex,
+        ImputationOption imputationOption,
+        Integer recencyEmphasis,
+        Integer seasonIntervals,
+        Integer historyIntervals,
+        List<Rule> rules,
+        Integer customResultIndexMinSize,
+        Integer customResultIndexMinAge,
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime,
+        TimeConfiguration frequency,
+        Boolean autoCreated,
+        String sourceType,
+        PrometheusSource prometheusSource
+    ) {
+        this(
+            detectorId,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            detectionInterval,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            categoryFields,
+            user,
+            resultIndex,
+            imputationOption,
+            recencyEmphasis,
+            seasonIntervals,
+            historyIntervals,
+            rules,
+            customResultIndexMinSize,
+            customResultIndexMinAge,
+            customResultIndexTTL,
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime,
+            frequency,
+            autoCreated,
+            sourceType,
+            prometheusSource,
+            null
+        );
+    }
+
+    public AnomalyDetector(
+        String detectorId,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration detectionInterval,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime,
+        List<String> categoryFields,
+        User user,
+        String resultIndex,
+        ImputationOption imputationOption,
+        Integer recencyEmphasis,
+        Integer seasonIntervals,
+        Integer historyIntervals,
+        List<Rule> rules,
+        Integer customResultIndexMinSize,
+        Integer customResultIndexMinAge,
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime,
+        TimeConfiguration frequency,
+        Boolean autoCreated,
+        String sourceType,
+        PrometheusSource prometheusSource,
+        PPLSource pplSource
+    ) {
         super(
             detectorId,
             version,
@@ -206,7 +348,7 @@ public class AnomalyDetector extends Config {
             categoryFields,
             user,
             resultIndex,
-            detectionInterval,
+            resolveDetectionInterval(detectionInterval, sourceType, pplSource),
             imputationOption,
             recencyEmphasis,
             seasonIntervals,
@@ -218,15 +360,32 @@ public class AnomalyDetector extends Config {
             flattenResultIndexMapping,
             lastBreakingUIChangeTime,
             frequency,
-            autoCreated
+            autoCreated,
+            sourceType,
+            prometheusSource,
+            pplSource
         );
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
 
-        if (detectionInterval == null) {
+        if (isPPLSourceConfig(this.sourceType, this.pplSource) && detectionInterval != null) {
+            IntervalTimeConfiguration pplInterval = getCompiledPPLInterval(this.pplSource);
+            if (pplInterval != null && !sameDuration(detectionInterval, pplInterval)) {
+                errorMessage = String
+                    .format(
+                        Locale.ROOT,
+                        "detection_interval must match ppl_source span interval (%s) when source_type is PPL.",
+                        pplInterval
+                    );
+                issueType = ValidationIssueType.DETECTION_INTERVAL;
+            }
+        }
+
+        TimeConfiguration resolvedDetectionInterval = this.interval;
+        if (resolvedDetectionInterval == null) {
             errorMessage = ADCommonMessages.NULL_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;
-        } else if (((IntervalTimeConfiguration) detectionInterval).getInterval() <= 0) {
+        } else if (((IntervalTimeConfiguration) resolvedDetectionInterval).getInterval() <= 0) {
             errorMessage = ADCommonMessages.INVALID_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;
         }
@@ -236,8 +395,7 @@ public class AnomalyDetector extends Config {
             errorMessage = CommonMessages.getTooManyCategoricalFieldErr(maxCategoryFields);
             issueType = ValidationIssueType.CATEGORY;
         }
-
-        validateRules(features, rules);
+        validateRules(featureAttributes, rules);
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
 
@@ -305,6 +463,26 @@ public class AnomalyDetector extends Config {
             this.frequency = null;
         }
         this.autoCreated = input.readOptionalBoolean();
+        if (input.available() > 0) {
+            this.sourceType = normalizeSerializedSourceType(input.readOptionalString());
+        } else {
+            this.sourceType = SOURCE_TYPE_OPENSEARCH;
+        }
+        if (this.sourceType == null) {
+            this.sourceType = SOURCE_TYPE_OPENSEARCH;
+        }
+        if (input.available() > 0 && input.readBoolean()) {
+            this.prometheusSource = new PrometheusSource(input);
+            this.sourceType = SOURCE_TYPE_PROMETHEUS;
+        } else {
+            this.prometheusSource = null;
+        }
+        if (input.available() > 0 && input.readBoolean()) {
+            this.pplSource = new PPLSource(input);
+            this.sourceType = SOURCE_TYPE_PPL;
+        } else {
+            this.pplSource = null;
+        }
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -379,6 +557,19 @@ public class AnomalyDetector extends Config {
             output.writeBoolean(false);
         }
         output.writeOptionalBoolean(autoCreated);
+        output.writeOptionalString(sourceType);
+        if (prometheusSource != null) {
+            output.writeBoolean(true);
+            prometheusSource.writeTo(output);
+        } else {
+            output.writeBoolean(false);
+        }
+        if (pplSource != null) {
+            output.writeBoolean(true);
+            pplSource.writeTo(output);
+        } else {
+            output.writeBoolean(false);
+        }
     }
 
     @Override
@@ -453,6 +644,7 @@ public class AnomalyDetector extends Config {
         TimeConfiguration detectionInterval = defaultDetectionInterval == null
             ? null
             : new IntervalTimeConfiguration(defaultDetectionInterval.getMinutes(), ChronoUnit.MINUTES);
+        boolean detectionIntervalProvided = false;
         TimeConfiguration windowDelay = defaultDetectionWindowDelay == null
             ? null
             : new IntervalTimeConfiguration(defaultDetectionWindowDelay.getSeconds(), ChronoUnit.SECONDS);
@@ -479,6 +671,9 @@ public class AnomalyDetector extends Config {
         // by default, frequency is the same as interval when not set
         TimeConfiguration frequency = null;
         Boolean autoCreated = null;
+        String sourceType = null;
+        PrometheusSource prometheusSource = null;
+        PPLSource pplSource = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -526,6 +721,7 @@ public class AnomalyDetector extends Config {
                 case DETECTION_INTERVAL_FIELD:
                     try {
                         detectionInterval = TimeConfiguration.parse(parser);
+                        detectionIntervalProvided = true;
                     } catch (Exception e) {
                         if (e instanceof IllegalArgumentException && e.getMessage().contains(CommonMessages.NEGATIVE_TIME_CONFIGURATION)) {
                             throw new ValidationException(
@@ -636,10 +832,23 @@ public class AnomalyDetector extends Config {
                 case AUTO_CREATED_FIELD:
                     autoCreated = onlyParseBooleanValue(parser);
                     break;
+                case SOURCE_TYPE_FIELD:
+                    sourceType = parser.textOrNull();
+                    break;
+                case PROMETHEUS_SOURCE_FIELD:
+                    prometheusSource = PrometheusSource.parse(parser);
+                    break;
+                case PPL_SOURCE_FIELD:
+                    pplSource = PPLSource.parse(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
+        }
+
+        if (isPPLSourceConfig(sourceType, pplSource) && !detectionIntervalProvided) {
+            detectionInterval = null;
         }
 
         AnomalyDetector detector = new AnomalyDetector(
@@ -671,10 +880,57 @@ public class AnomalyDetector extends Config {
             flattenResultIndexMapping,
             lastBreakingUIChangeTime,
             frequency,
-            autoCreated
+            autoCreated,
+            sourceType,
+            prometheusSource,
+            pplSource
         );
         detector.setDetectionDateRange(detectionDateRange);
         return detector;
+    }
+
+    private static TimeConfiguration resolveDetectionInterval(TimeConfiguration detectionInterval, String sourceType, PPLSource pplSource) {
+        if (detectionInterval != null || !isPPLSourceConfig(sourceType, pplSource)) {
+            return detectionInterval;
+        }
+
+        IntervalTimeConfiguration compiledInterval = getCompiledPPLInterval(pplSource);
+        return compiledInterval == null ? detectionInterval : compiledInterval;
+    }
+
+    private static IntervalTimeConfiguration getCompiledPPLInterval(PPLSource pplSource) {
+        if (pplSource == null) {
+            return null;
+        }
+
+        try {
+            return pplSource.compile().getInterval();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static boolean sameDuration(TimeConfiguration left, IntervalTimeConfiguration right) {
+        if (!(left instanceof IntervalTimeConfiguration) || right == null) {
+            return false;
+        }
+        return ((IntervalTimeConfiguration) left).toDuration().equals(right.toDuration());
+    }
+
+    private static boolean isPPLSourceConfig(String sourceType, PPLSource pplSource) {
+        String normalizedSourceType = normalizeSerializedSourceType(sourceType);
+        if (pplSource != null && normalizedSourceType == null) {
+            return true;
+        }
+        return SOURCE_TYPE_PPL.equals(normalizedSourceType);
+    }
+
+    private static String normalizeSerializedSourceType(String sourceType) {
+        if (sourceType == null) {
+            return null;
+        }
+        String normalized = sourceType.trim();
+        return normalized.isEmpty() ? null : normalized.toUpperCase(Locale.ROOT);
     }
 
     public String getDetectorType() {

--- a/src/main/java/org/opensearch/ad/rest/RestPreviewAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestPreviewAnomalyDetectorAction.java
@@ -15,8 +15,10 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.timeseries.util.RestHandlerUtils.PREVIEW;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -24,8 +26,10 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
 import org.opensearch.ad.settings.ADEnabledSetting;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
 import org.opensearch.ad.transport.PreviewAnomalyDetectorAction;
 import org.opensearch.ad.transport.PreviewAnomalyDetectorRequest;
+import org.opensearch.ad.transport.PreviewAnomalyDetectorTransportAction;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
@@ -53,6 +57,13 @@ public class RestPreviewAnomalyDetectorAction extends BaseRestHandler {
     }
 
     @Override
+    protected Set<String> responseParams() {
+        Set<String> responseParams = new HashSet<>(super.responseParams());
+        responseParams.add(PreviewAnomalyDetectorTransportAction.MIN_PREVIEW_SIZE_PARAM);
+        return responseParams;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, org.opensearch.transport.client.node.NodeClient client)
         throws IOException {
         if (!ADEnabledSetting.isADEnabled()) {
@@ -60,19 +71,29 @@ public class RestPreviewAnomalyDetectorAction extends BaseRestHandler {
         }
 
         AnomalyDetectorExecutionInput input = getConfigExecutionInput(request);
+        Integer minPreviewSize = request.hasParam(PreviewAnomalyDetectorTransportAction.MIN_PREVIEW_SIZE_PARAM)
+            ? request.paramAsInt(PreviewAnomalyDetectorTransportAction.MIN_PREVIEW_SIZE_PARAM, AnomalyDetectorSettings.MIN_PREVIEW_SIZE)
+            : null;
 
         return channel -> {
-            String rawPath = request.rawPath();
             String error = validateAdExecutionInput(input);
             if (StringUtils.isNotBlank(error)) {
                 channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, error));
+                return;
+            }
+            if (minPreviewSize != null && minPreviewSize <= 0) {
+                channel
+                    .sendResponse(
+                        new BytesRestResponse(RestStatus.BAD_REQUEST, "min_preview_size must be a positive integer when provided")
+                    );
                 return;
             }
             PreviewAnomalyDetectorRequest previewRequest = new PreviewAnomalyDetectorRequest(
                 input.getDetector(),
                 input.getDetectorId(),
                 input.getPeriodStart(),
-                input.getPeriodEnd()
+                input.getPeriodEnd(),
+                minPreviewSize
             );
             client.execute(PreviewAnomalyDetectorAction.INSTANCE, previewRequest, new RestToXContentListener<>(channel));
         };

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -252,7 +252,10 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             config.getFlattenResultIndexMapping(),
             breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime(),
             config.getFrequency(),
-            detector.getAutoCreated()
+            detector.getAutoCreated(),
+            config.getSourceType(),
+            config.getPrometheusSource(),
+            config.getPPLSource()
         );
     }
 

--- a/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/org/opensearch/ad/settings/AnomalyDetectorSettings.java
@@ -614,7 +614,7 @@ public final class AnomalyDetectorSettings {
     // ======================================
     // preview setting
     // ======================================
-    public static final int MIN_PREVIEW_SIZE = 400; // ok to lower
+    public static final int MIN_PREVIEW_SIZE = 400;
 
     public static final double PREVIEW_SAMPLE_RATE = 0.25; // ok to adjust, higher for more data, lower for lower latency
 

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorRequest.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorRequest.java
@@ -29,6 +29,7 @@ public class PreviewAnomalyDetectorRequest extends ActionRequest implements DocR
     private String detectorId;
     private Instant startTime;
     private Instant endTime;
+    private Integer minPreviewSize;
 
     public PreviewAnomalyDetectorRequest(StreamInput in) throws IOException {
         super(in);
@@ -36,15 +37,28 @@ public class PreviewAnomalyDetectorRequest extends ActionRequest implements DocR
         detectorId = in.readOptionalString();
         startTime = in.readInstant();
         endTime = in.readInstant();
+        minPreviewSize = in.readOptionalInt();
     }
 
     public PreviewAnomalyDetectorRequest(AnomalyDetector detector, String detectorId, Instant startTime, Instant endTime)
+        throws IOException {
+        this(detector, detectorId, startTime, endTime, null);
+    }
+
+    public PreviewAnomalyDetectorRequest(
+        AnomalyDetector detector,
+        String detectorId,
+        Instant startTime,
+        Instant endTime,
+        Integer minPreviewSize
+    )
         throws IOException {
         super();
         this.detector = detector;
         this.detectorId = detectorId;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.minPreviewSize = minPreviewSize;
     }
 
     public AnomalyDetector getDetector() {
@@ -63,6 +77,10 @@ public class PreviewAnomalyDetectorRequest extends ActionRequest implements DocR
         return endTime;
     }
 
+    public Integer getMinPreviewSize() {
+        return minPreviewSize;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -70,6 +88,7 @@ public class PreviewAnomalyDetectorRequest extends ActionRequest implements DocR
         out.writeOptionalString(detectorId);
         out.writeInstant(startTime);
         out.writeInstant(endTime);
+        out.writeOptionalInt(minPreviewSize);
     }
 
     @Override

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -62,6 +62,8 @@ import org.opensearch.transport.client.Client;
 
 public class PreviewAnomalyDetectorTransportAction extends
     HandledTransportAction<PreviewAnomalyDetectorRequest, PreviewAnomalyDetectorResponse> {
+    public static final String MIN_PREVIEW_SIZE_PARAM = "min_preview_size";
+
     private final Logger logger = LogManager.getLogger(PreviewAnomalyDetectorTransportAction.class);
     private final AnomalyDetectorRunner anomalyDetectorRunner;
     private final ClusterService clusterService;
@@ -151,6 +153,7 @@ public class PreviewAnomalyDetectorTransportAction extends
                 String detectorId = request.getId();
                 Instant startTime = request.getStartTime();
                 Instant endTime = request.getEndTime();
+                Integer minPreviewSize = request.getMinPreviewSize();
                 ActionListener<PreviewAnomalyDetectorResponse> releaseListener = ActionListener.runAfter(listener, () -> lock.release());
                 if (detector != null) {
                     String error = validateDetector(detector);
@@ -165,10 +168,11 @@ public class PreviewAnomalyDetectorTransportAction extends
                             startTime,
                             endTime,
                             context,
+                            minPreviewSize,
                             getPreviewDetectorActionListener(releaseListener, detector)
                         );
                 } else {
-                    previewAnomalyDetector(releaseListener, detectorId, detector, startTime, endTime, context);
+                    previewAnomalyDetector(releaseListener, detectorId, detector, startTime, endTime, minPreviewSize, context);
                 }
             } catch (Exception e) {
                 logger.error("Fail to preview", e);
@@ -200,6 +204,14 @@ public class PreviewAnomalyDetectorTransportAction extends
             }
         }, exception -> {
             logger.error("Unexpected error running anomaly detector " + detector.getId(), exception);
+            if (exception instanceof OpenSearchStatusException) {
+                listener.onFailure(exception);
+                return;
+            }
+            if (exception instanceof IllegalArgumentException) {
+                listener.onFailure(new OpenSearchStatusException(exception.getMessage(), RestStatus.BAD_REQUEST, exception));
+                return;
+            }
             listener
                 .onFailure(
                     new OpenSearchStatusException(
@@ -216,14 +228,22 @@ public class PreviewAnomalyDetectorTransportAction extends
         AnomalyDetector detector,
         Instant startTime,
         Instant endTime,
+        Integer minPreviewSize,
         ThreadContext.StoredContext context
     ) throws IOException {
         if (!StringUtils.isBlank(detectorId)) {
             GetRequest getRequest = new GetRequest(ADCommonName.CONFIG_INDEX).id(detectorId);
-            client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime, context));
+            client.get(getRequest, onGetAnomalyDetectorResponse(listener, startTime, endTime, minPreviewSize, context));
         } else {
             anomalyDetectorRunner
-                .executeDetector(detector, startTime, endTime, context, getPreviewDetectorActionListener(listener, detector));
+                .executeDetector(
+                    detector,
+                    startTime,
+                    endTime,
+                    context,
+                    minPreviewSize,
+                    getPreviewDetectorActionListener(listener, detector)
+                );
         }
     }
 
@@ -231,6 +251,7 @@ public class PreviewAnomalyDetectorTransportAction extends
         ActionListener<PreviewAnomalyDetectorResponse> listener,
         Instant startTime,
         Instant endTime,
+        Integer minPreviewSize,
         ThreadContext.StoredContext context
     ) {
         return ActionListener.wrap(new CheckedConsumer<GetResponse, Exception>() {
@@ -251,7 +272,14 @@ public class PreviewAnomalyDetectorTransportAction extends
                     AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
                     anomalyDetectorRunner
-                        .executeDetector(detector, startTime, endTime, context, getPreviewDetectorActionListener(listener, detector));
+                        .executeDetector(
+                            detector,
+                            startTime,
+                            endTime,
+                            context,
+                            minPreviewSize,
+                            getPreviewDetectorActionListener(listener, detector)
+                        );
                 } catch (IOException e) {
                     listener.onFailure(e);
                 }

--- a/src/main/java/org/opensearch/forecast/ForecasterRunner.java
+++ b/src/main/java/org/opensearch/forecast/ForecasterRunner.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.forecast.ml.ForecastColdStart;
+import org.opensearch.forecast.model.ForecastResult;
+import org.opensearch.forecast.model.Forecaster;
+import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.feature.FeatureManager;
+import org.opensearch.timeseries.feature.Features;
+import org.opensearch.timeseries.ml.Sample;
+
+/**
+ * Runner to trigger a forecasting preview request.
+ */
+public final class ForecasterRunner {
+
+    private static final Logger logger = LogManager.getLogger(ForecasterRunner.class);
+
+    private final ForecastColdStart forecastColdStart;
+    private final FeatureManager featureManager;
+
+    public ForecasterRunner(ForecastColdStart forecastColdStart, FeatureManager featureManager) {
+        this.forecastColdStart = forecastColdStart;
+        this.featureManager = featureManager;
+    }
+
+    /**
+     * Runs forecasting preview and returns preview forecast results.
+     *
+     * @param forecaster forecaster instance
+     * @param startTime preview period start time
+     * @param endTime preview period end time
+     * @param listener callback with preview forecast results
+     * @throws IOException if feature query cannot be built
+     */
+    public void executeForecaster(Forecaster forecaster, Instant startTime, Instant endTime, ActionListener<List<ForecastResult>> listener)
+        throws IOException {
+        if (forecaster.getCategoryFields() != null && !forecaster.getCategoryFields().isEmpty()) {
+            listener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "Forecast preview does not support high-cardinality forecasters yet.",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            return;
+        }
+
+        featureManager
+            .getPreviewFeatures(
+                forecaster,
+                AnalysisType.FORECAST,
+                startTime.toEpochMilli(),
+                endTime.toEpochMilli(),
+                ActionListener.wrap(features -> {
+                    try {
+                        List<Sample> samples = toSamples(features);
+                        if (samples.isEmpty()) {
+                            listener.onResponse(Collections.emptyList());
+                            return;
+                        }
+
+                        listener.onResponse(forecastColdStart.preview(samples, forecaster));
+                    } catch (Exception e) {
+                        logger.info("Fail to preview forecaster {}", forecaster.getId(), e);
+                        listener.onFailure(e);
+                    }
+                }, listener::onFailure)
+            );
+    }
+
+    private List<Sample> toSamples(Features features) {
+        List<Entry<Long, Long>> timeRanges = features.getTimeRanges();
+        double[][] unprocessedFeatures = features.getUnprocessedFeatures();
+        if (timeRanges == null || unprocessedFeatures == null) {
+            return Collections.emptyList();
+        }
+
+        int sampleSize = Math.min(timeRanges.size(), unprocessedFeatures.length);
+        List<Sample> samples = new ArrayList<>(sampleSize);
+        for (int i = 0; i < sampleSize; i++) {
+            Entry<Long, Long> timeRange = timeRanges.get(i);
+            if (timeRange == null || unprocessedFeatures[i] == null || unprocessedFeatures[i].length == 0) {
+                continue;
+            }
+            samples
+                .add(
+                    new Sample(unprocessedFeatures[i], Instant.ofEpochMilli(timeRange.getKey()), Instant.ofEpochMilli(timeRange.getValue()))
+                );
+        }
+
+        return samples;
+    }
+}

--- a/src/main/java/org/opensearch/forecast/ml/ForecastColdStart.java
+++ b/src/main/java/org/opensearch/forecast/ml/ForecastColdStart.java
@@ -15,6 +15,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,6 +33,7 @@ import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
 import org.opensearch.timeseries.feature.FeatureManager;
 import org.opensearch.timeseries.feature.SearchFeatureDao;
 import org.opensearch.timeseries.ml.ModelColdStart;
+import org.opensearch.timeseries.ml.ModelManager;
 import org.opensearch.timeseries.ml.ModelState;
 import org.opensearch.timeseries.ml.Sample;
 import org.opensearch.timeseries.model.Config;
@@ -208,5 +210,25 @@ public class ForecastColdStart extends ModelColdStart<RCFCaster, ForecastIndex, 
         modelState.setModel(caster);
 
         return res;
+    }
+
+    /**
+     * Runs forecast preview on the provided samples and forecaster without persisting state.
+     *
+     * @param pointSamples sampled points in chronological order
+     * @param forecaster preview forecaster config
+     * @return forecast preview results
+     */
+    public List<ForecastResult> preview(List<Sample> pointSamples, Forecaster forecaster) {
+        String modelId = (forecaster.getId() == null ? "preview" : forecaster.getId()) + "_preview_model";
+        ModelState<RCFCaster> previewState = new ModelState<>(
+            null,
+            modelId,
+            forecaster.getId(),
+            ModelManager.ModelType.RCFCASTER.getName(),
+            clock
+        );
+        List<ForecastResult> previewResults = trainModelFromDataSegments(pointSamples, previewState, forecaster, null);
+        return previewResults == null ? Collections.emptyList() : previewResults;
     }
 }

--- a/src/main/java/org/opensearch/forecast/rest/RestPreviewForecasterAction.java
+++ b/src/main/java/org/opensearch/forecast/rest/RestPreviewForecasterAction.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast.rest;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.timeseries.util.RestHandlerUtils.PREVIEW;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.forecast.constant.ForecastCommonMessages;
+import org.opensearch.forecast.settings.ForecastEnabledSetting;
+import org.opensearch.forecast.transport.PreviewForecasterAction;
+import org.opensearch.forecast.transport.PreviewForecasterRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.transport.client.node.NodeClient;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * REST handler for forecasting preview endpoint.
+ */
+public class RestPreviewForecasterAction extends BaseRestHandler {
+
+    public static final String PREVIEW_FORECASTER_ACTION = "preview_forecaster";
+
+    @Override
+    public String getName() {
+        return PREVIEW_FORECASTER_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList
+            .of(
+                new Route(
+                    RestRequest.Method.POST,
+                    String.format(Locale.ROOT, "%s/%s", TimeSeriesAnalyticsPlugin.FORECAST_FORECASTERS_URI, PREVIEW)
+                )
+            );
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        if (!ForecastEnabledSetting.isForecastEnabled()) {
+            throw new IllegalStateException(ForecastCommonMessages.DISABLED_ERR_MSG);
+        }
+
+        ForecasterExecutionInput input;
+        try {
+            input = getForecasterExecutionInput(request);
+        } catch (IOException e) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, e.getMessage()));
+        }
+
+        String error = validateForecasterExecutionInput(input);
+        if (error != null) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, error));
+        }
+
+        PreviewForecasterRequest previewRequest = new PreviewForecasterRequest(
+            input.getForecaster(),
+            input.getForecasterId(),
+            input.getPeriodStart(),
+            input.getPeriodEnd()
+        );
+
+        return channel -> client.execute(PreviewForecasterAction.INSTANCE, previewRequest, new RestToXContentListener<>(channel));
+    }
+
+    private ForecasterExecutionInput getForecasterExecutionInput(RestRequest request) throws IOException {
+        XContentParser parser = request.contentParser();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        return ForecasterExecutionInput.parse(parser);
+    }
+
+    private String validateForecasterExecutionInput(ForecasterExecutionInput input) {
+        if (input.getPeriodStart() == null || input.getPeriodEnd() == null) {
+            return "Must set both period start and end date with epoch of milliseconds";
+        }
+        if (!input.getPeriodStart().isBefore(input.getPeriodEnd())) {
+            return "Period start date should be before end date";
+        }
+        if (input.getForecasterId() == null && input.getForecaster() == null) {
+            return "Must set forecaster id or forecaster";
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/forecast/transport/PreviewForecasterAction.java
+++ b/src/main/java/org/opensearch/forecast/transport/PreviewForecasterAction.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.forecast.constant.ForecastCommonValue;
+
+public class PreviewForecasterAction extends ActionType<PreviewForecasterResponse> {
+    // External Action which used for public facing RestAPIs.
+    public static final String NAME = ForecastCommonValue.EXTERNAL_ACTION_PREFIX + "forecaster/preview";
+    public static final PreviewForecasterAction INSTANCE = new PreviewForecasterAction();
+
+    private PreviewForecasterAction() {
+        super(NAME, PreviewForecasterResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/forecast/transport/PreviewForecasterRequest.java
+++ b/src/main/java/org/opensearch/forecast/transport/PreviewForecasterRequest.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast.transport;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.forecast.constant.ForecastCommonName;
+import org.opensearch.forecast.indices.ForecastIndex;
+import org.opensearch.forecast.model.Forecaster;
+
+public class PreviewForecasterRequest extends ActionRequest implements DocRequest {
+    private Forecaster forecaster;
+    private String forecasterId;
+    private Instant periodStart;
+    private Instant periodEnd;
+
+    public PreviewForecasterRequest(StreamInput in) throws IOException {
+        super(in);
+        forecaster = in.readOptionalWriteable(Forecaster::new);
+        forecasterId = in.readOptionalString();
+        periodStart = in.readInstant();
+        periodEnd = in.readInstant();
+    }
+
+    public PreviewForecasterRequest(Forecaster forecaster, String forecasterId, Instant periodStart, Instant periodEnd) {
+        super();
+        this.forecaster = forecaster;
+        this.forecasterId = forecasterId;
+        this.periodStart = periodStart;
+        this.periodEnd = periodEnd;
+    }
+
+    public Forecaster getForecaster() {
+        return forecaster;
+    }
+
+    public String getForecasterId() {
+        return forecasterId;
+    }
+
+    public Instant getPeriodStart() {
+        return periodStart;
+    }
+
+    public Instant getPeriodEnd() {
+        return periodEnd;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalWriteable(forecaster);
+        out.writeOptionalString(forecasterId);
+        out.writeInstant(periodStart);
+        out.writeInstant(periodEnd);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public String type() {
+        return ForecastCommonName.FORECAST_RESOURCE_TYPE;
+    }
+
+    @Override
+    public String index() {
+        return ForecastIndex.CONFIG.getIndexName();
+    }
+
+    @Override
+    public String id() {
+        return forecasterId;
+    }
+}

--- a/src/main/java/org/opensearch/forecast/transport/PreviewForecasterResponse.java
+++ b/src/main/java/org/opensearch/forecast/transport/PreviewForecasterResponse.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast.transport;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.forecast.model.ForecastResult;
+import org.opensearch.forecast.model.Forecaster;
+
+public class PreviewForecasterResponse extends ActionResponse implements ToXContentObject {
+    public static final String FORECAST_RESULT_FIELD = "forecast_result";
+    public static final String FORECASTER_FIELD = "forecaster";
+
+    private List<ForecastResult> forecastResult;
+    private Forecaster forecaster;
+
+    public PreviewForecasterResponse(StreamInput in) throws IOException {
+        super(in);
+        forecastResult = in.readList(ForecastResult::new);
+        forecaster = new Forecaster(in);
+    }
+
+    public PreviewForecasterResponse(List<ForecastResult> forecastResult, Forecaster forecaster) {
+        this.forecastResult = forecastResult;
+        this.forecaster = forecaster;
+    }
+
+    public List<ForecastResult> getForecastResult() {
+        return forecastResult;
+    }
+
+    public Forecaster getForecaster() {
+        return forecaster;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(forecastResult);
+        forecaster.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject().field(FORECAST_RESULT_FIELD, forecastResult).field(FORECASTER_FIELD, forecaster).endObject();
+    }
+}

--- a/src/main/java/org/opensearch/forecast/transport/PreviewForecasterTransportAction.java
+++ b/src/main/java/org/opensearch/forecast/transport/PreviewForecasterTransportAction.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.forecast.transport;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.timeseries.util.RestHandlerUtils.createXContentParserFromRegistry;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.forecast.ForecasterRunner;
+import org.opensearch.forecast.constant.ForecastCommonName;
+import org.opensearch.forecast.model.Forecaster;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class PreviewForecasterTransportAction extends HandledTransportAction<PreviewForecasterRequest, PreviewForecasterResponse> {
+
+    public static final String MISSING_REQUEST_MESSAGE = "Must set forecaster id or forecaster";
+    private final ForecasterRunner forecasterRunner;
+    private final Client client;
+    private final NamedXContentRegistry xContentRegistry;
+
+    @Inject
+    public PreviewForecasterTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ForecasterRunner forecasterRunner,
+        Client client,
+        NamedXContentRegistry xContentRegistry
+    ) {
+        super(PreviewForecasterAction.NAME, transportService, actionFilters, PreviewForecasterRequest::new);
+        this.forecasterRunner = forecasterRunner;
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    @Override
+    protected void doExecute(Task task, PreviewForecasterRequest request, ActionListener<PreviewForecasterResponse> listener) {
+        Forecaster forecaster = request.getForecaster();
+        if (forecaster != null) {
+            executePreview(forecaster, request, listener);
+            return;
+        }
+
+        String forecasterId = request.getForecasterId();
+        if (StringUtils.isBlank(forecasterId)) {
+            listener.onFailure(new OpenSearchStatusException(MISSING_REQUEST_MESSAGE, RestStatus.BAD_REQUEST));
+            return;
+        }
+
+        GetRequest getRequest = new GetRequest(ForecastCommonName.CONFIG_INDEX).id(forecasterId);
+        client.get(getRequest, onGetForecasterResponse(request, listener));
+    }
+
+    private void executePreview(
+        Forecaster forecaster,
+        PreviewForecasterRequest request,
+        ActionListener<PreviewForecasterResponse> listener
+    ) {
+        try {
+            forecasterRunner
+                .executeForecaster(
+                    forecaster,
+                    request.getPeriodStart(),
+                    request.getPeriodEnd(),
+                    ActionListener
+                        .wrap(
+                            forecastResult -> listener.onResponse(new PreviewForecasterResponse(forecastResult, forecaster)),
+                            listener::onFailure
+                        )
+                );
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private ActionListener<GetResponse> onGetForecasterResponse(
+        PreviewForecasterRequest request,
+        ActionListener<PreviewForecasterResponse> listener
+    ) {
+        return ActionListener.wrap(response -> {
+            if (!response.isExists()) {
+                listener
+                    .onFailure(new OpenSearchStatusException("Can't find forecaster with id:" + response.getId(), RestStatus.NOT_FOUND));
+                return;
+            }
+
+            try (XContentParser parser = createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                Forecaster forecaster = Forecaster.parse(parser, response.getId(), response.getVersion());
+                executePreview(forecaster, request, listener);
+            } catch (IOException e) {
+                listener.onFailure(e);
+            }
+        }, e -> listener.onFailure(normalizeGetFailure(e, request.getForecasterId())));
+    }
+
+    private Exception normalizeGetFailure(Exception exception, String forecasterId) {
+        if (exception instanceof IndexNotFoundException) {
+            return new OpenSearchStatusException("Can't find forecaster with id:" + forecasterId, RestStatus.NOT_FOUND, exception);
+        }
+        return exception;
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java
@@ -180,6 +180,7 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.forecast.ExecuteForecastResultResponseRecorder;
 import org.opensearch.forecast.ForecastJobProcessor;
 import org.opensearch.forecast.ForecastTaskProfileRunner;
+import org.opensearch.forecast.ForecasterRunner;
 import org.opensearch.forecast.caching.ForecastCacheProvider;
 import org.opensearch.forecast.caching.ForecastPriorityCache;
 import org.opensearch.forecast.constant.ForecastCommonName;
@@ -203,6 +204,7 @@ import org.opensearch.forecast.rest.RestForecasterJobAction;
 import org.opensearch.forecast.rest.RestForecasterSuggestAction;
 import org.opensearch.forecast.rest.RestGetForecasterAction;
 import org.opensearch.forecast.rest.RestIndexForecasterAction;
+import org.opensearch.forecast.rest.RestPreviewForecasterAction;
 import org.opensearch.forecast.rest.RestRunOnceForecasterAction;
 import org.opensearch.forecast.rest.RestSearchForecastTasksAction;
 import org.opensearch.forecast.rest.RestSearchForecasterAction;
@@ -246,6 +248,8 @@ import org.opensearch.forecast.transport.GetForecasterAction;
 import org.opensearch.forecast.transport.GetForecasterTransportAction;
 import org.opensearch.forecast.transport.IndexForecasterAction;
 import org.opensearch.forecast.transport.IndexForecasterTransportAction;
+import org.opensearch.forecast.transport.PreviewForecasterAction;
+import org.opensearch.forecast.transport.PreviewForecasterTransportAction;
 import org.opensearch.forecast.transport.SearchForecastTasksAction;
 import org.opensearch.forecast.transport.SearchForecastTasksTransportAction;
 import org.opensearch.forecast.transport.SearchForecasterAction;
@@ -460,6 +464,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin
         RestSearchTopForecastResultAction searchTopForecastResultAction = new RestSearchTopForecastResultAction();
         RestSearchForecastTasksAction searchForecastTasksAction = new RestSearchForecastTasksAction();
         RestStatsForecasterAction statsForecasterAction = new RestStatsForecasterAction(forecastStats, this.nodeFilter);
+        RestPreviewForecasterAction previewForecasterAction = new RestPreviewForecasterAction();
         RestRunOnceForecasterAction runOnceForecasterAction = new RestRunOnceForecasterAction();
         RestValidateForecasterAction validateForecasterAction = new RestValidateForecasterAction(settings, clusterService);
         RestForecasterSuggestAction suggestForecasterParamAction = new RestForecasterSuggestAction(settings, clusterService);
@@ -504,6 +509,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin
                 searchTopForecastResultAction,
                 searchForecastTasksAction,
                 statsForecasterAction,
+                previewForecasterAction,
                 runOnceForecasterAction,
                 validateForecasterAction,
                 suggestForecasterParamAction
@@ -1168,6 +1174,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin
             forecastMemoryTracker,
             featureManager
         );
+        ForecasterRunner forecasterRunner = new ForecasterRunner(forecastColdStarter, featureManager);
 
         ForecastIndexMemoryPressureAwareResultHandler forecastIndexMemoryPressureAwareResultHandler =
             new ForecastIndexMemoryPressureAwareResultHandler(client, forecastIndices, clusterService);
@@ -1432,6 +1439,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin
                 forecastCheckpointWriteQueue,
                 forecastColdEntityQueue,
                 forecastColdStarter,
+                forecasterRunner,
                 forecastTaskManager,
                 forecastSearchHandler,
                 forecastIndexJobActionHandler,
@@ -1746,6 +1754,7 @@ public class TimeSeriesAnalyticsPlugin extends Plugin
                 new ActionHandler<>(SearchForecastTasksAction.INSTANCE, SearchForecastTasksTransportAction.class),
                 new ActionHandler<>(StatsForecasterAction.INSTANCE, StatsForecasterTransportAction.class),
                 new ActionHandler<>(ForecastStatsNodesAction.INSTANCE, ForecastStatsNodesTransportAction.class),
+                new ActionHandler<>(PreviewForecasterAction.INSTANCE, PreviewForecasterTransportAction.class),
                 new ActionHandler<>(ForecastRunOnceAction.INSTANCE, ForecastRunOnceTransportAction.class),
                 new ActionHandler<>(ForecastRunOnceProfileAction.INSTANCE, ForecastRunOnceProfileTransportAction.class),
                 new ActionHandler<>(ValidateForecasterAction.INSTANCE, ValidateForecasterTransportAction.class),

--- a/src/main/java/org/opensearch/timeseries/feature/CompositeRetriever.java
+++ b/src/main/java/org/opensearch/timeseries/feature/CompositeRetriever.java
@@ -17,7 +17,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -79,6 +82,7 @@ public class CompositeRetriever extends AbstractRetriever {
     private IndexNameExpressionResolver indexNameExpressionResolver;
     private ClusterService clusterService;
     private AnalysisType context;
+    private final PrometheusDirectQueryExecutor prometheusDirectQueryExecutor;
 
     public CompositeRetriever(
         long dataStartEpoch,
@@ -110,6 +114,11 @@ public class CompositeRetriever extends AbstractRetriever {
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.clusterService = clusterService;
         this.context = context;
+        this.prometheusDirectQueryExecutor = new PrometheusDirectQueryExecutor(
+            client,
+            clientUtil,
+            settings.get(PrometheusDirectQueryExecutor.DATASOURCE_ENCRYPTION_MASTER_KEY)
+        );
     }
 
     // a constructor that provide default value of clock
@@ -152,6 +161,10 @@ public class CompositeRetriever extends AbstractRetriever {
      *  detector definition
      */
     public PageIterator iterator() throws IOException {
+        if (isPrometheusConfig(config)) {
+            return new PageIterator(null);
+        }
+
         RangeQueryBuilder rangeQuery = new RangeQueryBuilder(config.getTimeField())
             .gte(dataStartEpoch)
             .lt(dataEndEpoch)
@@ -204,6 +217,11 @@ public class CompositeRetriever extends AbstractRetriever {
         public void next(ActionListener<Page> listener) {
             iterations++;
 
+            if (isPrometheusConfig(config)) {
+                nextPrometheus(listener);
+                return;
+            }
+
             // inject user role while searching.
 
             SearchRequest searchRequest = new SearchRequest(config.getIndices().toArray(new String[0]), source);
@@ -228,6 +246,18 @@ public class CompositeRetriever extends AbstractRetriever {
                     client,
                     context,
                     searchResponseListener
+                );
+        }
+
+        private void nextPrometheus(ActionListener<Page> listener) {
+            prometheusDirectQueryExecutor
+                .executeRangeQueryBySeries(
+                    config,
+                    dataStartEpoch,
+                    dataEndEpoch,
+                    Math.max(1L, config.getIntervalInSeconds()),
+                    context,
+                    ActionListener.wrap(valuesBySeries -> listener.onResponse(analyzePrometheusSeries(valuesBySeries)), listener::onFailure)
                 );
         }
 
@@ -306,6 +336,21 @@ public class CompositeRetriever extends AbstractRetriever {
             totalResults += results.size();
 
             afterKey = composite.afterKey();
+            return new Page(results);
+        }
+
+        private Page analyzePrometheusSeries(Map<Map<String, String>, NavigableMap<Long, Double>> valuesBySeries) {
+            Map<Entity, double[]> results = new HashMap<>();
+            valuesBySeries.forEach((seriesLabels, values) -> {
+                Optional<Entity> entity = buildEntity(config.getCategoryFields(), seriesLabels);
+                Optional<Double> value = findRangeValue(values, dataStartEpoch, dataEndEpoch);
+                if (entity.isPresent() && value.isPresent()) {
+                    results.put(entity.get(), new double[] { value.get() });
+                }
+            });
+
+            totalResults += results.size();
+            afterKey = null;
             return new Page(results);
         }
 
@@ -440,5 +485,37 @@ public class CompositeRetriever extends AbstractRetriever {
 
             return toStringBuilder.toString();
         }
+    }
+
+    private boolean isPrometheusConfig(Config config) {
+        return config != null && Config.SOURCE_TYPE_PROMETHEUS.equals(config.getSourceType()) && config.getPrometheusSource() != null;
+    }
+
+    private Optional<Entity> buildEntity(List<String> categoryFields, Map<String, String> seriesLabels) {
+        if (categoryFields == null || categoryFields.isEmpty() || seriesLabels == null || seriesLabels.isEmpty()) {
+            return Optional.empty();
+        }
+
+        SortedMap<String, String> entityAttributes = new TreeMap<>();
+        for (String categoryField : categoryFields) {
+            String categoryValue = seriesLabels.get(categoryField);
+            if (categoryValue == null) {
+                return Optional.empty();
+            }
+            entityAttributes.put(categoryField, categoryValue);
+        }
+        return Optional.of(Entity.createEntityFromOrderedMap(entityAttributes));
+    }
+
+    private Optional<Double> findRangeValue(NavigableMap<Long, Double> values, long startTimeMs, long endTimeMs) {
+        if (values == null || values.isEmpty() || startTimeMs >= endTimeMs) {
+            return Optional.empty();
+        }
+
+        Map.Entry<Long, Double> candidate = values.floorEntry(endTimeMs);
+        if (candidate == null || candidate.getKey() < startTimeMs) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(candidate.getValue());
     }
 }

--- a/src/main/java/org/opensearch/timeseries/feature/FeatureManager.java
+++ b/src/main/java/org/opensearch/timeseries/feature/FeatureManager.java
@@ -298,6 +298,10 @@ public class FeatureManager {
         // TODO refactor this common lines so that these code can be run for 1 time for all entities
         Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
         List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
+        if (sampleRanges.isEmpty()) {
+            listener.onFailure(new IllegalArgumentException("No data available for preview."));
+            return;
+        }
         int stride = sampleRangeResults.getValue();
         int shingleSize = detector.getShingleSize();
 
@@ -312,7 +316,7 @@ public class FeatureManager {
         return ActionListener.wrap(samples -> {
             List<Entry<Long, Long>> searchTimeRange = samples.getKey();
             if (searchTimeRange.size() == 0) {
-                listener.onFailure(new IllegalArgumentException("No data to preview anomaly detection."));
+                listener.onFailure(new IllegalArgumentException("No data available for preview."));
                 return;
             }
             double[][] sampleFeatures = samples.getValue();
@@ -338,12 +342,31 @@ public class FeatureManager {
      */
     public void getPreviewFeatures(AnomalyDetector detector, long startMilli, long endMilli, ActionListener<Features> listener)
         throws IOException {
-        Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
-        List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
-        int stride = sampleRangeResults.getValue();
-        int shingleSize = detector.getShingleSize();
+        getPreviewFeatures(detector, AnalysisType.AD, startMilli, endMilli, listener);
+    }
 
-        getSamplesForPreview(detector, sampleRanges, getFeatureSamplesListener(stride, shingleSize, listener));
+    /**
+     * Returns preview features for any time-series config.
+     *
+     * @param config config info containing indices, features, interval, etc
+     * @param context analysis type for security context injection
+     * @param startMilli start of the range in epoch milliseconds
+     * @param endMilli end of the range in epoch milliseconds
+     * @param listener onResponse is called with time ranges and unprocessed features of preview data points
+     * @throws IOException if a user gives wrong query input when defining a config
+     */
+    public void getPreviewFeatures(Config config, AnalysisType context, long startMilli, long endMilli, ActionListener<Features> listener)
+        throws IOException {
+        Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(config, startMilli, endMilli);
+        List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
+        if (sampleRanges.isEmpty()) {
+            listener.onFailure(new IllegalArgumentException("No data available for preview."));
+            return;
+        }
+        int stride = sampleRangeResults.getValue();
+        int shingleSize = config.getShingleSize();
+
+        getSamplesForPreview(config, context, sampleRanges, getFeatureSamplesListener(stride, shingleSize, listener));
     }
 
     /**
@@ -354,10 +377,10 @@ public class FeatureManager {
      *
      * @return key is a list of sampled time ranges, value is the stride between samples
      */
-    private Entry<List<Entry<Long, Long>>, Integer> getSampleRanges(AnomalyDetector detector, long startMilli, long endMilli) {
+    private Entry<List<Entry<Long, Long>>, Integer> getSampleRanges(Config config, long startMilli, long endMilli) {
         long start = truncateToMinute(startMilli);
         long end = truncateToMinute(endMilli);
-        long bucketSize = detector.getIntervalInMilliseconds();
+        long bucketSize = config.getIntervalInMilliseconds();
         int numBuckets = (int) Math.floor((end - start) / (double) bucketSize);
         int numSamples = (int) Math.max(Math.min(numBuckets * previewSampleRate, maxPreviewSamples), 1);
         int stride = (int) Math.max(1, Math.floor((double) numBuckets / numSamples));
@@ -419,12 +442,13 @@ public class FeatureManager {
      * @throws IOException if a user gives wrong query input when defining a detector
      */
     void getSamplesForPreview(
-        AnomalyDetector detector,
+        Config config,
+        AnalysisType context,
         List<Entry<Long, Long>> sampleRanges,
         ActionListener<Entry<List<Entry<Long, Long>>, double[][]>> listener
     ) throws IOException {
         searchFeatureDao
-            .getFeatureSamplesForPeriods(detector, sampleRanges, AnalysisType.AD, false, getSamplesRangesListener(sampleRanges, listener));
+            .getFeatureSamplesForPeriods(config, sampleRanges, context, false, getSamplesRangesListener(sampleRanges, listener));
     }
 
     /**

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -1,0 +1,345 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.feature;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ActionType;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.PPLSource;
+import org.opensearch.timeseries.util.SecurityClientUtil;
+import org.opensearch.transport.client.Client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Executes restricted single-stream PPL detector queries at runtime through the
+ * SQL plugin's internal PPL transport action.
+ */
+public class PPLDirectQueryExecutor {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final DateTimeFormatter PPL_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+        .appendPattern("yyyy-MM-dd HH:mm:ss")
+        .optionalStart()
+        .appendFraction(ChronoField.MILLI_OF_SECOND, 1, 9, true)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+    private static final ActionType<ActionResponse> PPL_QUERY_ACTION = new ActionType<>(
+        "cluster:admin/opensearch/ppl",
+        PPLTransportResponse::new
+    );
+    private static final String PPL_QUERY_PATH = "/_plugins/_ppl";
+    private static final String PPL_RESPONSE_FORMAT = "jdbc";
+
+    private final Client client;
+    private final SecurityClientUtil clientUtil;
+
+    public PPLDirectQueryExecutor(Client client, SecurityClientUtil clientUtil) {
+        this.client = client;
+        this.clientUtil = clientUtil;
+    }
+
+    public void executeMetricQuery(
+        Config config,
+        long startTimeMs,
+        long endTimeMs,
+        AnalysisType context,
+        ActionListener<Optional<double[]>> listener
+    ) {
+        final PPLSource.CompiledPPLQuery compiledQuery;
+        try {
+            compiledQuery = config.getPPLSource().compile();
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        executeQuery(
+            null,
+            config,
+            compiled -> compiledQuery.buildMetricQueryForRange(startTimeMs, endTimeMs),
+            context,
+            responseBody -> parseMetricValues(responseBody, compiledQuery.getMetricCount()),
+            listener
+        );
+    }
+
+    public void executeLatestDataTimeQuery(User user, Config config, AnalysisType context, ActionListener<Optional<Long>> listener) {
+        executeQuery(
+            user,
+            config,
+            PPLSource.CompiledPPLQuery::buildLatestTimeQuery,
+            context,
+            PPLDirectQueryExecutor::parseSingleTimestamp,
+            listener
+        );
+    }
+
+    public void executeMinDataTimeQuery(Config config, AnalysisType context, ActionListener<Optional<Long>> listener) {
+        executeQuery(
+            null,
+            config,
+            PPLSource.CompiledPPLQuery::buildMinTimeQuery,
+            context,
+            PPLDirectQueryExecutor::parseSingleTimestamp,
+            listener
+        );
+    }
+
+    public void executeDateRangeQuery(User user, Config config, AnalysisType context, ActionListener<Pair<Long, Long>> listener) {
+        executeQuery(
+            user,
+            config,
+            PPLSource.CompiledPPLQuery::buildDateRangeQuery,
+            context,
+            PPLDirectQueryExecutor::parseDateRange,
+            listener
+        );
+    }
+
+    private <T> void executeQuery(
+        User user,
+        Config config,
+        Function<PPLSource.CompiledPPLQuery, String> queryBuilder,
+        AnalysisType context,
+        ResponseParser<T> responseParser,
+        ActionListener<T> listener
+    ) {
+        if (config == null || config.getPPLSource() == null) {
+            listener.onFailure(new IllegalArgumentException("ppl_source must be set when source_type is PPL."));
+            return;
+        }
+
+        final PPLSource.CompiledPPLQuery compiledQuery;
+        try {
+            compiledQuery = config.getPPLSource().compile();
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        PPLTransportRequest request = new PPLTransportRequest(queryBuilder.apply(compiledQuery), PPL_RESPONSE_FORMAT, PPL_QUERY_PATH);
+        ActionListener<ActionResponse> queryResponseListener = ActionListener.wrap(response -> {
+            try {
+                listener.onResponse(responseParser.parse(PPLTransportResponse.fromActionResponse(response).getResult()));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, listener::onFailure);
+
+        if (user != null) {
+            clientUtil
+                .asyncRequestWithInjectedSecurity(
+                    request,
+                    (pplRequest, actionListener) -> client.execute(PPL_QUERY_ACTION, pplRequest, actionListener),
+                    user,
+                    client,
+                    context,
+                    queryResponseListener
+                );
+        } else {
+            clientUtil
+                .asyncRequestWithInjectedSecurity(
+                    request,
+                    (pplRequest, actionListener) -> client.execute(PPL_QUERY_ACTION, pplRequest, actionListener),
+                    config.getId(),
+                    client,
+                    context,
+                    queryResponseListener
+                );
+        }
+    }
+
+    private static Optional<double[]> parseMetricValues(String responseBody, int metricCount) throws IOException {
+        JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
+        if (!datarows.isArray() || datarows.isEmpty()) {
+            return Optional.empty();
+        }
+
+        JsonNode firstRow = datarows.get(0);
+        if (!firstRow.isArray() || firstRow.size() < metricCount) {
+            return Optional.empty();
+        }
+
+        double[] values = new double[metricCount];
+        for (int i = 0; i < metricCount; i++) {
+            JsonNode valueNode = firstRow.get(i);
+            if (valueNode == null || valueNode.isNull()) {
+                return Optional.empty();
+            }
+            if (valueNode.isNumber()) {
+                values[i] = valueNode.doubleValue();
+                continue;
+            }
+            if (valueNode.isTextual() && valueNode.textValue() != null && !valueNode.textValue().isBlank()) {
+                values[i] = Double.parseDouble(valueNode.textValue());
+                continue;
+            }
+            return Optional.empty();
+        }
+        return Optional.of(values);
+    }
+
+    private static Optional<Long> parseSingleTimestamp(String responseBody) throws IOException {
+        JsonNode valueNode = getFirstRowValue(responseBody, 0);
+        return parseTimestampValue(valueNode);
+    }
+
+    private static Pair<Long, Long> parseDateRange(String responseBody) throws IOException {
+        Optional<Long> minTime = parseTimestampValue(getFirstRowValue(responseBody, 0));
+        Optional<Long> maxTime = parseTimestampValue(getFirstRowValue(responseBody, 1));
+        if (minTime.isEmpty() || maxTime.isEmpty()) {
+            throw new IllegalStateException("PPL date range query did not return both min and max timestamps.");
+        }
+        return Pair.of(minTime.get(), maxTime.get());
+    }
+
+    private static JsonNode getFirstRowValue(String responseBody, int columnIndex) throws IOException {
+        JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
+        if (!datarows.isArray() || datarows.isEmpty()) {
+            return null;
+        }
+        JsonNode firstRow = datarows.get(0);
+        if (!firstRow.isArray() || firstRow.size() <= columnIndex) {
+            return null;
+        }
+        return firstRow.get(columnIndex);
+    }
+
+    private static Optional<Long> parseTimestampValue(JsonNode valueNode) {
+        if (valueNode == null || valueNode.isNull()) {
+            return Optional.empty();
+        }
+
+        if (valueNode.isNumber()) {
+            return Optional.of(valueNode.longValue());
+        }
+
+        if (valueNode.isTextual() && valueNode.textValue() != null && !valueNode.textValue().isBlank()) {
+            LocalDateTime localDateTime = LocalDateTime.parse(valueNode.textValue(), PPL_TIMESTAMP_FORMATTER);
+            return Optional.of(localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli());
+        }
+
+        return Optional.empty();
+    }
+
+    private interface ResponseParser<T> {
+        T parse(String responseBody) throws Exception;
+    }
+
+    private enum PPLJsonStyle {
+        PRETTY,
+        COMPACT
+    }
+
+    private static final class PPLTransportRequest extends ActionRequest {
+        private final String query;
+        private final String format;
+        private final String explainMode;
+        private final String jsonContent;
+        private final String path;
+        private final boolean sanitize;
+        private final boolean profile;
+        private final String queryId;
+
+        private PPLTransportRequest(String query, String format, String path) {
+            this.query = query;
+            this.format = format;
+            this.explainMode = null;
+            this.jsonContent = null;
+            this.path = path;
+            this.sanitize = true;
+            this.profile = false;
+            this.queryId = null;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalString(query);
+            out.writeOptionalString(format);
+            out.writeOptionalString(explainMode);
+            out.writeOptionalString(jsonContent);
+            out.writeOptionalString(path);
+            out.writeBoolean(sanitize);
+            out.writeEnum(PPLJsonStyle.COMPACT);
+            out.writeBoolean(profile);
+            out.writeOptionalString(queryId);
+        }
+    }
+
+    private static final class PPLTransportResponse extends ActionResponse {
+        private final String result;
+        private final String contentType;
+
+        private PPLTransportResponse(StreamInput in) throws IOException {
+            super(in);
+            this.result = in.readString();
+            this.contentType = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(result);
+            out.writeString(contentType);
+        }
+
+        private static PPLTransportResponse fromActionResponse(ActionResponse actionResponse) {
+            if (actionResponse instanceof PPLTransportResponse) {
+                return (PPLTransportResponse) actionResponse;
+            }
+
+            try (
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)
+            ) {
+                actionResponse.writeTo(output);
+                try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                    return new PPLTransportResponse(input);
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("failed to parse ActionResponse into local PPL transport response", e);
+            }
+        }
+
+        private String getResult() {
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/feature/PrometheusDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PrometheusDirectQueryExecutor.java
@@ -1,0 +1,1005 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.feature;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.PrometheusSource;
+import org.opensearch.timeseries.util.SecurityClientUtil;
+import org.opensearch.transport.client.Client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Executes Prometheus range queries for Prometheus source detectors.
+ *
+ * Instead of depending on SQL direct-query transport classes (which are not visible across
+ * plugin classloaders), this executor resolves datasource metadata from SQL datasource storage
+ * and sends Prometheus query_range HTTP requests directly.
+ */
+public class PrometheusDirectQueryExecutor {
+    static final String DATASOURCE_ENCRYPTION_MASTER_KEY = "plugins.query.datasources.encryption.masterkey";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String DATASOURCE_INDEX = ".ql-datasources";
+    private static final String PROMETHEUS_CONNECTOR = "PROMETHEUS";
+    private static final String PROMETHEUS_URI_PROPERTY = "prometheus.uri";
+    private static final String PROMETHEUS_AUTH_TYPE_PROPERTY = "prometheus.auth.type";
+    private static final String PROMETHEUS_AUTH_USERNAME_PROPERTY = "prometheus.auth.username";
+    private static final String PROMETHEUS_AUTH_PASSWORD_PROPERTY = "prometheus.auth.password";
+    private static final String PROMETHEUS_AUTH_REGION_PROPERTY = "prometheus.auth.region";
+    private static final String PROMETHEUS_AUTH_ACCESS_KEY_PROPERTY = "prometheus.auth.access_key";
+    private static final String PROMETHEUS_AUTH_SECRET_KEY_PROPERTY = "prometheus.auth.secret_key";
+    private static final String RANGE_QUERY_PATH = "api/v1/query_range";
+    private static final String AWS_SIGV4_ALGORITHM = "AWS4-HMAC-SHA256";
+    private static final String AWS_SIGV4_SERVICE = "aps";
+    private static final String AWS4_REQUEST = "aws4_request";
+    private static final String EMPTY_PAYLOAD_SHA256 = sha256Hex("");
+    private static final DateTimeFormatter AWS_AMZ_DATE_FORMATTER = DateTimeFormatter
+        .ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.ROOT)
+        .withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter AWS_DATE_STAMP_FORMATTER = DateTimeFormatter
+        .ofPattern("yyyyMMdd", Locale.ROOT)
+        .withZone(ZoneOffset.UTC);
+
+    private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+    private static final int ERROR_BODY_LIMIT = 512;
+
+    private final Client client;
+    private final HttpClient httpClient;
+    private final ConcurrentHashMap<String, ResolvedPrometheusDataSource> dataSourceConfigCache;
+    private final String dataSourceEncryptionMasterKey;
+
+    public PrometheusDirectQueryExecutor(Client client, SecurityClientUtil clientUtil, Settings settings) {
+        this(
+            client,
+            clientUtil,
+            settings == null ? null : settings.get(DATASOURCE_ENCRYPTION_MASTER_KEY),
+            HttpClient
+                .newBuilder()
+                .connectTimeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build()
+        );
+    }
+
+    // Visible for tests.
+    PrometheusDirectQueryExecutor(Client client, SecurityClientUtil clientUtil, HttpClient httpClient) {
+        this(client, clientUtil, null, httpClient);
+    }
+
+    PrometheusDirectQueryExecutor(Client client, SecurityClientUtil clientUtil, String dataSourceEncryptionMasterKey) {
+        this(
+            client,
+            clientUtil,
+            dataSourceEncryptionMasterKey,
+            HttpClient
+                .newBuilder()
+                .connectTimeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build()
+        );
+    }
+
+    // Visible for tests.
+    PrometheusDirectQueryExecutor(
+        Client client,
+        SecurityClientUtil clientUtil,
+        String dataSourceEncryptionMasterKey,
+        HttpClient httpClient
+    ) {
+        this.client = client;
+        this.httpClient = httpClient;
+        this.dataSourceConfigCache = new ConcurrentHashMap<>();
+        this.dataSourceEncryptionMasterKey = dataSourceEncryptionMasterKey;
+    }
+
+    /**
+     * Executes a PROMQL range query and returns a single series (timestamp -> value).
+     * If {@code prometheus_source.series_filter} is set, the matching result series is used.
+     * Otherwise, multiple returned series are averaged per timestamp for backward compatibility.
+     */
+    public void executeRangeQuery(
+        Config config,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds,
+        AnalysisType context,
+        ActionListener<NavigableMap<Long, Double>> listener
+    ) {
+        executeRangeQuery(config, startTimeMs, endTimeMs, stepSeconds, null, context, listener);
+    }
+
+    public void executeRangeQuery(
+        Config config,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds,
+        Map<String, String> seriesFilterOverride,
+        AnalysisType context,
+        ActionListener<NavigableMap<Long, Double>> listener
+    ) {
+        PrometheusSource source = config.getPrometheusSource();
+        Map<String, String> effectiveSeriesFilter = mergeSeriesFilters(
+            source == null ? null : source.getSeriesFilter(),
+            seriesFilterOverride
+        );
+        executeRangeQuery(
+            source,
+            startTimeMs,
+            endTimeMs,
+            stepSeconds,
+            responseBody -> parsePrometheusResponse(responseBody, effectiveSeriesFilter),
+            listener
+        );
+    }
+
+    public void executeRangeQueryBySeries(
+        Config config,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds,
+        AnalysisType context,
+        ActionListener<Map<Map<String, String>, NavigableMap<Long, Double>>> listener
+    ) {
+        PrometheusSource source = config.getPrometheusSource();
+        executeRangeQuery(
+            source,
+            startTimeMs,
+            endTimeMs,
+            stepSeconds,
+            responseBody -> parsePrometheusResponseBySeries(responseBody, source == null ? null : source.getSeriesFilter()),
+            listener
+        );
+    }
+
+    private <T> void executeRangeQuery(
+        PrometheusSource source,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds,
+        ResponseParser<T> responseParser,
+        ActionListener<T> listener
+    ) {
+        Exception validationException = validateRangeQuery(source, startTimeMs, endTimeMs, stepSeconds);
+        if (validationException != null) {
+            listener.onFailure(validationException);
+            return;
+        }
+
+        resolvePrometheusDataSource(source, ActionListener.wrap(prometheusDataSource -> {
+            HttpRequest request;
+            try {
+                request = buildRangeQueryRequest(prometheusDataSource, source.getQuery(), startTimeMs, endTimeMs, stepSeconds);
+            } catch (Exception e) {
+                listener.onFailure(e);
+                return;
+            }
+
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, throwable) -> {
+                if (throwable != null) {
+                    listener
+                        .onFailure(
+                            new IllegalStateException(
+                                "Failed to query Prometheus datasource [" + source.getDataConnectionId() + "].",
+                                throwable
+                            )
+                        );
+                    return;
+                }
+
+                if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                    listener
+                        .onFailure(
+                            new IllegalStateException(
+                                "Prometheus query_range failed with HTTP " + response.statusCode() + ". Body: " + truncate(response.body())
+                            )
+                        );
+                    return;
+                }
+
+                try {
+                    listener.onResponse(responseParser.parse(response.body()));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        }, listener::onFailure));
+    }
+
+    private Exception validateRangeQuery(PrometheusSource source, long startTimeMs, long endTimeMs, long stepSeconds) {
+        if (source == null) {
+            return new IllegalArgumentException("prometheus_source must be set when source_type is PROMETHEUS.");
+        }
+        if (stepSeconds <= 0) {
+            return new IllegalArgumentException("stepSeconds must be positive.");
+        }
+        if (source.getQuery() == null || source.getQuery().trim().isEmpty()) {
+            return new IllegalArgumentException("prometheus_source.query must be set when source_type is PROMETHEUS.");
+        }
+        if (endTimeMs <= startTimeMs) {
+            return new IllegalArgumentException("endTimeMs must be larger than startTimeMs.");
+        }
+        return null;
+    }
+
+    private void resolvePrometheusDataSource(PrometheusSource source, ActionListener<ResolvedPrometheusDataSource> listener) {
+        String dataConnectionId = source.getDataConnectionId();
+        if (dataConnectionId == null || dataConnectionId.trim().isEmpty()) {
+            listener.onFailure(new IllegalArgumentException("prometheus_source.data_connection_id must be set."));
+            return;
+        }
+
+        ResolvedPrometheusDataSource cached = dataSourceConfigCache.get(dataConnectionId);
+        if (cached != null) {
+            listener.onResponse(cached);
+            return;
+        }
+
+        GetRequest getRequest = new GetRequest(DATASOURCE_INDEX, dataConnectionId);
+        GetResponse response;
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            response = client.get(getRequest).actionGet();
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        try {
+            if (response == null || !response.isExists()) {
+                listener.onFailure(new IllegalArgumentException("Prometheus datasource [" + dataConnectionId + "] does not exist."));
+                return;
+            }
+
+            Map<String, Object> sourceMap = response.getSourceAsMap();
+            if (sourceMap == null || sourceMap.isEmpty()) {
+                listener.onFailure(new IllegalStateException("Datasource [" + dataConnectionId + "] metadata is empty."));
+                return;
+            }
+
+            String connector = sourceMap.get("connector") == null ? null : sourceMap.get("connector").toString();
+            if (connector == null || !PROMETHEUS_CONNECTOR.equalsIgnoreCase(connector)) {
+                listener.onFailure(new IllegalArgumentException("Datasource [" + dataConnectionId + "] is not a PROMETHEUS datasource."));
+                return;
+            }
+
+            Object propertiesObject = sourceMap.get("properties");
+            if (!(propertiesObject instanceof Map)) {
+                listener.onFailure(new IllegalStateException("Datasource [" + dataConnectionId + "] properties are invalid."));
+                return;
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> properties = (Map<String, Object>) propertiesObject;
+            ResolvedPrometheusDataSource resolved = resolvePrometheusDataSourceProperties(properties, dataConnectionId);
+            dataSourceConfigCache.put(dataConnectionId, resolved);
+            listener.onResponse(resolved);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private HttpRequest buildRangeQueryRequest(
+        ResolvedPrometheusDataSource prometheusDataSource,
+        String query,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds
+    ) {
+        return buildRangeQueryRequest(prometheusDataSource, query, startTimeMs, endTimeMs, stepSeconds, Instant.now());
+    }
+
+    HttpRequest buildRangeQueryRequest(
+        ResolvedPrometheusDataSource prometheusDataSource,
+        String query,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds,
+        Instant requestTime
+    ) {
+        RangeQueryRequestContext requestContext = buildRangeQueryRequestContext(
+            prometheusDataSource.getPrometheusBaseUri(),
+            query,
+            startTimeMs,
+            endTimeMs,
+            stepSeconds
+        );
+
+        HttpRequest.Builder builder = HttpRequest
+            .newBuilder(requestContext.getRequestUri())
+            .GET()
+            .timeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS));
+
+        switch (prometheusDataSource.getAuthType()) {
+            case BASICAUTH:
+                builder
+                    .header(
+                        "Authorization",
+                        buildBasicAuthorizationHeader(prometheusDataSource.getUsername(), prometheusDataSource.getPassword())
+                    );
+                break;
+            case AWSSIGV4:
+                applyAwsSigV4Headers(builder, requestContext, prometheusDataSource, requestTime);
+                break;
+            case NOAUTH:
+            default:
+                break;
+        }
+
+        return builder.build();
+    }
+
+    private RangeQueryRequestContext buildRangeQueryRequestContext(
+        String prometheusBaseUri,
+        String query,
+        long startTimeMs,
+        long endTimeMs,
+        long stepSeconds
+    ) {
+        String base = prometheusBaseUri;
+        if (!base.endsWith("/")) {
+            base += "/";
+        }
+
+        long startSeconds = Math.max(0L, startTimeMs / 1000L);
+        long endSeconds = Math.max(0L, endTimeMs / 1000L);
+
+        Map<String, String> queryParameters = new LinkedHashMap<>();
+        queryParameters.put("query", query);
+        queryParameters.put("start", Long.toString(startSeconds));
+        queryParameters.put("end", Long.toString(endSeconds));
+        queryParameters.put("step", Long.toString(Math.max(1L, stepSeconds)));
+
+        String canonicalQueryString = buildCanonicalQueryString(queryParameters);
+        String url = base + RANGE_QUERY_PATH + "?" + canonicalQueryString;
+        return new RangeQueryRequestContext(URI.create(url), canonicalQueryString);
+    }
+
+    ResolvedPrometheusDataSource resolvePrometheusDataSourceProperties(Map<String, Object> properties, String dataConnectionId) {
+        String prometheusUri = getStringProperty(properties, PROMETHEUS_URI_PROPERTY);
+        String authType = normalizeAuthType(getStringProperty(properties, PROMETHEUS_AUTH_TYPE_PROPERTY));
+
+        ResolvedPrometheusDataSource.Builder builder = ResolvedPrometheusDataSource
+            .builder()
+            .prometheusBaseUri(normalizePrometheusUri(prometheusUri, dataConnectionId));
+
+        if (authType == null || authType.isEmpty() || PrometheusAuthType.NOAUTH.getWireName().equals(authType)) {
+            return builder.authType(PrometheusAuthType.NOAUTH).build();
+        }
+
+        if (PrometheusAuthType.BASICAUTH.getWireName().equals(authType)) {
+            return builder
+                .authType(PrometheusAuthType.BASICAUTH)
+                .username(requireCredentialProperty(properties, PROMETHEUS_AUTH_USERNAME_PROPERTY, dataConnectionId))
+                .password(requireCredentialProperty(properties, PROMETHEUS_AUTH_PASSWORD_PROPERTY, dataConnectionId))
+                .build();
+        }
+
+        if (PrometheusAuthType.AWSSIGV4.getWireName().equals(authType)) {
+            return builder
+                .authType(PrometheusAuthType.AWSSIGV4)
+                .region(requireProperty(properties, PROMETHEUS_AUTH_REGION_PROPERTY, dataConnectionId))
+                .accessKey(requireCredentialProperty(properties, PROMETHEUS_AUTH_ACCESS_KEY_PROPERTY, dataConnectionId))
+                .secretKey(requireCredentialProperty(properties, PROMETHEUS_AUTH_SECRET_KEY_PROPERTY, dataConnectionId))
+                .build();
+        }
+
+        throw new IllegalArgumentException("Datasource [" + dataConnectionId + "] has unsupported Prometheus auth type: " + authType);
+    }
+
+    private String normalizePrometheusUri(String rawUri, String dataConnectionId) {
+        if (rawUri == null || rawUri.trim().isEmpty()) {
+            throw new IllegalArgumentException("Datasource [" + dataConnectionId + "] does not contain properties.prometheus.uri.");
+        }
+
+        String candidate = rawUri.trim();
+        if (!candidate.startsWith("http://") && !candidate.startsWith("https://")) {
+            candidate = "http://" + candidate;
+        }
+        if (candidate.endsWith("/")) {
+            candidate = candidate.substring(0, candidate.length() - 1);
+        }
+
+        try {
+            URI uri = URI.create(candidate);
+            if (uri.getHost() == null || uri.getHost().isEmpty()) {
+                throw new IllegalArgumentException("Datasource [" + dataConnectionId + "] has invalid Prometheus URI: " + rawUri);
+            }
+            return candidate;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Datasource [" + dataConnectionId + "] has invalid Prometheus URI: " + rawUri, e);
+        }
+    }
+
+    private String getStringProperty(Map<String, Object> properties, String propertyName) {
+        Object rawValue = properties.get(propertyName);
+        if (rawValue == null) {
+            return null;
+        }
+        return rawValue.toString();
+    }
+
+    private String requireProperty(Map<String, Object> properties, String propertyName, String dataConnectionId) {
+        String value = getStringProperty(properties, propertyName);
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("Datasource [" + dataConnectionId + "] does not contain " + propertyName + ".");
+        }
+        return value;
+    }
+
+    private String requireCredentialProperty(Map<String, Object> properties, String propertyName, String dataConnectionId) {
+        String value = requireProperty(properties, propertyName, dataConnectionId);
+        return maybeDecryptCredential(value);
+    }
+
+    String maybeDecryptCredential(String credentialValue) {
+        if (credentialValue == null
+            || credentialValue.trim().isEmpty()
+            || dataSourceEncryptionMasterKey == null
+            || dataSourceEncryptionMasterKey.isEmpty()) {
+            return credentialValue;
+        }
+
+        try {
+            return decryptCredential(credentialValue);
+        } catch (Exception e) {
+            return credentialValue;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String decryptCredential(String encryptedText) {
+        try {
+            Class<?> commitmentPolicyClass = Class.forName("com.amazonaws.encryptionsdk.CommitmentPolicy");
+            Object commitmentPolicy = Enum
+                .valueOf((Class<? extends Enum>) commitmentPolicyClass.asSubclass(Enum.class), "RequireEncryptRequireDecrypt");
+
+            Class<?> awsCryptoClass = Class.forName("com.amazonaws.encryptionsdk.AwsCrypto");
+            Object builder = awsCryptoClass.getMethod("builder").invoke(null);
+            builder.getClass().getMethod("withCommitmentPolicy", commitmentPolicyClass).invoke(builder, commitmentPolicy);
+            Object crypto = builder.getClass().getMethod("build").invoke(builder);
+
+            Class<?> jceMasterKeyClass = Class.forName("com.amazonaws.encryptionsdk.jce.JceMasterKey");
+            Object jceMasterKey = jceMasterKeyClass
+                .getMethod("getInstance", java.security.Key.class, String.class, String.class, String.class)
+                .invoke(
+                    null,
+                    new SecretKeySpec(dataSourceEncryptionMasterKey.getBytes(StandardCharsets.UTF_8), "AES"),
+                    "Custom",
+                    "opensearch.config.master.key",
+                    "AES/GCM/NoPadding"
+                );
+            Method decryptDataMethod = null;
+            for (Method method : crypto.getClass().getMethods()) {
+                if ("decryptData".equals(method.getName()) && method.getParameterCount() == 2) {
+                    decryptDataMethod = method;
+                    break;
+                }
+            }
+            if (decryptDataMethod == null) {
+                throw new NoSuchMethodException("decryptData");
+            }
+            Object decryptedResult = decryptDataMethod.invoke(crypto, jceMasterKey, Base64.getDecoder().decode(encryptedText));
+            byte[] decryptedBytes = (byte[]) decryptedResult.getClass().getMethod("getResult").invoke(decryptedResult);
+            return new String(decryptedBytes, StandardCharsets.UTF_8);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("failed to decrypt Prometheus datasource credential", e);
+        }
+    }
+
+    private String normalizeAuthType(String rawAuthType) {
+        if (rawAuthType == null) {
+            return null;
+        }
+        String normalized = rawAuthType.trim().toLowerCase(Locale.ROOT);
+        if ("awssigv4auth".equals(normalized)) {
+            return PrometheusAuthType.AWSSIGV4.getWireName();
+        }
+        return normalized;
+    }
+
+    private String buildBasicAuthorizationHeader(String username, String password) {
+        String credentials = username + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void applyAwsSigV4Headers(
+        HttpRequest.Builder builder,
+        RangeQueryRequestContext requestContext,
+        ResolvedPrometheusDataSource prometheusDataSource,
+        Instant requestTime
+    ) {
+        String amzDate = AWS_AMZ_DATE_FORMATTER.format(requestTime);
+        String dateStamp = AWS_DATE_STAMP_FORMATTER.format(requestTime);
+        String hostHeader = requestContext.getRequestUri().getHost();
+        String canonicalUri = requestContext.getRequestUri().getRawPath() == null || requestContext.getRequestUri().getRawPath().isEmpty()
+            ? "/"
+            : requestContext.getRequestUri().getRawPath();
+        String canonicalHeaders = "host:"
+            + hostHeader
+            + "\n"
+            + "x-amz-content-sha256:"
+            + EMPTY_PAYLOAD_SHA256
+            + "\n"
+            + "x-amz-date:"
+            + amzDate
+            + "\n";
+        String signedHeaders = "host;x-amz-content-sha256;x-amz-date";
+        String canonicalRequest = "GET"
+            + "\n"
+            + canonicalUri
+            + "\n"
+            + requestContext.getCanonicalQueryString()
+            + "\n"
+            + canonicalHeaders
+            + "\n"
+            + signedHeaders
+            + "\n"
+            + EMPTY_PAYLOAD_SHA256;
+        String credentialScope = dateStamp + "/" + prometheusDataSource.getRegion() + "/" + AWS_SIGV4_SERVICE + "/" + AWS4_REQUEST;
+        String stringToSign = AWS_SIGV4_ALGORITHM + "\n" + amzDate + "\n" + credentialScope + "\n" + sha256Hex(canonicalRequest);
+        String signature = hmacSha256Hex(
+            getAwsSigV4SigningKey(prometheusDataSource.getSecretKey(), dateStamp, prometheusDataSource.getRegion()),
+            stringToSign
+        );
+        String authorization = AWS_SIGV4_ALGORITHM
+            + " Credential="
+            + prometheusDataSource.getAccessKey()
+            + "/"
+            + credentialScope
+            + ", SignedHeaders="
+            + signedHeaders
+            + ", Signature="
+            + signature;
+
+        builder.header("x-amz-date", amzDate);
+        builder.header("x-amz-content-sha256", EMPTY_PAYLOAD_SHA256);
+        builder.header("Authorization", authorization);
+    }
+
+    private String buildCanonicalQueryString(Map<String, String> queryParameters) {
+        TreeSet<String> orderedKeys = new TreeSet<>(queryParameters.keySet());
+        List<String> encodedParameters = new ArrayList<>(orderedKeys.size());
+        for (String key : orderedKeys) {
+            String value = queryParameters.get(key);
+            encodedParameters.add(encodeQueryComponent(key) + "=" + encodeQueryComponent(value == null ? "" : value));
+        }
+        return String.join("&", encodedParameters);
+    }
+
+    private String encodeQueryComponent(String value) {
+        StringBuilder builder = new StringBuilder();
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        for (byte currentByte : bytes) {
+            int current = currentByte & 0xFF;
+            if ((current >= 'A' && current <= 'Z')
+                || (current >= 'a' && current <= 'z')
+                || (current >= '0' && current <= '9')
+                || current == '-'
+                || current == '_'
+                || current == '.'
+                || current == '~') {
+                builder.append((char) current);
+            } else {
+                builder.append('%');
+                char upper = Character.toUpperCase(Character.forDigit((current >> 4) & 0xF, 16));
+                char lower = Character.toUpperCase(Character.forDigit(current & 0xF, 16));
+                builder.append(upper).append(lower);
+            }
+        }
+        return builder.toString();
+    }
+
+    private byte[] getAwsSigV4SigningKey(String secretKey, String dateStamp, String region) {
+        byte[] kDate = hmacSha256(("AWS4" + secretKey).getBytes(StandardCharsets.UTF_8), dateStamp);
+        byte[] kRegion = hmacSha256(kDate, region);
+        byte[] kService = hmacSha256(kRegion, AWS_SIGV4_SERVICE);
+        return hmacSha256(kService, AWS4_REQUEST);
+    }
+
+    private byte[] hmacSha256(byte[] key, String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to compute HMAC-SHA256 signature.", e);
+        }
+    }
+
+    private static String sha256Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hash);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to compute SHA-256 hash.", e);
+        }
+    }
+
+    private String hmacSha256Hex(byte[] key, String value) {
+        return bytesToHex(hmacSha256(key, value));
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte currentByte : bytes) {
+            builder.append(Character.forDigit((currentByte >> 4) & 0xF, 16));
+            builder.append(Character.forDigit(currentByte & 0xF, 16));
+        }
+        return builder.toString();
+    }
+
+    NavigableMap<Long, Double> parsePrometheusResponse(String body, Map<String, String> seriesFilter) throws IOException {
+        Map<Map<String, String>, NavigableMap<Long, Double>> valuesBySeries = parsePrometheusResponseBySeries(body, seriesFilter);
+        if (seriesFilter != null && !seriesFilter.isEmpty()) {
+            return valuesBySeries.values().stream().findFirst().orElseGet(TreeMap::new);
+        }
+
+        Map<Long, double[]> timestampAccumulator = new TreeMap<>();
+        valuesBySeries.values().forEach(seriesValues -> {
+            seriesValues.forEach((timestamp, value) -> {
+                double[] sumAndCount = timestampAccumulator.computeIfAbsent(timestamp, key -> new double[] { 0d, 0d });
+                sumAndCount[0] += value;
+                sumAndCount[1] += 1d;
+            });
+        });
+
+        NavigableMap<Long, Double> averaged = new TreeMap<>();
+        for (Map.Entry<Long, double[]> entry : timestampAccumulator.entrySet()) {
+            double[] sumAndCount = entry.getValue();
+            if (sumAndCount[1] > 0d) {
+                averaged.put(entry.getKey(), sumAndCount[0] / sumAndCount[1]);
+            }
+        }
+        return averaged;
+    }
+
+    Map<Map<String, String>, NavigableMap<Long, Double>> parsePrometheusResponseBySeries(String body, Map<String, String> seriesFilter)
+        throws IOException {
+        if (body == null || body.trim().isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        JsonNode root = OBJECT_MAPPER.readTree(body);
+        String status = root.path("status").asText("");
+        if (!"success".equalsIgnoreCase(status)) {
+            throw new IllegalStateException(
+                "Prometheus query_range failed. errorType=" + root.path("errorType").asText("") + ", error=" + root.path("error").asText("")
+            );
+        }
+
+        JsonNode data = root.path("data");
+        JsonNode result = data.path("result");
+        if (!result.isArray() || result.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<Map<String, String>, NavigableMap<Long, Double>> valuesBySeries = new LinkedHashMap<>();
+        for (JsonNode series : result) {
+            Map<String, String> seriesLabels = parseSeriesLabels(series.path("metric"));
+            if (!matchesSeriesFilter(seriesLabels, seriesFilter)) {
+                continue;
+            }
+
+            NavigableMap<Long, Double> seriesValues = parseSingleSeries(series);
+            if (!seriesValues.isEmpty()) {
+                valuesBySeries.put(Collections.unmodifiableMap(seriesLabels), seriesValues);
+            }
+        }
+        return valuesBySeries;
+    }
+
+    private Map<String, String> parseSeriesLabels(JsonNode metric) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        if (!metric.isObject()) {
+            return labels;
+        }
+
+        Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field = fields.next();
+            JsonNode value = field.getValue();
+            if (value != null && !value.isNull()) {
+                labels.put(field.getKey(), value.asText());
+            }
+        }
+        return labels;
+    }
+
+    private Map<String, String> mergeSeriesFilters(Map<String, String> storedFilter, Map<String, String> overrideFilter) {
+        if ((storedFilter == null || storedFilter.isEmpty()) && (overrideFilter == null || overrideFilter.isEmpty())) {
+            return null;
+        }
+
+        Map<String, String> merged = new LinkedHashMap<>();
+        if (storedFilter != null) {
+            merged.putAll(storedFilter);
+        }
+        if (overrideFilter != null) {
+            merged.putAll(overrideFilter);
+        }
+        return merged;
+    }
+
+    private boolean matchesSeriesFilter(Map<String, String> labels, Map<String, String> seriesFilter) {
+        if (seriesFilter == null || seriesFilter.isEmpty()) {
+            return true;
+        }
+
+        for (Map.Entry<String, String> filterEntry : seriesFilter.entrySet()) {
+            String actualValue = labels.get(filterEntry.getKey());
+            if (actualValue == null || !actualValue.equals(filterEntry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private NavigableMap<Long, Double> parseSingleSeries(JsonNode series) {
+        NavigableMap<Long, Double> valuesByTimestamp = new TreeMap<>();
+        JsonNode values = series.get("values");
+        if (values != null && values.isArray()) {
+            for (JsonNode point : values) {
+                addSingleSeriesPoint(valuesByTimestamp, point);
+            }
+            return valuesByTimestamp;
+        }
+
+        JsonNode value = series.get("value");
+        if (value != null && value.isArray()) {
+            addSingleSeriesPoint(valuesByTimestamp, value);
+        }
+        return valuesByTimestamp;
+    }
+
+    private void addSingleSeriesPoint(Map<Long, Double> valuesByTimestamp, JsonNode point) {
+        if (point == null || !point.isArray() || point.size() < 2) {
+            return;
+        }
+
+        long timestamp = parseEpochMillis(point.get(0));
+        if (timestamp < 0) {
+            return;
+        }
+
+        double value = parseDouble(point.get(1));
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            return;
+        }
+
+        valuesByTimestamp.put(timestamp, value);
+    }
+
+    private long parseEpochMillis(JsonNode rawTimestamp) {
+        if (rawTimestamp == null || rawTimestamp.isNull()) {
+            return -1L;
+        }
+
+        String text = rawTimestamp.isNumber() ? rawTimestamp.numberValue().toString() : rawTimestamp.asText("");
+        if (text.isEmpty()) {
+            return -1L;
+        }
+
+        double numeric = Double.parseDouble(text);
+        long asLong = (long) numeric;
+        if (asLong > 1_000_000_000_000L) {
+            return asLong;
+        }
+        return (long) Math.floor(numeric * 1000d);
+    }
+
+    private double parseDouble(JsonNode rawValue) {
+        if (rawValue == null || rawValue.isNull()) {
+            return Double.NaN;
+        }
+
+        String text = rawValue.isNumber() ? rawValue.numberValue().toString() : rawValue.asText("");
+        String normalized = text == null ? "" : text.trim();
+
+        if (normalized.isEmpty() || "nan".equalsIgnoreCase(normalized)) {
+            return Double.NaN;
+        }
+        if ("+inf".equalsIgnoreCase(normalized) || "inf".equalsIgnoreCase(normalized) || "infinity".equalsIgnoreCase(normalized)) {
+            return Double.POSITIVE_INFINITY;
+        }
+        if ("-inf".equalsIgnoreCase(normalized) || "-infinity".equalsIgnoreCase(normalized)) {
+            return Double.NEGATIVE_INFINITY;
+        }
+
+        return Double.parseDouble(normalized);
+    }
+
+    private String truncate(String text) {
+        if (text == null) {
+            return "";
+        }
+        if (text.length() <= ERROR_BODY_LIMIT) {
+            return text;
+        }
+        return text.substring(0, ERROR_BODY_LIMIT) + "...";
+    }
+
+    enum PrometheusAuthType {
+        NOAUTH("noauth"),
+        BASICAUTH("basicauth"),
+        AWSSIGV4("awssigv4");
+
+        private final String wireName;
+
+        PrometheusAuthType(String wireName) {
+            this.wireName = wireName;
+        }
+
+        String getWireName() {
+            return wireName;
+        }
+    }
+
+    static final class ResolvedPrometheusDataSource {
+        private final String prometheusBaseUri;
+        private final PrometheusAuthType authType;
+        private final String username;
+        private final String password;
+        private final String region;
+        private final String accessKey;
+        private final String secretKey;
+
+        private ResolvedPrometheusDataSource(Builder builder) {
+            this.prometheusBaseUri = builder.prometheusBaseUri;
+            this.authType = builder.authType;
+            this.username = builder.username;
+            this.password = builder.password;
+            this.region = builder.region;
+            this.accessKey = builder.accessKey;
+            this.secretKey = builder.secretKey;
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        String getPrometheusBaseUri() {
+            return prometheusBaseUri;
+        }
+
+        PrometheusAuthType getAuthType() {
+            return authType;
+        }
+
+        String getUsername() {
+            return username;
+        }
+
+        String getPassword() {
+            return password;
+        }
+
+        String getRegion() {
+            return region;
+        }
+
+        String getAccessKey() {
+            return accessKey;
+        }
+
+        String getSecretKey() {
+            return secretKey;
+        }
+
+        static final class Builder {
+            private String prometheusBaseUri;
+            private PrometheusAuthType authType = PrometheusAuthType.NOAUTH;
+            private String username;
+            private String password;
+            private String region;
+            private String accessKey;
+            private String secretKey;
+
+            Builder prometheusBaseUri(String prometheusBaseUri) {
+                this.prometheusBaseUri = prometheusBaseUri;
+                return this;
+            }
+
+            Builder authType(PrometheusAuthType authType) {
+                this.authType = authType;
+                return this;
+            }
+
+            Builder username(String username) {
+                this.username = username;
+                return this;
+            }
+
+            Builder password(String password) {
+                this.password = password;
+                return this;
+            }
+
+            Builder region(String region) {
+                this.region = region;
+                return this;
+            }
+
+            Builder accessKey(String accessKey) {
+                this.accessKey = accessKey;
+                return this;
+            }
+
+            Builder secretKey(String secretKey) {
+                this.secretKey = secretKey;
+                return this;
+            }
+
+            ResolvedPrometheusDataSource build() {
+                return new ResolvedPrometheusDataSource(this);
+            }
+        }
+    }
+
+    static final class RangeQueryRequestContext {
+        private final URI requestUri;
+        private final String canonicalQueryString;
+
+        RangeQueryRequestContext(URI requestUri, String canonicalQueryString) {
+            this.requestUri = requestUri;
+            this.canonicalQueryString = canonicalQueryString;
+        }
+
+        URI getRequestUri() {
+            return requestUri;
+        }
+
+        String getCanonicalQueryString() {
+            return canonicalQueryString;
+        }
+    }
+
+    @FunctionalInterface
+    private interface ResponseParser<T> {
+        T parse(String body) throws IOException;
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
@@ -28,7 +28,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -94,6 +97,8 @@ public class SearchFeatureDao extends AbstractRetriever {
     private final int minimumDocCountForPreview;
     private long previewTimeoutInMilliseconds;
     private Clock clock;
+    private final PrometheusDirectQueryExecutor prometheusDirectQueryExecutor;
+    private final PPLDirectQueryExecutor pplDirectQueryExecutor;
 
     // used for testing as we can mock clock
     public SearchFeatureDao(
@@ -106,6 +111,65 @@ public class SearchFeatureDao extends AbstractRetriever {
         int maxEntitiesForPreview,
         int pageSize,
         long previewTimeoutInMilliseconds
+    ) {
+        this(
+            client,
+            xContent,
+            clientUtil,
+            clusterService,
+            null,
+            minimumDocCount,
+            clock,
+            maxEntitiesForPreview,
+            pageSize,
+            previewTimeoutInMilliseconds,
+            null,
+            null
+        );
+    }
+
+    // used for testing as we can mock clock
+    public SearchFeatureDao(
+        Client client,
+        NamedXContentRegistry xContent,
+        SecurityClientUtil clientUtil,
+        ClusterService clusterService,
+        String dataSourceEncryptionMasterKey,
+        int minimumDocCount,
+        Clock clock,
+        int maxEntitiesForPreview,
+        int pageSize,
+        long previewTimeoutInMilliseconds
+    ) {
+        this(
+            client,
+            xContent,
+            clientUtil,
+            clusterService,
+            dataSourceEncryptionMasterKey,
+            minimumDocCount,
+            clock,
+            maxEntitiesForPreview,
+            pageSize,
+            previewTimeoutInMilliseconds,
+            null,
+            null
+        );
+    }
+
+    SearchFeatureDao(
+        Client client,
+        NamedXContentRegistry xContent,
+        SecurityClientUtil clientUtil,
+        ClusterService clusterService,
+        String dataSourceEncryptionMasterKey,
+        int minimumDocCount,
+        Clock clock,
+        int maxEntitiesForPreview,
+        int pageSize,
+        long previewTimeoutInMilliseconds,
+        PrometheusDirectQueryExecutor prometheusDirectQueryExecutor,
+        PPLDirectQueryExecutor pplDirectQueryExecutor
     ) {
         this.client = client;
         this.xContent = xContent;
@@ -121,6 +185,12 @@ public class SearchFeatureDao extends AbstractRetriever {
         this.minimumDocCountForPreview = minimumDocCount;
         this.previewTimeoutInMilliseconds = previewTimeoutInMilliseconds;
         this.clock = clock;
+        this.prometheusDirectQueryExecutor = prometheusDirectQueryExecutor != null
+            ? prometheusDirectQueryExecutor
+            : new PrometheusDirectQueryExecutor(client, clientUtil, dataSourceEncryptionMasterKey);
+        this.pplDirectQueryExecutor = pplDirectQueryExecutor != null
+            ? pplDirectQueryExecutor
+            : new PPLDirectQueryExecutor(client, clientUtil);
     }
 
     /**
@@ -146,6 +216,7 @@ public class SearchFeatureDao extends AbstractRetriever {
             xContent,
             clientUtil,
             clusterService,
+            settings.get(PrometheusDirectQueryExecutor.DATASOURCE_ENCRYPTION_MASTER_KEY),
             minimumDocCount,
             Clock.systemUTC(),
             MAX_ENTITIES_FOR_PREVIEW.get(settings),
@@ -177,6 +248,19 @@ public class SearchFeatureDao extends AbstractRetriever {
         AnalysisType context,
         ActionListener<Optional<Long>> listener
     ) {
+        if (isPrometheusConfig(config)) {
+            listener.onResponse(Optional.of(clock.millis()));
+            return;
+        }
+        if (isPPLConfig(config)) {
+            if (entity.isPresent()) {
+                listener.onFailure(new IllegalArgumentException("PPL source_type does not support entity-scoped latest time queries."));
+                return;
+            }
+            pplDirectQueryExecutor.executeLatestDataTimeQuery(user, config, context, listener);
+            return;
+        }
+
         BoolQueryBuilder internalFilterQuery = QueryBuilders.boolQuery();
         if (entity.isPresent()) {
             for (TermQueryBuilder term : entity.get().getTermQueryForCustomerIndex()) {
@@ -221,6 +305,28 @@ public class SearchFeatureDao extends AbstractRetriever {
         Map<String, Object> topEntity,
         ActionListener<Pair<Long, Long>> internalListener
     ) {
+        if (isPrometheusConfig(config)) {
+            long endTime = clock.millis();
+            long startTime = Math
+                .max(0L, endTime - Math.max(config.getIntervalInMilliseconds(), 1L) * Math.max(config.getHistoryIntervals(), 1));
+            internalListener.onResponse(Pair.of(startTime, endTime));
+            return;
+        }
+        if (isPPLConfig(config)) {
+            if (topEntity != null && !topEntity.isEmpty()) {
+                internalListener.onFailure(new IllegalArgumentException("PPL source_type does not support categorical entity filters."));
+                return;
+            }
+            pplDirectQueryExecutor
+                .executeDateRangeQuery(
+                    user,
+                    config,
+                    config instanceof AnomalyDetector ? AnalysisType.AD : AnalysisType.FORECAST,
+                    internalListener
+                );
+            return;
+        }
+
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
             .aggregation(AggregationBuilders.min(CommonName.AGG_NAME_MIN_TIME).field(config.getTimeField()))
             .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(config.getTimeField()))
@@ -289,6 +395,10 @@ public class SearchFeatureDao extends AbstractRetriever {
     ) {
         if (!detector.isHighCardinality()) {
             listener.onResponse(null);
+            return;
+        }
+        if (isPrometheusConfig(detector)) {
+            getPrometheusHighestCountEntities(detector, startTime, endTime, maxEntitiesSize, minimumDocCount, listener);
             return;
         }
 
@@ -549,6 +659,21 @@ public class SearchFeatureDao extends AbstractRetriever {
      * @param listener listener to return back the requested timestamps
      */
     public void getMinDataTime(Config config, Optional<Entity> entity, AnalysisType context, ActionListener<Optional<Long>> listener) {
+        if (isPrometheusConfig(config)) {
+            long endTime = clock.millis();
+            long lookback = Math.max(config.getIntervalInMilliseconds(), 1L) * Math.max(config.getHistoryIntervals(), 1);
+            listener.onResponse(Optional.of(Math.max(0L, endTime - lookback)));
+            return;
+        }
+        if (isPPLConfig(config)) {
+            if (entity.isPresent()) {
+                listener.onFailure(new IllegalArgumentException("PPL source_type does not support entity-scoped min time queries."));
+                return;
+            }
+            pplDirectQueryExecutor.executeMinDataTimeQuery(config, context, listener);
+            return;
+        }
+
         BoolQueryBuilder internalFilterQuery = QueryBuilders.boolQuery();
 
         if (entity.isPresent()) {
@@ -596,6 +721,31 @@ public class SearchFeatureDao extends AbstractRetriever {
      * @param listener onResponse is called with features for the given time period.
      */
     public void getFeaturesForPeriod(AnomalyDetector detector, long startTime, long endTime, ActionListener<Optional<double[]>> listener) {
+        if (isPrometheusConfig(detector)) {
+            try {
+                getFeatureSamplesForPeriods(
+                    detector,
+                    Collections.singletonList(new SimpleImmutableEntry<>(startTime, endTime)),
+                    AnalysisType.AD,
+                    true,
+                    ActionListener.wrap(samples -> {
+                        if (samples.size() == 1) {
+                            listener.onResponse(samples.get(0));
+                        } else {
+                            listener.onResponse(Optional.empty());
+                        }
+                    }, listener::onFailure)
+                );
+            } catch (IOException e) {
+                listener.onFailure(e);
+            }
+            return;
+        }
+        if (isPPLConfig(detector)) {
+            pplDirectQueryExecutor.executeMetricQuery(detector, startTime, endTime, AnalysisType.AD, listener);
+            return;
+        }
+
         SearchRequest searchRequest = createFeatureSearchRequest(detector, startTime, endTime, Optional.empty());
         final ActionListener<SearchResponse> searchResponseListener = ActionListener
             .wrap(response -> listener.onResponse(parseResponse(response, detector.getEnabledFeatureIds(), true)), listener::onFailure);
@@ -619,6 +769,15 @@ public class SearchFeatureDao extends AbstractRetriever {
         long endTime,
         ActionListener<Map<Long, Optional<double[]>>> listener
     ) throws IOException {
+        if (isPrometheusConfig(detector)) {
+            getPrometheusFeatureDataPointsByBatch(detector, entity, startTime, endTime, listener);
+            return;
+        }
+        if (isPPLConfig(detector)) {
+            listener.onFailure(new IllegalArgumentException("PPL source_type only supports single-stream detectors."));
+            return;
+        }
+
         SearchSourceBuilder searchSourceBuilder = batchFeatureQuery(detector, entity, startTime, endTime, xContent);
         logger.debug("Batch query for detector {}: {} ", detector.getId(), searchSourceBuilder);
 
@@ -683,6 +842,19 @@ public class SearchFeatureDao extends AbstractRetriever {
         boolean keepMissingValues,
         ActionListener<List<Optional<double[]>>> listener
     ) throws IOException {
+        if (ranges == null || ranges.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+        if (isPrometheusConfig(config)) {
+            getPrometheusFeatureSamplesForPeriods(config, ranges, Optional.empty(), context, keepMissingValues, listener);
+            return;
+        }
+        if (isPPLConfig(config)) {
+            getPPLFeatureSamplesForPeriods(config, ranges, Optional.empty(), context, keepMissingValues, listener);
+            return;
+        }
+
         SearchRequest request = createRangeSearchRequest(config, ranges);
         final ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(response -> {
             Aggregations aggs = response.getAggregations();
@@ -772,6 +944,20 @@ public class SearchFeatureDao extends AbstractRetriever {
         AnalysisType context,
         ActionListener<List<Optional<double[]>>> listener
     ) {
+        if (ranges == null || ranges.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+        if (isPrometheusConfig(config)) {
+            // Keep behavior aligned with existing cold-start path where missing values are dropped.
+            getPrometheusFeatureSamplesForPeriods(config, ranges, entity, context, false, listener);
+            return;
+        }
+        if (isPPLConfig(config)) {
+            getPPLFeatureSamplesForPeriods(config, ranges, entity, context, false, listener);
+            return;
+        }
+
         SearchRequest request = createColdStartFeatureSearchRequest(config, ranges, entity);
         final ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(response -> {
             listener.onResponse(parseColdStartSampleResp(response, includesEmptyBucket, config));
@@ -1166,5 +1352,204 @@ public class SearchFeatureDao extends AbstractRetriever {
         Collections.reverse(sampleRanges);
 
         return sampleRanges;
+    }
+
+    private boolean isPrometheusConfig(Config config) {
+        return config != null && Config.SOURCE_TYPE_PROMETHEUS.equals(config.getSourceType()) && config.getPrometheusSource() != null;
+    }
+
+    private boolean isPPLConfig(Config config) {
+        return config != null && Config.SOURCE_TYPE_PPL.equals(config.getSourceType()) && config.getPPLSource() != null;
+    }
+
+    private void getPPLFeatureSamplesForPeriods(
+        Config config,
+        List<Entry<Long, Long>> ranges,
+        Optional<Entity> entity,
+        AnalysisType context,
+        boolean keepMissingValues,
+        ActionListener<List<Optional<double[]>>> listener
+    ) {
+        if (entity.isPresent()) {
+            listener.onFailure(new IllegalArgumentException("PPL source_type only supports single-stream detectors."));
+            return;
+        }
+        if (ranges == null || ranges.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+
+        List<Optional<double[]>> results = new ArrayList<>(ranges.size());
+        fetchPPLFeatureSample(config, ranges, 0, context, keepMissingValues, results, listener);
+    }
+
+    private void fetchPPLFeatureSample(
+        Config config,
+        List<Entry<Long, Long>> ranges,
+        int index,
+        AnalysisType context,
+        boolean keepMissingValues,
+        List<Optional<double[]>> results,
+        ActionListener<List<Optional<double[]>>> listener
+    ) {
+        if (index >= ranges.size()) {
+            listener.onResponse(results);
+            return;
+        }
+
+        Entry<Long, Long> range = ranges.get(index);
+        pplDirectQueryExecutor.executeMetricQuery(config, range.getKey(), range.getValue(), context, ActionListener.wrap(value -> {
+            if (value.isPresent()) {
+                results.add(value);
+            } else if (keepMissingValues) {
+                results.add(Optional.of(createMissingFeatureVector(config)));
+            } else {
+                results.add(Optional.empty());
+            }
+            fetchPPLFeatureSample(config, ranges, index + 1, context, keepMissingValues, results, listener);
+        }, listener::onFailure));
+    }
+
+    private double[] createMissingFeatureVector(Config config) {
+        int featureCount = config.getEnabledFeatureIds().size();
+        double[] missingValues = new double[featureCount];
+        Arrays.fill(missingValues, Double.NaN);
+        return missingValues;
+    }
+
+    private void getPrometheusFeatureSamplesForPeriods(
+        Config config,
+        List<Entry<Long, Long>> ranges,
+        Optional<Entity> entity,
+        AnalysisType context,
+        boolean keepMissingValues,
+        ActionListener<List<Optional<double[]>>> listener
+    ) {
+        if (ranges == null || ranges.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+
+        long startTimeMs = ranges.get(0).getKey();
+        long endTimeMs = ranges.get(ranges.size() - 1).getValue();
+        long stepSeconds = Math.max(1L, config.getIntervalInSeconds());
+        Map<String, String> entityFilter = entity.map(Entity::getAttributes).orElse(null);
+
+        prometheusDirectQueryExecutor
+            .executeRangeQuery(config, startTimeMs, endTimeMs, stepSeconds, entityFilter, context, ActionListener.wrap(values -> {
+                List<Optional<double[]>> results = new ArrayList<>(ranges.size());
+                for (Entry<Long, Long> range : ranges) {
+                    Optional<Double> value = findRangeValue(values, range.getKey(), range.getValue());
+                    if (value.isPresent()) {
+                        results.add(Optional.of(new double[] { value.get() }));
+                    } else if (keepMissingValues) {
+                        results.add(Optional.of(new double[] { Double.NaN }));
+                    } else {
+                        results.add(Optional.empty());
+                    }
+                }
+                listener.onResponse(results);
+            }, listener::onFailure));
+    }
+
+    private void getPrometheusFeatureDataPointsByBatch(
+        AnomalyDetector detector,
+        Entity entity,
+        long startTime,
+        long endTime,
+        ActionListener<Map<Long, Optional<double[]>>> listener
+    ) {
+        List<Entry<Long, Long>> ranges = getContiguousRanges(startTime, endTime, Math.max(detector.getIntervalInMilliseconds(), 1L));
+        getPrometheusFeatureSamplesForPeriods(
+            detector,
+            ranges,
+            Optional.ofNullable(entity),
+            AnalysisType.AD,
+            true,
+            ActionListener.wrap(samples -> {
+                Map<Long, Optional<double[]>> dataPoints = new HashMap<>();
+                for (int i = 0; i < ranges.size() && i < samples.size(); i++) {
+                    dataPoints.put(ranges.get(i).getKey(), samples.get(i));
+                }
+                listener.onResponse(dataPoints);
+            }, listener::onFailure)
+        );
+    }
+
+    private List<Entry<Long, Long>> getContiguousRanges(long startTime, long endTime, long intervalMillis) {
+        List<Entry<Long, Long>> ranges = new ArrayList<>();
+        for (long rangeStart = startTime; rangeStart < endTime; rangeStart += intervalMillis) {
+            ranges.add(new SimpleImmutableEntry<>(rangeStart, Math.min(rangeStart + intervalMillis, endTime)));
+        }
+        return ranges;
+    }
+
+    private void getPrometheusHighestCountEntities(
+        AnomalyDetector detector,
+        long startTime,
+        long endTime,
+        int maxEntitiesSize,
+        int minimumDocCount,
+        ActionListener<List<Entity>> listener
+    ) {
+        prometheusDirectQueryExecutor
+            .executeRangeQueryBySeries(
+                detector,
+                startTime,
+                endTime,
+                Math.max(1L, detector.getIntervalInSeconds()),
+                AnalysisType.AD,
+                ActionListener.wrap(valuesBySeries -> {
+                    List<Entity> entities = valuesBySeries
+                        .entrySet()
+                        .stream()
+                        .map(entry -> buildEntityCount(detector.getCategoryFields(), entry.getKey(), entry.getValue().size()))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .filter(entry -> entry.getValue() >= minimumDocCount)
+                        .sorted((left, right) -> Integer.compare(right.getValue(), left.getValue()))
+                        .limit(maxEntitiesSize)
+                        .map(Entry::getKey)
+                        .collect(Collectors.toList());
+                    listener.onResponse(entities);
+                }, listener::onFailure)
+            );
+    }
+
+    private Optional<Entry<Entity, Integer>> buildEntityCount(
+        List<String> categoryFields,
+        Map<String, String> seriesLabels,
+        int valueCount
+    ) {
+        return buildEntity(categoryFields, seriesLabels).map(entity -> new SimpleImmutableEntry<>(entity, valueCount));
+    }
+
+    private Optional<Entity> buildEntity(List<String> categoryFields, Map<String, String> seriesLabels) {
+        if (categoryFields == null || categoryFields.isEmpty() || seriesLabels == null || seriesLabels.isEmpty()) {
+            return Optional.empty();
+        }
+
+        SortedMap<String, String> entityAttributes = new TreeMap<>();
+        for (String categoryField : categoryFields) {
+            String categoryValue = seriesLabels.get(categoryField);
+            if (categoryValue == null) {
+                return Optional.empty();
+            }
+            entityAttributes.put(categoryField, categoryValue);
+        }
+        return Optional.of(Entity.createEntityFromOrderedMap(entityAttributes));
+    }
+
+    private Optional<Double> findRangeValue(NavigableMap<Long, Double> values, long startTimeMs, long endTimeMs) {
+        if (values == null || values.isEmpty() || startTimeMs >= endTimeMs) {
+            return Optional.empty();
+        }
+
+        // Prometheus range-vector samples at bucket end describe the trailing window for that bucket.
+        Entry<Long, Double> candidate = values.floorEntry(endTimeMs);
+        if (candidate == null || candidate.getKey() < startTimeMs) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(candidate.getValue());
     }
 }

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -88,6 +89,14 @@ public abstract class Config implements Writeable, ToXContentObject {
     // We cannot use last update time as it would change whenever other fields like name changes.
     public static final String BREAKING_UI_CHANGE_TIME = "last_ui_breaking_change_time";
     public static final String FREQUENCY_FIELD = "frequency";
+    public static final String SOURCE_TYPE_FIELD = "source_type";
+    public static final String PROMETHEUS_SOURCE_FIELD = "prometheus_source";
+    public static final String PPL_SOURCE_FIELD = "ppl_source";
+    public static final String SOURCE_TYPE_OPENSEARCH = "OPENSEARCH";
+    public static final String SOURCE_TYPE_PROMETHEUS = "PROMETHEUS";
+    public static final String SOURCE_TYPE_PPL = "PPL";
+    public static final String PROMETHEUS_QUERY_LANGUAGE = "PROMQL";
+    public static final String PPL_QUERY_LANGUAGE = "PPL";
 
     protected String id;
     protected Long version;
@@ -131,6 +140,9 @@ public abstract class Config implements Writeable, ToXContentObject {
     protected Instant lastUIBreakingChangeTime;
     protected TimeConfiguration frequency;
     protected Boolean autoCreated;
+    protected String sourceType;
+    protected PrometheusSource prometheusSource;
+    protected PPLSource pplSource;
 
     public static String INVALID_RESULT_INDEX_NAME_SIZE = "Result index name size must contains less than "
         + MAX_RESULT_INDEX_NAME_SIZE
@@ -167,20 +179,295 @@ public abstract class Config implements Writeable, ToXContentObject {
         TimeConfiguration frequency,
         Boolean autoCreated
     ) {
+        this(
+            id,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            categoryFields,
+            user,
+            resultIndex,
+            interval,
+            imputationOption,
+            recencyEmphasis,
+            seasonIntervals,
+            shingleGetter,
+            historyIntervals,
+            customResultIndexMinSize,
+            customResultIndexMinAge,
+            customResultIndexTTL,
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime,
+            frequency,
+            autoCreated,
+            null,
+            null,
+            null
+        );
+    }
+
+    protected Config(
+        String id,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime,
+        List<String> categoryFields,
+        User user,
+        String resultIndex,
+        TimeConfiguration interval,
+        ImputationOption imputationOption,
+        Integer recencyEmphasis,
+        Integer seasonIntervals,
+        ShingleGetter shingleGetter,
+        Integer historyIntervals,
+        Integer customResultIndexMinSize,
+        Integer customResultIndexMinAge,
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime,
+        TimeConfiguration frequency,
+        Boolean autoCreated,
+        String sourceType,
+        PrometheusSource prometheusSource
+    ) {
+        this(
+            id,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            categoryFields,
+            user,
+            resultIndex,
+            interval,
+            imputationOption,
+            recencyEmphasis,
+            seasonIntervals,
+            shingleGetter,
+            historyIntervals,
+            customResultIndexMinSize,
+            customResultIndexMinAge,
+            customResultIndexTTL,
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime,
+            frequency,
+            autoCreated,
+            sourceType,
+            prometheusSource,
+            null
+        );
+    }
+
+    protected Config(
+        String id,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime,
+        List<String> categoryFields,
+        User user,
+        String resultIndex,
+        TimeConfiguration interval,
+        ImputationOption imputationOption,
+        Integer recencyEmphasis,
+        Integer seasonIntervals,
+        ShingleGetter shingleGetter,
+        Integer historyIntervals,
+        Integer customResultIndexMinSize,
+        Integer customResultIndexMinAge,
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime,
+        TimeConfiguration frequency,
+        Boolean autoCreated,
+        String sourceType,
+        PrometheusSource prometheusSource,
+        PPLSource pplSource
+    ) {
         if (Strings.isBlank(name)) {
             errorMessage = CommonMessages.EMPTY_NAME;
             issueType = ValidationIssueType.NAME;
             return;
         }
-        if (Strings.isBlank(timeField)) {
-            errorMessage = CommonMessages.NULL_TIME_FIELD;
-            issueType = ValidationIssueType.TIMEFIELD_FIELD;
+
+        String normalizedSourceType = normalizeSourceType(sourceType, prometheusSource, pplSource);
+        if (normalizedSourceType == null) {
+            issueType = ValidationIssueType.GENERAL_SETTINGS;
+            errorMessage = "Unsupported source_type [" + sourceType + "]. Supported values are OPENSEARCH, PROMETHEUS, and PPL.";
             return;
         }
-        if (indices == null || indices.isEmpty()) {
-            errorMessage = CommonMessages.EMPTY_INDICES;
-            issueType = ValidationIssueType.INDICES;
-            return;
+
+        String resolvedTimeField = timeField;
+        List<String> resolvedIndices = indices;
+        List<Feature> resolvedFeatures = features;
+
+        if (isPrometheusSource(normalizedSourceType)) {
+            if (prometheusSource == null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "Must set prometheus_source when source_type is PROMETHEUS.";
+                return;
+            }
+            if (!Strings.isBlank(timeField)) {
+                issueType = ValidationIssueType.TIMEFIELD_FIELD;
+                errorMessage = "time_field must be empty when source_type is PROMETHEUS.";
+                return;
+            }
+            if (indices != null && !indices.isEmpty()) {
+                issueType = ValidationIssueType.INDICES;
+                errorMessage = "indices must be empty when source_type is PROMETHEUS.";
+                return;
+            }
+            if (Strings.isBlank(prometheusSource.getQuery())) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "prometheus_source.query must be set when source_type is PROMETHEUS.";
+                return;
+            }
+            if (!PROMETHEUS_QUERY_LANGUAGE.equalsIgnoreCase(prometheusSource.getQueryLanguage())) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "prometheus_source.query_language must be PROMQL when source_type is PROMETHEUS.";
+                return;
+            }
+            if (Strings.isBlank(prometheusSource.getDataConnectionId())) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "prometheus_source.data_connection_id must be set when source_type is PROMETHEUS.";
+                return;
+            }
+            long enabledFeatureCount = features == null ? 0L : features.stream().filter(Feature::getEnabled).count();
+            if (enabledFeatureCount != 1) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = "Exactly one enabled feature is required when source_type is PROMETHEUS.";
+                return;
+            }
+            if (pplSource != null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "ppl_source must be empty when source_type is PROMETHEUS.";
+                return;
+            }
+        } else if (isPPLSource(normalizedSourceType)) {
+            if (pplSource == null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "Must set ppl_source when source_type is PPL.";
+                return;
+            }
+            if (!PPL_QUERY_LANGUAGE.equalsIgnoreCase(pplSource.getQueryLanguage())) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "ppl_source.query_language must be PPL when source_type is PPL.";
+                return;
+            }
+            if (prometheusSource != null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "prometheus_source must be empty when source_type is PPL.";
+                return;
+            }
+            if (categoryFields != null && !categoryFields.isEmpty()) {
+                issueType = ValidationIssueType.CATEGORY;
+                errorMessage = "category_field must be empty when source_type is PPL.";
+                return;
+            }
+
+            PPLSource.CompiledPPLQuery compiledPPLQuery;
+            try {
+                compiledPPLQuery = pplSource.compile();
+            } catch (IllegalArgumentException e) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = e.getMessage();
+                return;
+            }
+
+            resolvedTimeField = compiledPPLQuery.getTimeField();
+            resolvedIndices = Collections.singletonList(compiledPPLQuery.getIndex());
+            resolvedFeatures = features == null || features.isEmpty() ? compiledPPLQuery.toPlaceholderFeatures() : features;
+
+            if (resolvedFeatures.size() != compiledPPLQuery.getMetricCount()) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = String
+                    .format(
+                        Locale.ROOT,
+                        "feature_attributes must contain exactly %d entries when source_type is PPL.",
+                        compiledPPLQuery.getMetricCount()
+                    );
+                return;
+            }
+
+            for (int i = 0; i < resolvedFeatures.size(); i++) {
+                if (!compiledPPLQuery.getFeatureNames().get(i).equals(resolvedFeatures.get(i).getName())) {
+                    issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                    errorMessage = "feature_attributes must match the metric aliases defined in ppl_source.query.";
+                    return;
+                }
+            }
+
+            long enabledFeatureCount = resolvedFeatures.stream().filter(Feature::getEnabled).count();
+            if (enabledFeatureCount != compiledPPLQuery.getMetricCount()) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = String
+                    .format(
+                        Locale.ROOT,
+                        "Exactly %d enabled feature(s) are required when source_type is PPL.",
+                        compiledPPLQuery.getMetricCount()
+                    );
+                return;
+            }
+        } else {
+            if (Strings.isBlank(resolvedTimeField)) {
+                errorMessage = CommonMessages.NULL_TIME_FIELD;
+                issueType = ValidationIssueType.TIMEFIELD_FIELD;
+                return;
+            }
+            if (resolvedIndices == null || resolvedIndices.isEmpty()) {
+                errorMessage = CommonMessages.EMPTY_INDICES;
+                issueType = ValidationIssueType.INDICES;
+                return;
+            }
+            if (resolvedFeatures != null && resolvedFeatures.stream().anyMatch(Feature::usesPlaceholderAggregation)) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = "feature_attributes.aggregation_query must be set when source_type is OPENSEARCH.";
+                return;
+            }
+            if (prometheusSource != null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "prometheus_source must be empty when source_type is OPENSEARCH.";
+                return;
+            }
+            if (pplSource != null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "ppl_source must be empty when source_type is OPENSEARCH.";
+                return;
+            }
         }
 
         // shingle size
@@ -234,7 +521,7 @@ public abstract class Config implements Writeable, ToXContentObject {
             return;
         }
 
-        List<String> redundantNames = findRedundantNames(features);
+        List<String> redundantNames = findRedundantNames(resolvedFeatures);
         if (redundantNames.size() > 0) {
             issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
             errorMessage = redundantNames + " appears more than once. Feature name has to be unique";
@@ -243,9 +530,9 @@ public abstract class Config implements Writeable, ToXContentObject {
 
         if (imputationOption != null && imputationOption.getMethod() == ImputationMethod.FIXED_VALUES) {
             // Calculate the number of enabled features
-            List<Feature> enabledFeatures = features == null
+            List<Feature> enabledFeatures = resolvedFeatures == null
                 ? null
-                : features.stream().filter(Feature::getEnabled).collect(Collectors.toList());
+                : resolvedFeatures.stream().filter(Feature::getEnabled).collect(Collectors.toList());
 
             Map<String, Double> defaultFill = imputationOption.getDefaultFill();
 
@@ -333,10 +620,10 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.version = version;
         this.name = name;
         this.description = description;
-        this.timeField = timeField;
-        this.indices = indices;
+        this.timeField = Strings.isBlank(resolvedTimeField) ? "" : resolvedTimeField;
+        this.indices = resolvedIndices == null ? ImmutableList.of() : ImmutableList.copyOf(resolvedIndices);
         // we validate empty or no enabled features when starting config (Read IndexJobActionHandler.validateConfig)
-        this.featureAttributes = features == null ? ImmutableList.of() : ImmutableList.copyOf(features);
+        this.featureAttributes = resolvedFeatures == null ? ImmutableList.of() : ImmutableList.copyOf(resolvedFeatures);
         this.filterQuery = filterQuery;
         this.interval = interval;
         this.windowDelay = windowDelay;
@@ -361,6 +648,34 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.lastUIBreakingChangeTime = lastBreakingUIChangeTime;
         this.frequency = frequency;
         this.autoCreated = autoCreated != null ? autoCreated : false;
+        this.sourceType = normalizedSourceType;
+        this.prometheusSource = prometheusSource;
+        this.pplSource = pplSource;
+    }
+
+    private String normalizeSourceType(String sourceType, PrometheusSource prometheusSource, PPLSource pplSource) {
+        if (Strings.isBlank(sourceType)) {
+            if (prometheusSource != null) {
+                return SOURCE_TYPE_PROMETHEUS;
+            }
+            if (pplSource != null) {
+                return SOURCE_TYPE_PPL;
+            }
+            return SOURCE_TYPE_OPENSEARCH;
+        }
+        String normalized = sourceType.trim().toUpperCase(Locale.ROOT);
+        if (SOURCE_TYPE_OPENSEARCH.equals(normalized) || SOURCE_TYPE_PROMETHEUS.equals(normalized) || SOURCE_TYPE_PPL.equals(normalized)) {
+            return normalized;
+        }
+        return null;
+    }
+
+    private boolean isPrometheusSource(String sourceType) {
+        return SOURCE_TYPE_PROMETHEUS.equals(sourceType);
+    }
+
+    private boolean isPPLSource(String sourceType) {
+        return SOURCE_TYPE_PPL.equals(sourceType);
     }
 
     /**
@@ -465,6 +780,26 @@ public abstract class Config implements Writeable, ToXContentObject {
             this.frequency = null;
         }
         this.autoCreated = input.readOptionalBoolean();
+        if (input.available() > 0) {
+            this.sourceType = normalizeSourceType(input.readOptionalString(), null, null);
+        } else {
+            this.sourceType = SOURCE_TYPE_OPENSEARCH;
+        }
+        if (this.sourceType == null) {
+            this.sourceType = SOURCE_TYPE_OPENSEARCH;
+        }
+        if (input.available() > 0 && input.readBoolean()) {
+            this.prometheusSource = new PrometheusSource(input);
+            this.sourceType = normalizeSourceType(this.sourceType, this.prometheusSource, null);
+        } else {
+            this.prometheusSource = null;
+        }
+        if (input.available() > 0 && input.readBoolean()) {
+            this.pplSource = new PPLSource(input);
+            this.sourceType = normalizeSourceType(this.sourceType, this.prometheusSource, this.pplSource);
+        } else {
+            this.pplSource = null;
+        }
     }
 
     /*
@@ -526,6 +861,19 @@ public abstract class Config implements Writeable, ToXContentObject {
             output.writeBoolean(false);
         }
         output.writeOptionalBoolean(autoCreated);
+        output.writeOptionalString(sourceType);
+        if (prometheusSource != null) {
+            output.writeBoolean(true);
+            prometheusSource.writeTo(output);
+        } else {
+            output.writeBoolean(false);
+        }
+        if (pplSource != null) {
+            output.writeBoolean(true);
+            pplSource.writeTo(output);
+        } else {
+            output.writeBoolean(false);
+        }
     }
 
     public boolean invalidShingleSizeRange(Integer shingleSizeToTest) {
@@ -585,7 +933,10 @@ public abstract class Config implements Writeable, ToXContentObject {
             && Objects.equal(customResultIndexTTL, config.customResultIndexTTL)
             && Objects.equal(flattenResultIndexMapping, config.flattenResultIndexMapping)
             && Objects.equal(frequency, config.frequency)
-            && Objects.equal(autoCreated, config.autoCreated);
+            && Objects.equal(autoCreated, config.autoCreated)
+            && Objects.equal(sourceType, config.sourceType)
+            && Objects.equal(prometheusSource, config.prometheusSource)
+            && Objects.equal(pplSource, config.pplSource);
     }
 
     @Generated
@@ -615,7 +966,10 @@ public abstract class Config implements Writeable, ToXContentObject {
                 customResultIndexTTL,
                 flattenResultIndexMapping,
                 frequency,
-                autoCreated
+                autoCreated,
+                sourceType,
+                prometheusSource,
+                pplSource
             );
     }
 
@@ -624,8 +978,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         builder
             .field(NAME_FIELD, name)
             .field(DESCRIPTION_FIELD, Encode.forHtml(description))
-            .field(TIMEFIELD_FIELD, timeField)
-            .field(INDICES_FIELD, indices.toArray())
             .field(FILTER_QUERY_FIELD, filterQuery)
             .field(WINDOW_DELAY_FIELD, windowDelay)
             .field(SHINGLE_SIZE_FIELD, shingleSize)
@@ -633,6 +985,22 @@ public abstract class Config implements Writeable, ToXContentObject {
             .field(FEATURE_ATTRIBUTES_FIELD, featureAttributes.toArray())
             .field(RECENCY_EMPHASIS_FIELD, recencyEmphasis)
             .field(HISTORY_INTERVAL_FIELD, historyIntervals);
+
+        if (SOURCE_TYPE_PROMETHEUS.equals(sourceType)) {
+            builder.field(SOURCE_TYPE_FIELD, sourceType);
+            if (prometheusSource != null) {
+                builder.field(PROMETHEUS_SOURCE_FIELD, prometheusSource);
+            }
+        } else {
+            builder.field(TIMEFIELD_FIELD, timeField);
+            builder.field(INDICES_FIELD, indices.toArray());
+            if (SOURCE_TYPE_PPL.equals(sourceType)) {
+                builder.field(SOURCE_TYPE_FIELD, sourceType);
+                if (pplSource != null) {
+                    builder.field(PPL_SOURCE_FIELD, pplSource);
+                }
+            }
+        }
 
         if (uiMetadata != null && !uiMetadata.isEmpty()) {
             builder.field(UI_METADATA_FIELD, uiMetadata);
@@ -697,6 +1065,18 @@ public abstract class Config implements Writeable, ToXContentObject {
 
     public List<String> getIndices() {
         return indices;
+    }
+
+    public String getSourceType() {
+        return sourceType;
+    }
+
+    public PrometheusSource getPrometheusSource() {
+        return prometheusSource;
+    }
+
+    public PPLSource getPPLSource() {
+        return pplSource;
     }
 
     public List<Feature> getFeatureAttributes() {

--- a/src/main/java/org/opensearch/timeseries/model/Feature.java
+++ b/src/main/java/org/opensearch/timeseries/model/Feature.java
@@ -25,6 +25,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.timeseries.annotation.Generated;
 import org.opensearch.timeseries.util.ParseUtils;
 
@@ -39,6 +40,10 @@ public class Feature implements Writeable, ToXContentObject {
     public static final String FEATURE_NAME_FIELD = "feature_name";
     private static final String FEATURE_ENABLED_FIELD = "feature_enabled";
     private static final String AGGREGATION_QUERY = "aggregation_query";
+    public static final String PROMETHEUS_PLACEHOLDER_AGG_NAME = "__prometheus_feature_value__";
+    private static final String PROMETHEUS_PLACEHOLDER_FIELD = "__prometheus_value__";
+    public static final String DIRECT_QUERY_PLACEHOLDER_AGG_NAME = "__direct_query_feature_value__";
+    private static final String DIRECT_QUERY_PLACEHOLDER_FIELD = "__direct_query_value__";
 
     private final String id;
     private final String name;
@@ -47,7 +52,7 @@ public class Feature implements Writeable, ToXContentObject {
 
     /**
      * Constructor function.
-     *  @param id      feature id
+     * @param id      feature id
      * @param name    feature name
      * @param enabled feature enabled or not
      * @param aggregation feature aggregation query
@@ -130,7 +135,16 @@ public class Feature implements Writeable, ToXContentObject {
                     break;
             }
         }
+        if (aggregation == null) {
+            aggregation = AggregationBuilders.avg(PROMETHEUS_PLACEHOLDER_AGG_NAME).field(PROMETHEUS_PLACEHOLDER_FIELD);
+        }
         return new Feature(id, name, enabled, aggregation);
+    }
+
+    public static Feature createDirectQueryPlaceholder(String id, String name, Boolean enabled) {
+        String suffix = id == null ? UUIDs.base64UUID() : id;
+        String aggregationName = DIRECT_QUERY_PLACEHOLDER_AGG_NAME + "_" + suffix.replaceAll("[^A-Za-z0-9_]+", "_");
+        return new Feature(id, name, enabled, AggregationBuilders.avg(aggregationName).field(DIRECT_QUERY_PLACEHOLDER_FIELD));
     }
 
     @Generated
@@ -169,6 +183,18 @@ public class Feature implements Writeable, ToXContentObject {
 
     public AggregationBuilder getAggregation() {
         return aggregation;
+    }
+
+    public boolean usesPrometheusPlaceholderAggregation() {
+        return aggregation != null && PROMETHEUS_PLACEHOLDER_AGG_NAME.equals(aggregation.getName());
+    }
+
+    public boolean usesDirectQueryPlaceholderAggregation() {
+        return aggregation != null && aggregation.getName() != null && aggregation.getName().startsWith(DIRECT_QUERY_PLACEHOLDER_AGG_NAME);
+    }
+
+    public boolean usesPlaceholderAggregation() {
+        return usesPrometheusPlaceholderAggregation() || usesDirectQueryPlaceholderAggregation();
     }
 
     @Override

--- a/src/main/java/org/opensearch/timeseries/model/PPLSource.java
+++ b/src/main/java/org/opensearch/timeseries/model/PPLSource.java
@@ -1,0 +1,785 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.model;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.logging.log4j.util.Strings;
+import org.opensearch.common.UUIDs;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.timeseries.annotation.Generated;
+
+import com.google.common.base.Objects;
+
+/**
+ * Stores the original PPL query for detectors created from a detector-friendly
+ * single-stream PPL form. The query is compiled into detector metadata at
+ * creation time, then executed through the PPL engine at runtime.
+ */
+public class PPLSource implements Writeable, ToXContentObject {
+
+    public static final String QUERY_LANGUAGE_FIELD = "query_language";
+    public static final String QUERY_FIELD = "query";
+    public static final String PPL_QUERY_LANGUAGE = "PPL";
+
+    private static final String STATS_ERROR_MESSAGE =
+        "Unsupported PPL stats clause. Expected a final stage shaped like: stats <agg>(...) [as <feature>][, ...] by span(<time_field>, <interval>), where interval uses s or m.";
+    private static final DateTimeFormatter QUERY_TIMESTAMP_FORMATTER = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ss.SSS", Locale.ROOT)
+        .withZone(ZoneOffset.UTC);
+
+    private final String queryLanguage;
+    private final String query;
+
+    public PPLSource(String queryLanguage, String query) {
+        this.queryLanguage = queryLanguage;
+        this.query = query;
+    }
+
+    public PPLSource(StreamInput in) throws IOException {
+        this.queryLanguage = in.readOptionalString();
+        this.query = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(queryLanguage);
+        out.writeOptionalString(query);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (queryLanguage != null) {
+            builder.field(QUERY_LANGUAGE_FIELD, queryLanguage);
+        }
+        if (query != null) {
+            builder.field(QUERY_FIELD, query);
+        }
+        return builder.endObject();
+    }
+
+    public static PPLSource parse(XContentParser parser) throws IOException {
+        String queryLanguage = null;
+        String query = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            switch (fieldName) {
+                case QUERY_LANGUAGE_FIELD:
+                    queryLanguage = parser.textOrNull();
+                    break;
+                case QUERY_FIELD:
+                    query = parser.textOrNull();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new PPLSource(queryLanguage, query);
+    }
+
+    public CompiledPPLQuery compile() {
+        return compile(query);
+    }
+
+    public static CompiledPPLQuery compile(String query) {
+        if (Strings.isBlank(query)) {
+            throw new IllegalArgumentException("ppl_source.query must be set when source_type is PPL.");
+        }
+
+        List<String> stages = splitTopLevel(query.trim(), '|');
+        if (stages.size() < 2) {
+            throw new IllegalArgumentException(
+                "Unsupported ppl_source.query. Expected a PPL pipeline that starts with source = <index> and ends with stats ... by span(...)."
+            );
+        }
+
+        SourceStage sourceStage = parseSourceStage(stages.get(0));
+        int statsStageIndex = findFinalStatsStageIndex(stages);
+        if (statsStageIndex <= 0) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        for (int i = statsStageIndex + 1; i < stages.size(); i++) {
+            String stage = stages.get(i);
+            if (!isSortStage(stage)) {
+                throw new IllegalArgumentException(
+                    "Unsupported PPL pipeline stage [" + stage + "] after the final stats stage. Only trailing sort stages are supported."
+                );
+            }
+        }
+
+        List<String> preStatsStages = new ArrayList<>(Math.max(0, statsStageIndex - 1));
+        for (int i = 1; i < statsStageIndex; i++) {
+            String stage = stages.get(i).trim();
+            if (stage.isEmpty()) {
+                continue;
+            }
+            if (isSourceStage(stage)) {
+                throw new IllegalArgumentException("PPL detector queries must contain exactly one source stage.");
+            }
+            if (isStatsStage(stage)) {
+                throw new IllegalArgumentException("Only one final stats stage is supported in ppl_source.query for detector creation.");
+            }
+            preStatsStages.add(stage);
+        }
+
+        StatsStage statsStage = parseStatsStage(stages.get(statsStageIndex));
+        return new CompiledPPLQuery(
+            sourceStage.getIndex(),
+            Collections.unmodifiableList(preStatsStages),
+            statsStage.getTimeField(),
+            statsStage.getMetrics(),
+            statsStage.getInterval()
+        );
+    }
+
+    private static SourceStage parseSourceStage(String stage) {
+        String trimmed = stage.trim();
+        int equalsIndex = trimmed.indexOf('=');
+        if (!startsWithKeyword(trimmed, "source") || equalsIndex < 0) {
+            throw new IllegalArgumentException("Unsupported PPL source clause. Expected: source = <index>.");
+        }
+
+        String index = stripBackticks(trimmed.substring(equalsIndex + 1));
+        if (Strings.isBlank(index) || index.contains(",")) {
+            throw new IllegalArgumentException("PPL source must reference exactly one index or index pattern.");
+        }
+        return new SourceStage(index);
+    }
+
+    private static int findFinalStatsStageIndex(List<String> stages) {
+        int lastStatsStageIndex = -1;
+        for (int i = stages.size() - 1; i >= 1; i--) {
+            String stage = stages.get(i).trim();
+            if (stage.isEmpty()) {
+                continue;
+            }
+            if (isStatsStage(stage)) {
+                lastStatsStageIndex = i;
+                break;
+            }
+        }
+        return lastStatsStageIndex;
+    }
+
+    private static StatsStage parseStatsStage(String stage) {
+        String trimmed = stage.trim();
+        if (!isStatsStage(trimmed)) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String statsBody = trimmed.substring("stats".length()).trim();
+        int bySpanIndex = findTopLevelBySpanIndex(statsBody);
+        if (bySpanIndex < 0) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String metricsClause = statsBody.substring(0, bySpanIndex).trim();
+        String spanClause = statsBody.substring(bySpanIndex).trim();
+
+        if (!startsWithKeyword(spanClause, "by")) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+        spanClause = spanClause.substring(2).trim();
+        if (!startsWithKeyword(spanClause, "span")) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        int openParenIndex = spanClause.indexOf('(');
+        int closeParenIndex = findMatchingParen(spanClause, openParenIndex);
+        if (openParenIndex < 0 || closeParenIndex < 0) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String spanArgs = spanClause.substring(openParenIndex + 1, closeParenIndex).trim();
+        List<String> spanParts = splitTopLevel(spanArgs, ',');
+        if (spanParts.size() != 2) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String trailingSpanClause = spanClause.substring(closeParenIndex + 1).trim();
+        if (!trailingSpanClause.isEmpty()) {
+            int aliasSeparator = findTopLevelAsSeparator(trailingSpanClause);
+            if (aliasSeparator != 0 || trailingSpanClause.substring(aliasSeparator + 2).trim().isEmpty()) {
+                // `as bucket` is allowed, but we do not consume the alias.
+                throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+            }
+        }
+
+        String timeField = stripBackticks(spanParts.get(0));
+        if (Strings.isBlank(timeField) || timeField.contains(" ")) {
+            throw new IllegalArgumentException("PPL span time field must be a single field reference.");
+        }
+
+        List<MetricSpec> metrics = parseMetrics(metricsClause);
+        IntervalTimeConfiguration intervalConfiguration = parseInterval(spanParts.get(1).trim());
+        return new StatsStage(metrics, timeField, intervalConfiguration);
+    }
+
+    private static List<MetricSpec> parseMetrics(String metricsClause) {
+        List<String> metricExpressions = splitTopLevel(metricsClause, ',');
+        if (metricExpressions.isEmpty()) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        List<MetricSpec> metrics = new ArrayList<>(metricExpressions.size());
+        Set<String> seenFeatureNames = new HashSet<>();
+        for (String metricExpression : metricExpressions) {
+            MetricSpec metric = parseMetric(metricExpression.trim());
+            if (!seenFeatureNames.add(metric.getFeatureName())) {
+                throw new IllegalArgumentException(
+                    "Duplicate metric alias [" + metric.getFeatureName() + "] is not supported in ppl_source.query."
+                );
+            }
+            metrics.add(metric);
+        }
+        return Collections.unmodifiableList(metrics);
+    }
+
+    private static MetricSpec parseMetric(String metricExpression) {
+        int aliasSeparator = findTopLevelAsSeparator(metricExpression);
+        String metricCore = aliasSeparator >= 0 ? metricExpression.substring(0, aliasSeparator).trim() : metricExpression.trim();
+        String alias = aliasSeparator >= 0 ? stripBackticks(metricExpression.substring(aliasSeparator + 2).trim()) : null;
+
+        int openParenIndex = metricCore.indexOf('(');
+        int closeParenIndex = findMatchingParen(metricCore, openParenIndex);
+        if (openParenIndex <= 0 || closeParenIndex != metricCore.length() - 1) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String aggregationType = metricCore.substring(0, openParenIndex).trim().toLowerCase(Locale.ROOT);
+        if (!isSupportedAggregationType(aggregationType)) {
+            throw new IllegalArgumentException(
+                "Unsupported aggregation ["
+                    + aggregationType
+                    + "] in ppl_source.query. Supported aggregations are count, sum, avg, min, and max."
+            );
+        }
+
+        String argumentExpression = metricCore.substring(openParenIndex + 1, closeParenIndex).trim();
+        boolean countAll = "count".equals(aggregationType) && (argumentExpression.isEmpty() || "*".equals(argumentExpression));
+        if (!countAll && Strings.isBlank(argumentExpression)) {
+            throw new IllegalArgumentException("PPL aggregation arguments cannot be empty unless using count().");
+        }
+
+        String normalizedArgument = countAll ? null : argumentExpression;
+        String resolvedFeatureName = Strings.isBlank(alias) ? defaultFeatureName(aggregationType, normalizedArgument, countAll) : alias;
+
+        return new MetricSpec(aggregationType, normalizedArgument, resolvedFeatureName, countAll);
+    }
+
+    private static boolean isSupportedAggregationType(String aggregationType) {
+        return "count".equals(aggregationType)
+            || "sum".equals(aggregationType)
+            || "avg".equals(aggregationType)
+            || "min".equals(aggregationType)
+            || "max".equals(aggregationType);
+    }
+
+    private static String defaultFeatureName(String aggregationType, String argumentExpression, boolean countAll) {
+        if (countAll) {
+            return "count_all";
+        }
+        String sanitized = sanitizeIdentifier(stripBackticks(argumentExpression));
+        return aggregationType + "_" + (sanitized.isEmpty() ? "value" : sanitized);
+    }
+
+    private static String sanitizeIdentifier(String value) {
+        return (value == null ? "" : value).replaceAll("[^A-Za-z0-9_]+", "_").replaceAll("^_+|_+$", "");
+    }
+
+    private static List<String> splitTopLevel(String value, char delimiter) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            char previous = i > 0 ? value.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth = Math.max(0, depth - 1);
+                }
+            }
+
+            if (ch == delimiter && depth == 0 && !inSingleQuote && !inDoubleQuote && !inBackticks) {
+                String part = current.toString().trim();
+                if (!part.isEmpty()) {
+                    parts.add(part);
+                }
+                current.setLength(0);
+                continue;
+            }
+
+            current.append(ch);
+        }
+
+        String part = current.toString().trim();
+        if (!part.isEmpty()) {
+            parts.add(part);
+        }
+        return parts;
+    }
+
+    private static int findTopLevelBySpanIndex(String statsBody) {
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = 0; i < statsBody.length(); i++) {
+            char ch = statsBody.charAt(i);
+            char previous = i > 0 ? statsBody.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth = Math.max(0, depth - 1);
+                }
+            }
+
+            if (depth == 0 && !inSingleQuote && !inDoubleQuote && !inBackticks && matchesKeywordWithLeadingWhitespace(statsBody, i, "by")) {
+                String tail = statsBody.substring(i).trim();
+                if (tail.length() >= 2 && startsWithKeyword(tail, "by")) {
+                    String afterBy = tail.substring(2).trim();
+                    if (startsWithKeyword(afterBy, "span")) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static int findTopLevelAsSeparator(String value) {
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = 0; i <= value.length() - 2; i++) {
+            char ch = value.charAt(i);
+            char previous = i > 0 ? value.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth = Math.max(0, depth - 1);
+                }
+            }
+
+            if (depth == 0 && !inSingleQuote && !inDoubleQuote && !inBackticks && matchesKeywordWithWhitespace(value, i, "as")) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findMatchingParen(String value, int openParenIndex) {
+        if (openParenIndex < 0 || openParenIndex >= value.length() || value.charAt(openParenIndex) != '(') {
+            return -1;
+        }
+
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = openParenIndex; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            char previous = i > 0 ? value.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth--;
+                    if (depth == 0) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static boolean matchesKeywordWithWhitespace(String value, int startIndex, String keyword) {
+        int endIndex = startIndex + keyword.length();
+        if (endIndex > value.length()) {
+            return false;
+        }
+        if (!value.regionMatches(true, startIndex, keyword, 0, keyword.length())) {
+            return false;
+        }
+
+        boolean validLeft = startIndex == 0 || Character.isWhitespace(value.charAt(startIndex - 1));
+        boolean validRight = endIndex == value.length() || Character.isWhitespace(value.charAt(endIndex));
+        return validLeft && validRight;
+    }
+
+    private static boolean matchesKeywordWithLeadingWhitespace(String value, int startIndex, String keyword) {
+        if (!matchesKeywordWithWhitespace(value, startIndex, keyword)) {
+            return false;
+        }
+        return startIndex == 0 || Character.isWhitespace(value.charAt(startIndex - 1));
+    }
+
+    private static IntervalTimeConfiguration parseInterval(String interval) {
+        String trimmed = interval == null ? "" : interval.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Unsupported PPL span interval [" + interval + "].");
+        }
+
+        int numericEnd = 0;
+        while (numericEnd < trimmed.length() && Character.isDigit(trimmed.charAt(numericEnd))) {
+            numericEnd++;
+        }
+        if (numericEnd == 0) {
+            throw new IllegalArgumentException("Unsupported PPL span interval [" + interval + "].");
+        }
+
+        String numericText = trimmed.substring(0, numericEnd);
+        String unitText = trimmed.substring(numericEnd).trim().toLowerCase(Locale.ROOT);
+        if (unitText.length() != 1) {
+            throw new IllegalArgumentException("Unsupported PPL span interval [" + interval + "].");
+        }
+
+        int value = Integer.parseInt(numericText);
+        if (value <= 0) {
+            throw new IllegalArgumentException("PPL span interval must be positive.");
+        }
+
+        switch (unitText.charAt(0)) {
+            case 's':
+                return new IntervalTimeConfiguration(value, ChronoUnit.SECONDS);
+            case 'm':
+                return new IntervalTimeConfiguration(value, ChronoUnit.MINUTES);
+            default:
+                throw new IllegalArgumentException(
+                    "Unsupported PPL span interval unit [" + unitText + "]. Only seconds (s) and minutes (m) are supported."
+                );
+        }
+    }
+
+    private static boolean startsWithKeyword(String value, String keyword) {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.length() < keyword.length()) {
+            return false;
+        }
+        if (!trimmed.regionMatches(true, 0, keyword, 0, keyword.length())) {
+            return false;
+        }
+        return trimmed.length() == keyword.length()
+            || Character.isWhitespace(trimmed.charAt(keyword.length()))
+            || trimmed.charAt(keyword.length()) == '='
+            || trimmed.charAt(keyword.length()) == '(';
+    }
+
+    private static boolean isSourceStage(String stage) {
+        return startsWithKeyword(stage, "source");
+    }
+
+    private static boolean isWhereStage(String stage) {
+        return startsWithKeyword(stage, "where");
+    }
+
+    private static boolean isStatsStage(String stage) {
+        return startsWithKeyword(stage, "stats");
+    }
+
+    private static boolean isSortStage(String stage) {
+        return startsWithKeyword(stage, "sort");
+    }
+
+    private static String stripBackticks(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.startsWith("`") && trimmed.endsWith("`") && trimmed.length() >= 2) {
+            return trimmed.substring(1, trimmed.length() - 1).trim();
+        }
+        return trimmed;
+    }
+
+    public String getQueryLanguage() {
+        return queryLanguage;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PPLSource that = (PPLSource) o;
+        return Objects.equal(queryLanguage, that.queryLanguage) && Objects.equal(query, that.query);
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(queryLanguage, query);
+    }
+
+    public static class CompiledPPLQuery {
+        private final String index;
+        private final List<String> preStatsStages;
+        private final String timeField;
+        private final List<MetricSpec> metrics;
+        private final IntervalTimeConfiguration interval;
+
+        CompiledPPLQuery(
+            String index,
+            List<String> preStatsStages,
+            String timeField,
+            List<MetricSpec> metrics,
+            IntervalTimeConfiguration interval
+        ) {
+            this.index = index;
+            this.preStatsStages = preStatsStages;
+            this.timeField = timeField;
+            this.metrics = metrics;
+            this.interval = interval;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+
+        public List<String> getPreStatsStages() {
+            return preStatsStages;
+        }
+
+        public String getTimeField() {
+            return timeField;
+        }
+
+        public List<MetricSpec> getMetrics() {
+            return metrics;
+        }
+
+        public int getMetricCount() {
+            return metrics.size();
+        }
+
+        public List<String> getFeatureNames() {
+            List<String> featureNames = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                featureNames.add(metric.getFeatureName());
+            }
+            return Collections.unmodifiableList(featureNames);
+        }
+
+        public IntervalTimeConfiguration getInterval() {
+            return interval;
+        }
+
+        public List<Feature> toPlaceholderFeatures() {
+            List<Feature> features = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                features.add(Feature.createDirectQueryPlaceholder(UUIDs.base64UUID(), metric.getFeatureName(), true));
+            }
+            return features;
+        }
+
+        public String buildMetricQueryForRange(long startTimeMs, long endTimeMs) {
+            List<String> metricsExpressions = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                metricsExpressions.add(metric.toStatsExpression());
+            }
+            return buildStatsQuery(
+                String.join(", ", metricsExpressions),
+                String
+                    .format(
+                        Locale.ROOT,
+                        "%s >= \"%s\" and %s < \"%s\"",
+                        maybeQuote(timeField),
+                        formatQueryTimestamp(startTimeMs),
+                        maybeQuote(timeField),
+                        formatQueryTimestamp(endTimeMs)
+                    )
+            );
+        }
+
+        public String buildLatestTimeQuery() {
+            return buildStatsQuery("max(" + maybeQuote(timeField) + ") as latest_time", null);
+        }
+
+        public String buildMinTimeQuery() {
+            return buildStatsQuery("min(" + maybeQuote(timeField) + ") as min_time", null);
+        }
+
+        public String buildDateRangeQuery() {
+            return buildStatsQuery("min(" + maybeQuote(timeField) + ") as min_time, max(" + maybeQuote(timeField) + ") as max_time", null);
+        }
+
+        private String buildStatsQuery(String statsExpression, String appendedWhereClause) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("source = ").append(maybeQuote(index));
+            for (String stage : preStatsStages) {
+                builder.append(" | ").append(stage);
+            }
+            if (!Strings.isBlank(appendedWhereClause)) {
+                builder.append(" | where ").append(appendedWhereClause);
+            }
+            builder.append(" | stats ").append(statsExpression);
+            return builder.toString();
+        }
+
+        private static String formatQueryTimestamp(long epochMillis) {
+            return QUERY_TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(epochMillis));
+        }
+
+        private static String maybeQuote(String identifier) {
+            if (identifier == null) {
+                return null;
+            }
+            String trimmed = identifier.trim();
+            return trimmed.matches("[A-Za-z0-9_.*:-]+") ? trimmed : "`" + trimmed.replace("`", "\\`") + "`";
+        }
+    }
+
+    public static class MetricSpec {
+        private final String aggregationType;
+        private final String aggregationField;
+        private final String featureName;
+        private final boolean countAll;
+
+        MetricSpec(String aggregationType, String aggregationField, String featureName, boolean countAll) {
+            this.aggregationType = aggregationType;
+            this.aggregationField = aggregationField;
+            this.featureName = featureName;
+            this.countAll = countAll;
+        }
+
+        public String getAggregationType() {
+            return aggregationType;
+        }
+
+        public String getAggregationField() {
+            return aggregationField;
+        }
+
+        public String getFeatureName() {
+            return featureName;
+        }
+
+        public boolean isCountAll() {
+            return countAll;
+        }
+
+        private String toStatsExpression() {
+            if (countAll) {
+                return "count() as " + CompiledPPLQuery.maybeQuote(featureName);
+            }
+            return aggregationType + "(" + aggregationField + ") as " + CompiledPPLQuery.maybeQuote(featureName);
+        }
+    }
+
+    private static class SourceStage {
+        private final String index;
+
+        SourceStage(String index) {
+            this.index = index;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+    }
+
+    private static class StatsStage {
+        private final List<MetricSpec> metrics;
+        private final String timeField;
+        private final IntervalTimeConfiguration interval;
+
+        StatsStage(List<MetricSpec> metrics, String timeField, IntervalTimeConfiguration interval) {
+            this.metrics = metrics;
+            this.timeField = timeField;
+            this.interval = interval;
+        }
+
+        public List<MetricSpec> getMetrics() {
+            return metrics;
+        }
+
+        public String getTimeField() {
+            return timeField;
+        }
+
+        public IntervalTimeConfiguration getInterval() {
+            return interval;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/model/PrometheusSource.java
+++ b/src/main/java/org/opensearch/timeseries/model/PrometheusSource.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.model;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.timeseries.annotation.Generated;
+
+import com.google.common.base.Objects;
+
+/**
+ * Prometheus source configuration for external metrics ingestion.
+ */
+public class PrometheusSource implements Writeable, ToXContentObject {
+
+    public static final String QUERY_LANGUAGE_FIELD = "query_language";
+    public static final String QUERY_FIELD = "query";
+    public static final String DATA_CONNECTION_ID_FIELD = "data_connection_id";
+    public static final String SERIES_FILTER_FIELD = "series_filter";
+
+    private final String queryLanguage;
+    private final String query;
+    private final String dataConnectionId;
+    private final Map<String, String> seriesFilter;
+
+    public PrometheusSource(String queryLanguage, String query, String dataConnectionId) {
+        this(queryLanguage, query, dataConnectionId, null);
+    }
+
+    public PrometheusSource(String queryLanguage, String query, String dataConnectionId, Map<String, String> seriesFilter) {
+        this.queryLanguage = queryLanguage;
+        this.query = query;
+        this.dataConnectionId = dataConnectionId;
+        this.seriesFilter = seriesFilter == null || seriesFilter.isEmpty()
+            ? null
+            : Collections.unmodifiableMap(new LinkedHashMap<>(seriesFilter));
+    }
+
+    public PrometheusSource(StreamInput in) throws IOException {
+        this.queryLanguage = in.readOptionalString();
+        this.query = in.readOptionalString();
+        this.dataConnectionId = in.readOptionalString();
+        this.seriesFilter = in.readBoolean()
+            ? Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString))
+            : null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(queryLanguage);
+        out.writeOptionalString(query);
+        out.writeOptionalString(dataConnectionId);
+        out.writeBoolean(seriesFilter != null);
+        if (seriesFilter != null) {
+            out.writeMap(seriesFilter, StreamOutput::writeString, StreamOutput::writeString);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (queryLanguage != null) {
+            builder.field(QUERY_LANGUAGE_FIELD, queryLanguage);
+        }
+        if (query != null) {
+            builder.field(QUERY_FIELD, query);
+        }
+        if (dataConnectionId != null) {
+            builder.field(DATA_CONNECTION_ID_FIELD, dataConnectionId);
+        }
+        if (seriesFilter != null && !seriesFilter.isEmpty()) {
+            builder.field(SERIES_FILTER_FIELD, seriesFilter);
+        }
+        return builder.endObject();
+    }
+
+    public static PrometheusSource parse(XContentParser parser) throws IOException {
+        String queryLanguage = null;
+        String query = null;
+        String dataConnectionId = null;
+        Map<String, String> seriesFilter = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            switch (fieldName) {
+                case QUERY_LANGUAGE_FIELD:
+                    queryLanguage = parser.textOrNull();
+                    break;
+                case QUERY_FIELD:
+                    query = parser.textOrNull();
+                    break;
+                case DATA_CONNECTION_ID_FIELD:
+                    dataConnectionId = parser.textOrNull();
+                    break;
+                case SERIES_FILTER_FIELD:
+                    if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+                        seriesFilter = new LinkedHashMap<>();
+                        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                            String labelName = parser.currentName();
+                            parser.nextToken();
+                            seriesFilter.put(labelName, parser.textOrNull());
+                        }
+                    } else {
+                        parser.skipChildren();
+                    }
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new PrometheusSource(queryLanguage, query, dataConnectionId, seriesFilter);
+    }
+
+    public String getQueryLanguage() {
+        return queryLanguage;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public String getDataConnectionId() {
+        return dataConnectionId;
+    }
+
+    public Map<String, String> getSeriesFilter() {
+        return seriesFilter;
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PrometheusSource that = (PrometheusSource) o;
+        return Objects.equal(queryLanguage, that.queryLanguage)
+            && Objects.equal(query, that.query)
+            && Objects.equal(dataConnectionId, that.dataConnectionId)
+            && Objects.equal(seriesFilter, that.seriesFilter);
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(queryLanguage, query, dataConnectionId, seriesFilter);
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -325,6 +325,11 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
     }
 
     protected void validateTimeField(boolean indexingDryRun, ActionListener<T> listener) {
+        if (isPrometheusSourceConfig()) {
+            prepareConfigIndexing(indexingDryRun, listener);
+            return;
+        }
+
         String givenTimeField = config.getTimeField();
         HashMap<String, List<String>> clusterIndicesMap = CrossClusterConfigUtils
             .separateClusterIndexes(config.getIndices(), clusterService);
@@ -918,6 +923,15 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
     }
 
     protected void searchConfigInputIndices(String configId, boolean indexingDryRun, ActionListener<T> listener) {
+        if (isPrometheusSourceConfig()) {
+            try {
+                validateConfigFeatures(configId, indexingDryRun, listener);
+            } catch (IOException e) {
+                listener.onFailure(e);
+            }
+            return;
+        }
+
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
             .query(QueryBuilders.matchAllQuery())
             .size(0)
@@ -1152,6 +1166,10 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             listener.onFailure(new OpenSearchStatusException(error, RestStatus.BAD_REQUEST));
             return;
         }
+        if (isPrometheusSourceConfig() || isPPLSourceConfig()) {
+            checkConfigNameExists(id, indexingDryRun, listener);
+            return;
+        }
         // checking runtime error from feature query
         ActionListener<MergeableList<Optional<double[]>>> validateFeatureQueriesListener = ActionListener.wrap(response -> {
             checkConfigNameExists(id, indexingDryRun, listener);
@@ -1204,6 +1222,14 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             });
             clientUtil.asyncRequestWithInjectedSecurity(searchRequest, client::search, user, client, context, searchResponseListener);
         }
+    }
+
+    protected boolean isPrometheusSourceConfig() {
+        return config != null && Config.SOURCE_TYPE_PROMETHEUS.equals(config.getSourceType());
+    }
+
+    protected boolean isPPLSourceConfig() {
+        return config != null && Config.SOURCE_TYPE_PPL.equals(config.getSourceType());
     }
 
     /**

--- a/src/main/resources/mappings/config.json
+++ b/src/main/resources/mappings/config.json
@@ -1,11 +1,47 @@
 {
     "dynamic": false,
     "_meta": {
-        "schema_version": 9
+        "schema_version": 10
     },
     "properties": {
         "schema_version": {
             "type": "integer"
+        },
+        "source_type": {
+            "type": "keyword"
+        },
+        "prometheus_source": {
+            "type": "object",
+            "dynamic": "strict",
+            "properties": {
+                "query_language": {
+                    "type": "keyword"
+                },
+                "query": {
+                    "type": "text",
+                    "index": false
+                },
+                "data_connection_id": {
+                    "type": "keyword"
+                },
+                "series_filter": {
+                    "type": "object",
+                    "enabled": false
+                }
+            }
+        },
+        "ppl_source": {
+            "type": "object",
+            "dynamic": "strict",
+            "properties": {
+                "query_language": {
+                    "type": "keyword"
+                },
+                "query": {
+                    "type": "text",
+                    "index": false
+                }
+            }
         },
         "name": {
             "type": "text",

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -213,6 +213,24 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             );
     }
 
+    protected Response previewAnomalyDetector(RestClient client, String requestBody) throws IOException {
+        return previewAnomalyDetector(client, requestBody, null);
+    }
+
+    protected Response previewAnomalyDetector(RestClient client, String requestBody, Integer minPreviewSize) throws IOException {
+        return TestHelpers
+            .makeRequest(
+                client,
+                "POST",
+                minPreviewSize == null
+                    ? TestHelpers.AD_BASE_DETECTORS_URI + "/_preview"
+                    : TestHelpers.AD_BASE_DETECTORS_URI + "/_preview?min_preview_size=" + minPreviewSize,
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(requestBody),
+                null
+            );
+    }
+
     public AnomalyDetector getConfig(String detectorId, RestClient client) throws IOException {
         return (AnomalyDetector) getConfig(detectorId, false, client)[0];
     }

--- a/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/org/opensearch/ad/ml/ModelManagerTests.java
@@ -859,6 +859,25 @@ public class ModelManagerTests {
     }
 
     @Test
+    public void getPreviewResults_supportsRequestScopedMinPreviewSizeOverride() throws IOException {
+        int numPoints = 200;
+        double[][] points = Stream.generate(() -> new double[] { 0 }).limit(numPoints).toArray(double[][]::new);
+        List<Entry<Long, Long>> timeRanges = IntStream
+            .rangeClosed(1, points.length)
+            .mapToObj(i -> new SimpleEntry<Long, Long>((long) i, (long) i + 1))
+            .collect(Collectors.toList());
+        Features features = new Features(timeRanges, points);
+
+        AnomalyDetector detector = mock(AnomalyDetector.class);
+        when(detector.getShingleSize()).thenReturn(shingleSize);
+        when(detector.getRecencyEmphasis()).thenReturn(10000);
+
+        List<ThresholdingResult> results = modelManager.getPreviewResults(features, detector, 200);
+
+        assertEquals(numPoints, results.size());
+    }
+
+    @Test
     public void getNullState() {
         assertEquals(
             new ThresholdingResult(0, 0, 0),

--- a/src/test/java/org/opensearch/ad/model/ADTaskTests.java
+++ b/src/test/java/org/opensearch/ad/model/ADTaskTests.java
@@ -25,6 +25,7 @@ import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.TaskState;
 
 public class ADTaskTests extends OpenSearchSingleNodeTestCase {
@@ -90,6 +91,47 @@ public class ADTaskTests extends OpenSearchSingleNodeTestCase {
         String adTaskString = TestHelpers.xContentBuilderToString(adTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         ADTask parsedADTask = ADTask.parse(TestHelpers.parser(adTaskString));
         assertEquals("Parsing AD task doesn't work", adTask, parsedADTask);
+    }
+
+    public void testParseADTaskWithPrometheusDetector() throws IOException {
+        String detectorId = randomAlphaOfLength(8);
+        String taskId = randomAlphaOfLength(8);
+        String detectorJson = "{"
+            + "\"name\":\"prom-task-detector\","
+            + "\"description\":\"prometheus task parser test\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"up\","
+            + "\"data_connection_id\":\"local\""
+            + "},"
+            + "\"feature_attributes\":[{\"feature_name\":\"prometheus_value\",\"feature_enabled\":true}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}"
+            + "}";
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorJson), detectorId, 1L);
+        ADTask adTask = ADTask
+            .builder()
+            .taskId(taskId)
+            .configId(detectorId)
+            .taskType(ADTaskType.REALTIME_SINGLE_ENTITY.name())
+            .state(TaskState.RUNNING.name())
+            .executionStartTime(Instant.now().truncatedTo(ChronoUnit.SECONDS))
+            .isLatest(true)
+            .detector(detector)
+            .build();
+
+        String adTaskString = TestHelpers.xContentBuilderToString(adTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTask parsedADTask = ADTask.parse(TestHelpers.parser(adTaskString), taskId);
+
+        assertEquals(
+            "Prometheus detector source type should survive task parsing",
+            Config.SOURCE_TYPE_PROMETHEUS,
+            parsedADTask.getDetector().getSourceType()
+        );
+        assertNotNull("Prometheus source should survive task parsing", parsedADTask.getDetector().getPrometheusSource());
+        assertEquals("up", parsedADTask.getDetector().getPrometheusSource().getQuery());
+        assertEquals("local", parsedADTask.getDetector().getPrometheusSource().getDataConnectionId());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorSerializationTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorSerializationTests.java
@@ -24,6 +24,8 @@ import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.IntervalTimeConfiguration;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,6 +76,72 @@ public class AnomalyDetectorSerializationTests extends OpenSearchSingleNodeTestC
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyDetector parsedDetector = new AnomalyDetector(input);
         assertTrue(String.format(Locale.ROOT, "expected %s, but got %s", detector, parsedDetector), detector.equals(parsedDetector));
+    }
+
+    public void testPrometheusSourceSerializationRoundTrip() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"description\":\"prometheus detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\","
+            + "\"data_connection_id\":\"prome\","
+            + "\"series_filter\":{\"instance\":\"localhost:9090\"}"
+            + "},"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"f1\":{\"avg\":{\"field\":\"value\"}}}"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        BytesStreamOutput output = new BytesStreamOutput();
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+
+        assertEquals(detector, parsedDetector);
+        assertEquals(Config.SOURCE_TYPE_PROMETHEUS, parsedDetector.getSourceType());
+        assertNotNull(parsedDetector.getPrometheusSource());
+        assertEquals("prome", parsedDetector.getPrometheusSource().getDataConnectionId());
+        assertEquals("localhost:9090", parsedDetector.getPrometheusSource().getSeriesFilter().get("instance"));
+    }
+
+    public void testPPLSourceSerializationRoundTrip() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        BytesStreamOutput output = new BytesStreamOutput();
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+
+        assertEquals(detector, parsedDetector);
+        assertEquals(Config.SOURCE_TYPE_PPL, parsedDetector.getSourceType());
+        assertNotNull(parsedDetector.getPPLSource());
+        assertEquals("PPL", parsedDetector.getPPLSource().getQueryLanguage());
+        assertEquals(
+            "source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket",
+            parsedDetector.getPPLSource().getQuery()
+        );
+        assertEquals("timestamp", parsedDetector.getTimeField());
+        assertEquals(10L, ((IntervalTimeConfiguration) parsedDetector.getInterval()).getInterval());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -49,6 +49,7 @@ import org.opensearch.timeseries.dataprocessor.ImputationOption;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.Feature;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.model.PrometheusSource;
 import org.opensearch.timeseries.model.TimeConfiguration;
 import org.opensearch.timeseries.model.ValidationIssueType;
 import org.opensearch.timeseries.settings.TimeSeriesSettings;
@@ -1461,6 +1462,383 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
 
         // Should pass validation; no exception should be thrown
         assertNotNull(detector);
+    }
+
+    public void testParsePrometheusAnomalyDetector() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"description\":\"prometheus detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\","
+            + "\"data_connection_id\":\"prome\","
+            + "\"series_filter\":{\"instance\":\"localhost:9090\",\"job\":\"prometheus\"}"
+            + "},"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value\","
+            + "\"feature_enabled\":true"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PROMETHEUS, detector.getSourceType());
+        assertTrue(detector.getIndices().isEmpty());
+        assertEquals("", detector.getTimeField());
+
+        PrometheusSource prometheusSource = detector.getPrometheusSource();
+        assertNotNull(prometheusSource);
+        assertEquals("PROMQL", prometheusSource.getQueryLanguage());
+        assertEquals("prome", prometheusSource.getDataConnectionId());
+        assertEquals("rate(go_gc_heap_allocs_bytes_total{instance=\"localhost:9090\"}[5m])", prometheusSource.getQuery());
+        assertEquals("localhost:9090", prometheusSource.getSeriesFilter().get("instance"));
+        assertEquals("prometheus", prometheusSource.getSeriesFilter().get("job"));
+
+        String serialized = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        assertTrue(serialized.contains("\"source_type\":\"PROMETHEUS\""));
+        assertTrue(serialized.contains("\"prometheus_source\""));
+        assertTrue(serialized.contains("\"series_filter\""));
+        assertFalse(serialized.contains("\"time_field\""));
+        assertFalse(serialized.contains("\"indices\""));
+    }
+
+    public void testParsePrometheusAnomalyDetectorMissingConnectionId() {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\""
+            + "},"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value\","
+            + "\"feature_enabled\":true"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("prometheus_source.data_connection_id must be set when source_type is PROMETHEUS.", exception.getMessage());
+        assertEquals(ValidationIssueType.GENERAL_SETTINGS, exception.getType());
+    }
+
+    public void testParsePrometheusAnomalyDetectorRejectsTimeFieldAndIndices() {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"time_field\":\"timestamp\","
+            + "\"indices\":[\"source-index\"],"
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\","
+            + "\"data_connection_id\":\"prome\""
+            + "},"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"f1\":{\"avg\":{\"field\":\"value\"}}}"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("time_field must be empty when source_type is PROMETHEUS.", exception.getMessage());
+        assertEquals(ValidationIssueType.TIMEFIELD_FIELD, exception.getType());
+    }
+
+    public void testParsePrometheusAnomalyDetectorRequiresSingleEnabledFeature() {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\","
+            + "\"data_connection_id\":\"prome\""
+            + "},"
+            + "\"feature_attributes\":["
+            + "{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value_1\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"f1\":{\"avg\":{\"field\":\"value\"}}}"
+            + "},"
+            + "{"
+            + "\"feature_id\":\"f2\","
+            + "\"feature_name\":\"prom_value_2\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"f2\":{\"sum\":{\"field\":\"value\"}}}"
+            + "}"
+            + "],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("Exactly one enabled feature is required when source_type is PROMETHEUS.", exception.getMessage());
+        assertEquals(ValidationIssueType.FEATURE_ATTRIBUTES, exception.getType());
+    }
+
+    public void testParsePrometheusAnomalyDetectorAcceptsCategoryFields() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\","
+            + "\"data_connection_id\":\"prome\""
+            + "},"
+            + "\"category_field\":[\"host\"],"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"f1\":{\"avg\":{\"field\":\"value\"}}}"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PROMETHEUS, detector.getSourceType());
+        assertEquals(ImmutableList.of("host"), detector.getCategoryFields());
+        assertTrue(detector.isHighCardinality());
+    }
+
+    public void testParsePPLAnomalyDetector() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals("PPL", detector.getPPLSource().getQueryLanguage());
+        assertEquals(1, detector.getFeatureAttributes().size());
+        assertEquals("sum_http_4xx", detector.getFeatureAttributes().get(0).getName());
+        assertTrue(detector.getFeatureAttributes().get(0).usesDirectQueryPlaceholderAggregation());
+        assertEquals(10L, ((IntervalTimeConfiguration) detector.getInterval()).getInterval());
+        assertEquals(ChronoUnit.MINUTES, ((IntervalTimeConfiguration) detector.getInterval()).getUnit());
+
+        String serialized = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        assertTrue(serialized.contains("\"source_type\":\"PPL\""));
+        assertTrue(serialized.contains("\"ppl_source\""));
+        assertTrue(serialized.contains("\"time_field\":\"timestamp\""));
+        assertTrue(serialized.contains("\"indices\":[\"sample-http-responses\"]"));
+    }
+
+    public void testParsePPLAnomalyDetectorSupportsWhereAndMultipleMetrics() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals(2, detector.getFeatureAttributes().size());
+        assertEquals("sum_http_4xx", detector.getFeatureAttributes().get(0).getName());
+        assertEquals("max_http_5xx", detector.getFeatureAttributes().get(1).getName());
+        assertTrue(detector.getFeatureAttributes().get(0).usesDirectQueryPlaceholderAggregation());
+        assertTrue(detector.getFeatureAttributes().get(1).usesDirectQueryPlaceholderAggregation());
+        assertNotEquals(
+            detector.getFeatureAttributes().get(0).getAggregation().getName(),
+            detector.getFeatureAttributes().get(1).getAggregation().getName()
+        );
+    }
+
+    public void testParsePPLAnomalyDetectorSupportsCountAndMatchingIntervals() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | stats count() as error_count by span(timestamp, 60m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals(1, detector.getFeatureAttributes().size());
+        assertEquals("error_count", detector.getFeatureAttributes().get(0).getName());
+        assertTrue(detector.getFeatureAttributes().get(0).usesDirectQueryPlaceholderAggregation());
+        assertEquals(60L, ((IntervalTimeConfiguration) detector.getInterval()).getInterval());
+        assertEquals(ChronoUnit.MINUTES, ((IntervalTimeConfiguration) detector.getInterval()).getUnit());
+    }
+
+    public void testParsePPLAnomalyDetectorDerivesIntervalWhenDefaultsAreProvided() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | eval total_metric = http_4xx + http_5xx | stats count(*) as error_count, avg(total_metric) as avg_total_metric by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector
+            .parse(TestHelpers.parser(detectorString), "detector-id", 1L, TimeValue.timeValueMinutes(1), TimeValue.timeValueMinutes(1));
+
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals(2, detector.getFeatureAttributes().size());
+        assertEquals("error_count", detector.getFeatureAttributes().get(0).getName());
+        assertEquals("avg_total_metric", detector.getFeatureAttributes().get(1).getName());
+        assertEquals(10L, ((IntervalTimeConfiguration) detector.getInterval()).getInterval());
+        assertEquals(ChronoUnit.MINUTES, ((IntervalTimeConfiguration) detector.getInterval()).getUnit());
+    }
+
+    public void testParseStoredPPLAnomalyDetectorPreservesFeatureAttributes() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"feature_attributes\":["
+            + "{"
+            + "\"feature_id\":\"feature-1\","
+            + "\"feature_name\":\"sum_http_4xx\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"__direct_query_feature_value__\":{\"avg\":{\"field\":\"__direct_query_value__\"}}}"
+            + "},"
+            + "{"
+            + "\"feature_id\":\"feature-2\","
+            + "\"feature_name\":\"max_http_5xx\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"__direct_query_feature_value__\":{\"avg\":{\"field\":\"__direct_query_value__\"}}}"
+            + "}"
+            + "],"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(2, detector.getFeatureAttributes().size());
+        assertEquals("feature-1", detector.getFeatureAttributes().get(0).getId());
+        assertEquals("feature-2", detector.getFeatureAttributes().get(1).getId());
+        assertEquals("sum_http_4xx", detector.getFeatureAttributes().get(0).getName());
+        assertEquals("max_http_5xx", detector.getFeatureAttributes().get(1).getName());
+    }
+
+    public void testParsePPLAnomalyDetectorRejectsCategoryFields() {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"category_field\":[\"host\"],"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("category_field must be empty when source_type is PPL.", exception.getMessage());
+        assertEquals(ValidationIssueType.CATEGORY, exception.getType());
+    }
+
+    public void testParsePPLAnomalyDetectorRejectsDetectionIntervalMismatch() {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"detection_interval\":{\"period\":{\"interval\":5,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals(
+            "detection_interval must match ppl_source span interval (10 minutes) when source_type is PPL.",
+            exception.getMessage()
+        );
+        assertEquals(ValidationIssueType.DETECTION_INTERVAL, exception.getType());
+    }
+
+    public void testParseOpenSearchAnomalyDetectorRequiresAggregationQuery() {
+        String detectorString = "{"
+            + "\"name\":\"os-detector\","
+            + "\"time_field\":\"timestamp\","
+            + "\"indices\":[\"source-index\"],"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"os_value\","
+            + "\"feature_enabled\":true"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("feature_attributes.aggregation_query must be set when source_type is OPENSEARCH.", exception.getMessage());
+        assertEquals(ValidationIssueType.FEATURE_ATTRIBUTES, exception.getType());
     }
 
     /**

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -146,6 +146,73 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         return detector;
     }
 
+    private String createPPLRuntimeIndex(String indexName) throws IOException {
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/" + indexName,
+                ImmutableMap.of(),
+                TestHelpers
+                    .toHttpEntity(
+                        "{\"mappings\":{\"properties\":{\"timestamp\":{\"type\":\"date\"},\"status_code\":{\"type\":\"integer\"},\"metric_a\":{\"type\":\"double\"},\"metric_b\":{\"type\":\"double\"},\"service\":{\"type\":\"keyword\"}}}}"
+                    ),
+                null
+            );
+
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        for (int i = 0; i < 40; i++) {
+            Instant timestamp = now.minus(i, ChronoUnit.MINUTES);
+            int statusCode = i % 12 == 0 ? 500 : (i % 5 == 0 ? 404 : 200);
+            int metricA = (i % 9) + 1;
+            int metricB = (i % 7) + 10;
+            TestHelpers
+                .ingestDataToIndex(
+                    client(),
+                    indexName,
+                    TestHelpers
+                        .toHttpEntity(
+                            String
+                                .format(
+                                    Locale.ROOT,
+                                    "{\"timestamp\":%d,\"status_code\":%d,\"metric_a\":%d,\"metric_b\":%d,\"service\":\"checkout\"}",
+                                    timestamp.toEpochMilli(),
+                                    statusCode,
+                                    metricA,
+                                    metricB
+                                )
+                        )
+                );
+        }
+
+        return indexName;
+    }
+
+    private String buildPPLPreviewBody(String indexName, Instant periodStart, Instant periodEnd) {
+        return String
+            .format(
+                Locale.ROOT,
+                "{\"period_start\":%d,\"period_end\":%d,\"detector\":{\"name\":\"preview-ppl\",\"source_type\":\"PPL\",\"ppl_source\":{\"query_language\":\"PPL\",\"query\":\"source = %s | where service = 'checkout' | eval total_metric = metric_a + metric_b | stats count(*) as doc_count, avg(total_metric) as avg_total_metric by span(timestamp, 1m) as bucket\"},\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}}}",
+                periodStart.toEpochMilli(),
+                periodEnd.toEpochMilli(),
+                indexName
+            );
+    }
+
+    private String buildPPLDetectorBody(String detectorName, String indexName, boolean includeDetectionInterval, String query) {
+        String detectionInterval = includeDetectionInterval
+            ? ",\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}"
+            : "";
+        return String
+            .format(
+                Locale.ROOT,
+                "{\"name\":\"%s\",\"description\":\"ppl runtime detector\",\"source_type\":\"PPL\",\"ppl_source\":{\"query_language\":\"PPL\",\"query\":\"%s\"}%s,\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}}",
+                detectorName,
+                query.replace("\"", "\\\""),
+                detectionInterval
+            );
+    }
+
     public void testCreateAnomalyDetectorWithDuplicateName() throws Exception {
         AnomalyDetector detector = createIndexAndGetAnomalyDetector(INDEX_NAME);
         Feature feature = TestHelpers.randomFeature();
@@ -1146,6 +1213,116 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                         String.format(Locale.ROOT, TestHelpers.AD_BASE_PREVIEW_URI, input.getDetectorId()),
                         ImmutableMap.of(),
                         TestHelpers.toHttpEntity(input),
+                        null
+                    )
+            );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testPreviewPPLAnomalyDetectorWithoutExplicitDetectionInterval() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-preview-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+        Instant periodEnd = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Instant periodStart = periodEnd.minus(10, ChronoUnit.MINUTES);
+
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/_preview?min_preview_size=1",
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(buildPPLPreviewBody(indexName, periodStart, periodEnd)),
+                null,
+                false
+            );
+
+        assertEquals("Preview PPL detector failed", RestStatus.OK, TestHelpers.restStatus(response));
+        Map<String, Object> responseMap = entityAsMap(response);
+        List<Map<String, Object>> anomalyResults = (List<Map<String, Object>>) responseMap.get("anomaly_result");
+        assertNotNull(anomalyResults);
+        assertFalse(anomalyResults.isEmpty());
+
+        List<Map<String, Object>> featureData = (List<Map<String, Object>>) anomalyResults.get(0).get("feature_data");
+        assertNotNull(featureData);
+        assertEquals(2, featureData.size());
+        assertEquals("doc_count", featureData.get(0).get("feature_name"));
+        assertEquals("avg_total_metric", featureData.get(1).get("feature_name"));
+
+        Map<String, Object> detector = (Map<String, Object>) responseMap.get("anomaly_detector");
+        Map<String, Object> detectionInterval = (Map<String, Object>) detector.get("detection_interval");
+        Map<String, Object> period = (Map<String, Object>) detectionInterval.get("period");
+        assertEquals("PPL", detector.get("source_type"));
+        assertEquals(1, period.get("interval"));
+        assertEquals("Minutes", period.get("unit"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCreateStartAndProfilePPLAnomalyDetectorWithoutExplicitDetectionInterval() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-detector-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+        String detectorName = "ppl-runtime-" + randomAlphaOfLength(6);
+        String query = "source = "
+            + indexName
+            + " | where service = 'checkout' | eval total_metric = metric_a + metric_b | stats count() as doc_count, avg(total_metric) as avg_total_metric by span(timestamp, 1m) as bucket";
+
+        Response createResponse = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI,
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(buildPPLDetectorBody(detectorName, indexName, false, query)),
+                null
+            );
+
+        assertEquals("Create PPL detector failed", RestStatus.CREATED, TestHelpers.restStatus(createResponse));
+        Map<String, Object> createResponseMap = entityAsMap(createResponse);
+        String detectorId = (String) createResponseMap.get("_id");
+        Map<String, Object> detector = (Map<String, Object>) createResponseMap.get("anomaly_detector");
+        Map<String, Object> detectionInterval = (Map<String, Object>) detector.get("detection_interval");
+        Map<String, Object> period = (Map<String, Object>) detectionInterval.get("period");
+        List<Map<String, Object>> featureAttributes = (List<Map<String, Object>>) detector.get("feature_attributes");
+
+        assertNotNull(detectorId);
+        assertEquals("PPL", detector.get("source_type"));
+        assertEquals(2, featureAttributes.size());
+        assertEquals("doc_count", featureAttributes.get(0).get("feature_name"));
+        assertEquals("avg_total_metric", featureAttributes.get(1).get("feature_name"));
+        assertEquals(1, period.get("interval"));
+        assertEquals("Minutes", period.get("unit"));
+
+        Response startResponse = TestHelpers
+            .makeRequest(client(), "POST", TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId + "/_start", ImmutableMap.of(), "", null);
+        assertEquals("Start PPL detector failed", RestStatus.OK, TestHelpers.restStatus(startResponse));
+
+        Awaitility
+            .await("ppl detector profile to reach running")
+            .pollDelay(Duration.ZERO)
+            .pollInterval(Duration.ofSeconds(2))
+            .atMost(Duration.ofSeconds(30))
+            .untilAsserted(() -> {
+                Response profileResponse = getDetectorProfile(detectorId, true);
+                assertEquals(RestStatus.OK, TestHelpers.restStatus(profileResponse));
+                Map<String, Object> profileMap = entityAsMap(profileResponse);
+                assertEquals("RUNNING", profileMap.get("state"));
+                Map<String, Object> initProgress = (Map<String, Object>) profileMap.get("init_progress");
+                assertEquals("100%", initProgress.get("percentage"));
+            });
+    }
+
+    public void testCreatePPLAnomalyDetectorRejectsUnsupportedPostStatsStage() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-invalid-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+        String query = "source = " + indexName + " | stats count() as doc_count by span(timestamp, 1m) | head 5";
+
+        TestHelpers
+            .assertFailWith(
+                ResponseException.class,
+                "Only trailing sort stages are supported",
+                () -> TestHelpers
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        TestHelpers.AD_BASE_DETECTORS_URI,
+                        ImmutableMap.of(),
+                        TestHelpers.toHttpEntity(buildPPLDetectorBody("invalid-ppl-detector", indexName, false, query)),
                         null
                     )
             );

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -77,6 +77,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
     private static final String READ_ONLY_AG = "ad_read_only";
     private static final String READ_WRITE_AG = "ad_read_write";
     private static final String FULL_ACCESS_AG = "ad_full_access";
+    private static final String PPL_ACCESS_ROLE = "ppl_access";
 
     String oceanUser = "ocean";
     RestClient oceanClient;
@@ -91,6 +92,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         createIndexRole(indexAllAccessRole, "*");
         String indexSearchAccessRole = "index_all_search";
         createSearchRole(indexSearchAccessRole, "*");
+        createPPLAccessRole(PPL_ACCESS_ROLE);
         String alicePassword = generatePassword(aliceUser);
         createUser(aliceUser, alicePassword, new ArrayList<>(Arrays.asList("odfe")));
         aliceClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), aliceUser, alicePassword)
@@ -149,6 +151,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         createRoleMapping("anomaly_full_access", new ArrayList<>(Arrays.asList(aliceUser, catUser, dogUser, elkUser, fishUser, goatUser)));
         createRoleMapping(indexAllAccessRole, new ArrayList<>(Arrays.asList(aliceUser, bobUser, catUser, dogUser, fishUser, lionUser)));
         createRoleMapping(indexSearchAccessRole, new ArrayList<>(Arrays.asList(goatUser)));
+        createRoleMapping(PPL_ACCESS_ROLE, new ArrayList<>(Arrays.asList(aliceUser, catUser, goatUser)));
     }
 
     @After
@@ -186,6 +189,81 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Map<String, Object> responseMap = entityAsMap(resp);
         ArrayList<String> roles = (ArrayList<String>) responseMap.get("roles");
         assertTrue(roles.contains("all_access"));
+    }
+
+    private String createInlinePPLPreviewIndex() throws IOException {
+        String indexName = "secure-ppl-preview-" + System.nanoTime();
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/" + indexName,
+                ImmutableMap.of(),
+                TestHelpers
+                    .toHttpEntity(
+                        "{\"mappings\":{\"properties\":{\"timestamp\":{\"type\":\"date\"},\"status_code\":{\"type\":\"integer\"},\"metric_a\":{\"type\":\"double\"},\"metric_b\":{\"type\":\"double\"},\"service\":{\"type\":\"keyword\"}}}}"
+                    ),
+                null
+            );
+
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        for (int i = 0; i < 20; i++) {
+            Instant timestamp = now.minus(i, ChronoUnit.MINUTES);
+            int statusCode = i % 4 == 0 ? 500 : 200;
+            int metricA = (i % 5) + 1;
+            int metricB = (i % 7) + 10;
+            TestHelpers
+                .ingestDataToIndex(
+                    client(),
+                    indexName,
+                    TestHelpers
+                        .toHttpEntity(
+                            String
+                                .format(
+                                    Locale.ROOT,
+                                    "{\"timestamp\":%d,\"status_code\":%d,\"metric_a\":%d,\"metric_b\":%d,\"service\":\"checkout\"}",
+                                    timestamp.toEpochMilli(),
+                                    statusCode,
+                                    metricA,
+                                    metricB
+                                )
+                        )
+                );
+        }
+
+        return indexName;
+    }
+
+    private void createPPLAccessRole(String role) throws IOException {
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/_opendistro/_security/api/roles/" + role,
+                null,
+                TestHelpers
+                    .toHttpEntity(
+                        "{\n"
+                            + "\"cluster_permissions\": [\n"
+                            + "\"cluster:admin/opensearch/ppl\"\n"
+                            + "],\n"
+                            + "\"index_permissions\": [],\n"
+                            + "\"tenant_permissions\": []\n"
+                            + "}"
+                    ),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
+    }
+
+    private String buildInlinePPLPreviewBody(String indexName, Instant periodStart, Instant periodEnd) {
+        return String
+            .format(
+                Locale.ROOT,
+                "{\"period_start\":%d,\"period_end\":%d,\"detector\":{\"name\":\"secure-preview-ppl\",\"source_type\":\"PPL\",\"ppl_source\":{\"query_language\":\"PPL\",\"query\":\"source = %s | where service = 'checkout' | eval total_metric = metric_a + metric_b | stats count(*) as doc_count, avg(total_metric) as avg_total_metric by span(timestamp, 1m) as bucket\"},\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}}}",
+                periodStart.toEpochMilli(),
+                periodEnd.toEpochMilli(),
+                indexName
+            );
     }
 
     public void testCreateAnomalyDetector() throws IOException {
@@ -949,6 +1027,39 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
 
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testPreviewInlinePPLAnomalyDetector() throws IOException {
+        String indexName = createInlinePPLPreviewIndex();
+        Instant periodEnd = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Instant periodStart = periodEnd.minus(10, ChronoUnit.MINUTES);
+        String requestBody = buildInlinePPLPreviewBody(indexName, periodStart, periodEnd);
+
+        Response response = previewAnomalyDetector(aliceClient, requestBody, 1);
+        Assert.assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+        Map<String, Object> responseMap = entityAsMap(response);
+        List<Map<String, Object>> anomalyResults = (List<Map<String, Object>>) responseMap.get("anomaly_result");
+        Assert.assertNotNull(anomalyResults);
+        Assert.assertFalse(anomalyResults.isEmpty());
+
+        List<Map<String, Object>> featureData = (List<Map<String, Object>>) anomalyResults.get(0).get("feature_data");
+        Assert.assertEquals(2, featureData.size());
+        Assert.assertEquals("doc_count", featureData.get(0).get("feature_name"));
+        Assert.assertEquals("avg_total_metric", featureData.get(1).get("feature_name"));
+
+        Response catResponse = previewAnomalyDetector(catClient, requestBody, 1);
+        Assert.assertEquals(RestStatus.OK, TestHelpers.restStatus(catResponse));
+
+        Response goatResponse = previewAnomalyDetector(goatClient, requestBody, 1);
+        Assert.assertEquals(RestStatus.OK, TestHelpers.restStatus(goatResponse));
+
+        String noPermsMessage = "no permissions for [cluster:admin/opendistro/ad/detector/preview]";
+        Exception exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(bobClient, requestBody, 1); });
+        Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
+
+        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(lionClient, requestBody, 1); });
+        Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
     }
 
     public void testValidateAnomalyDetector() throws IOException {

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorActionTests.java
@@ -42,7 +42,8 @@ public class PreviewAnomalyDetectorActionTests extends OpenSearchSingleNodeTestC
             detector,
             "1234",
             Instant.now().minusSeconds(60),
-            Instant.now()
+            Instant.now(),
+            200
         );
         request.writeTo(out);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry());
@@ -50,6 +51,7 @@ public class PreviewAnomalyDetectorActionTests extends OpenSearchSingleNodeTestC
         Assert.assertEquals(request.getId(), newRequest.getId());
         Assert.assertEquals(request.getStartTime(), newRequest.getStartTime());
         Assert.assertEquals(request.getEndTime(), newRequest.getEndTime());
+        Assert.assertEquals(request.getMinPreviewSize(), newRequest.getMinPreviewSize());
         Assert.assertNotNull(newRequest.getDetector());
         Assert.assertNull(newRequest.validate());
     }

--- a/src/test/java/org/opensearch/forecast/transport/PreviewForecasterSerializationTests.java
+++ b/src/test/java/org/opensearch/forecast/transport/PreviewForecasterSerializationTests.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors.
+ */
+
+package org.opensearch.forecast.transport;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.forecast.model.Forecaster;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.opensearch.timeseries.TestHelpers;
+
+public class PreviewForecasterSerializationTests extends OpenSearchSingleNodeTestCase {
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testPreviewForecasterRequestRoundTrip() throws IOException {
+        Forecaster forecaster = TestHelpers.randomForecaster();
+        Instant periodStart = Instant.now().minusSeconds(600);
+        Instant periodEnd = Instant.now();
+
+        PreviewForecasterRequest original = new PreviewForecasterRequest(forecaster, forecaster.getId(), periodStart, periodEnd);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        NamedWriteableAwareStreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry());
+        PreviewForecasterRequest parsed = new PreviewForecasterRequest(in);
+
+        assertEquals(forecaster, parsed.getForecaster());
+        assertEquals(forecaster.getId(), parsed.getForecasterId());
+        assertEquals(periodStart, parsed.getPeriodStart());
+        assertEquals(periodEnd, parsed.getPeriodEnd());
+    }
+
+    public void testPreviewForecasterResponseRoundTrip() throws IOException {
+        Forecaster forecaster = TestHelpers.randomForecaster();
+        PreviewForecasterResponse original = new PreviewForecasterResponse(Collections.emptyList(), forecaster);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        NamedWriteableAwareStreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry());
+        PreviewForecasterResponse parsed = new PreviewForecasterResponse(in);
+
+        assertTrue(parsed.getForecastResult().isEmpty());
+        assertEquals(forecaster, parsed.getForecaster());
+    }
+}

--- a/src/test/java/org/opensearch/forecast/transport/PreviewForecasterTransportActionTests.java
+++ b/src/test/java/org/opensearch/forecast/transport/PreviewForecasterTransportActionTests.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors.
+ */
+
+package org.opensearch.forecast.transport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.forecast.ForecasterRunner;
+import org.opensearch.forecast.constant.ForecastCommonName;
+import org.opensearch.forecast.ml.ForecastColdStart;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.timeseries.feature.FeatureManager;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class PreviewForecasterTransportActionTests extends OpenSearchTestCase {
+
+    private PreviewForecasterTransportAction action;
+    private Client client;
+    private Task task;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        task = mock(Task.class);
+        ForecasterRunner forecasterRunner = new ForecasterRunner(mock(ForecastColdStart.class), mock(FeatureManager.class));
+        action = new PreviewForecasterTransportAction(
+            mock(TransportService.class),
+            mock(ActionFilters.class),
+            forecasterRunner,
+            client,
+            NamedXContentRegistry.EMPTY
+        );
+    }
+
+    @Test
+    public void testMissingForecasterIdentityReturnsBadRequest() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        PreviewForecasterRequest request = new PreviewForecasterRequest(null, null, Instant.ofEpochMilli(1), Instant.ofEpochMilli(2));
+
+        action.doExecute(task, request, new ActionListener<PreviewForecasterResponse>() {
+            @Override
+            public void onResponse(PreviewForecasterResponse response) {
+                fail("Expected failure for missing forecaster identity");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(e instanceof OpenSearchStatusException);
+                OpenSearchStatusException statusException = (OpenSearchStatusException) e;
+                assertEquals(RestStatus.BAD_REQUEST, statusException.status());
+                assertEquals(PreviewForecasterTransportAction.MISSING_REQUEST_MESSAGE, statusException.getMessage());
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testMissingConfigIndexReturnsNotFound() throws InterruptedException {
+        String forecasterId = "missing-forecaster";
+        CountDownLatch latch = new CountDownLatch(1);
+        PreviewForecasterRequest request = new PreviewForecasterRequest(
+            null,
+            forecasterId,
+            Instant.ofEpochMilli(1),
+            Instant.ofEpochMilli(2)
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new IndexNotFoundException(ForecastCommonName.CONFIG_INDEX));
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        action.doExecute(task, request, new ActionListener<PreviewForecasterResponse>() {
+            @Override
+            public void onResponse(PreviewForecasterResponse response) {
+                fail("Expected not found when forecaster config index is missing");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(e instanceof OpenSearchStatusException);
+                OpenSearchStatusException statusException = (OpenSearchStatusException) e;
+                assertEquals(RestStatus.NOT_FOUND, statusException.status());
+                assertTrue(statusException.getMessage().contains("Can't find forecaster with id:" + forecasterId));
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+    }
+
+}

--- a/src/test/java/org/opensearch/timeseries/feature/PrometheusDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PrometheusDirectQueryExecutorTests.java
@@ -1,0 +1,344 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.feature;
+
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Method;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.timeseries.AbstractTimeSeriesTest;
+import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.TestHelpers;
+import org.opensearch.timeseries.util.SecurityClientUtil;
+import org.opensearch.transport.client.Client;
+
+public class PrometheusDirectQueryExecutorTests extends AbstractTimeSeriesTest {
+    private static final String TEST_MASTER_KEY = "12345678901234567890123456789012";
+
+    public void testExecuteRangeQueryInvalidStepFailsFast() throws Exception {
+        String detectorString = "{"
+            + "\"name\":\"prom-detector\","
+            + "\"source_type\":\"PROMETHEUS\","
+            + "\"prometheus_source\":{"
+            + "\"query_language\":\"PROMQL\","
+            + "\"query\":\"rate(go_gc_heap_allocs_bytes_total{instance=\\\"localhost:9090\\\"}[5m])\","
+            + "\"data_connection_id\":\"prome\""
+            + "},"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"prom_value\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"f1\":{\"avg\":{\"field\":\"value\"}}}"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        executor
+            .executeRangeQuery(
+                org.opensearch.ad.model.AnomalyDetector.parse(TestHelpers.parser(detectorString)),
+                1700000000000L,
+                1700000060000L,
+                0L,
+                AnalysisType.AD,
+                ActionListener.wrap(result -> {
+                    fail("Expected validation exception for non-positive stepSeconds");
+                }, e -> {
+                    failure.set(e);
+                    latch.countDown();
+                })
+            );
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(failure.get());
+        assertTrue(failure.get() instanceof IllegalArgumentException);
+        assertTrue(failure.get().getMessage().contains("stepSeconds must be positive"));
+    }
+
+    public void testParsePrometheusResponseUsesSeriesFilterWhenProvided() throws Exception {
+        String responseBody = "{"
+            + "\"status\":\"success\","
+            + "\"data\":{"
+            + "\"resultType\":\"matrix\","
+            + "\"result\":["
+            + "{"
+            + "\"metric\":{\"instance\":\"prometheus-a:9090\",\"job\":\"leaf-prometheus\"},"
+            + "\"values\":[[1710000000,\"10\"],[1710000060,\"12\"]]"
+            + "},"
+            + "{"
+            + "\"metric\":{\"instance\":\"prometheus-b:9090\",\"job\":\"leaf-prometheus\"},"
+            + "\"values\":[[1710000000,\"20\"],[1710000060,\"22\"]]"
+            + "}"
+            + "]"
+            + "}"
+            + "}";
+
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+
+        NavigableMap<Long, Double> filtered = executor.parsePrometheusResponse(responseBody, Map.of("instance", "prometheus-b:9090"));
+
+        assertEquals(2, filtered.size());
+        assertEquals(20.0d, filtered.firstEntry().getValue(), 0.001d);
+        assertEquals(22.0d, filtered.lastEntry().getValue(), 0.001d);
+    }
+
+    public void testParsePrometheusResponseAveragesSeriesWithoutFilter() throws Exception {
+        String responseBody = "{"
+            + "\"status\":\"success\","
+            + "\"data\":{"
+            + "\"resultType\":\"matrix\","
+            + "\"result\":["
+            + "{"
+            + "\"metric\":{\"instance\":\"prometheus-a:9090\",\"job\":\"leaf-prometheus\"},"
+            + "\"values\":[[1710000000,\"10\"],[1710000060,\"12\"]]"
+            + "},"
+            + "{"
+            + "\"metric\":{\"instance\":\"prometheus-b:9090\",\"job\":\"leaf-prometheus\"},"
+            + "\"values\":[[1710000000,\"20\"],[1710000060,\"22\"]]"
+            + "}"
+            + "]"
+            + "}"
+            + "}";
+
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+
+        NavigableMap<Long, Double> averaged = executor.parsePrometheusResponse(responseBody, null);
+
+        assertEquals(2, averaged.size());
+        assertEquals(15.0d, averaged.firstEntry().getValue(), 0.001d);
+        assertEquals(17.0d, averaged.lastEntry().getValue(), 0.001d);
+    }
+
+    public void testParsePrometheusResponseBySeriesKeepsLabelSetsSeparate() throws Exception {
+        String responseBody = "{"
+            + "\"status\":\"success\","
+            + "\"data\":{"
+            + "\"resultType\":\"matrix\","
+            + "\"result\":["
+            + "{"
+            + "\"metric\":{\"instance\":\"prometheus-a:9090\",\"job\":\"leaf-prometheus\"},"
+            + "\"values\":[[1710000000,\"10\"],[1710000060,\"12\"]]"
+            + "},"
+            + "{"
+            + "\"metric\":{\"instance\":\"prometheus-b:9090\",\"job\":\"leaf-prometheus\"},"
+            + "\"values\":[[1710000000,\"20\"],[1710000060,\"22\"]]"
+            + "}"
+            + "]"
+            + "}"
+            + "}";
+
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+
+        Map<Map<String, String>, NavigableMap<Long, Double>> valuesBySeries = executor.parsePrometheusResponseBySeries(responseBody, null);
+
+        assertEquals(2, valuesBySeries.size());
+        assertTrue(valuesBySeries.keySet().stream().anyMatch(labels -> "prometheus-a:9090".equals(labels.get("instance"))));
+        assertTrue(valuesBySeries.keySet().stream().anyMatch(labels -> "prometheus-b:9090".equals(labels.get("instance"))));
+    }
+
+    public void testResolvePrometheusDataSourcePropertiesSupportsBasicAuth() {
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("prometheus.uri", "http://prometheus.example.org:9090");
+        properties.put("prometheus.auth.type", "basicauth");
+        properties.put("prometheus.auth.username", "demo-user");
+        properties.put("prometheus.auth.password", "demo-pass");
+
+        PrometheusDirectQueryExecutor.ResolvedPrometheusDataSource resolved = executor
+            .resolvePrometheusDataSourceProperties(properties, "prome-auth");
+
+        assertEquals(PrometheusDirectQueryExecutor.PrometheusAuthType.BASICAUTH, resolved.getAuthType());
+        assertEquals("http://prometheus.example.org:9090", resolved.getPrometheusBaseUri());
+        assertEquals("demo-user", resolved.getUsername());
+        assertEquals("demo-pass", resolved.getPassword());
+    }
+
+    public void testResolvePrometheusDataSourcePropertiesDecryptsEncryptedBasicAuth() {
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            TEST_MASTER_KEY,
+            mock(HttpClient.class)
+        );
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("prometheus.uri", "http://prometheus.example.org:9090");
+        properties.put("prometheus.auth.type", "basicauth");
+        properties.put("prometheus.auth.username", encryptCredential("demo-user"));
+        properties.put("prometheus.auth.password", encryptCredential("demo-pass"));
+
+        PrometheusDirectQueryExecutor.ResolvedPrometheusDataSource resolved = executor
+            .resolvePrometheusDataSourceProperties(properties, "prome-auth");
+
+        assertEquals(PrometheusDirectQueryExecutor.PrometheusAuthType.BASICAUTH, resolved.getAuthType());
+        assertEquals("demo-user", resolved.getUsername());
+        assertEquals("demo-pass", resolved.getPassword());
+    }
+
+    public void testBuildRangeQueryRequestAddsBasicAuthHeader() {
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+        PrometheusDirectQueryExecutor.ResolvedPrometheusDataSource resolved = PrometheusDirectQueryExecutor.ResolvedPrometheusDataSource
+            .builder()
+            .prometheusBaseUri("http://prometheus.example.org:9090")
+            .authType(PrometheusDirectQueryExecutor.PrometheusAuthType.BASICAUTH)
+            .username("demo-user")
+            .password("demo-pass")
+            .build();
+
+        HttpRequest request = executor
+            .buildRangeQueryRequest(resolved, "up", 1700000000000L, 1700000060000L, 60L, Instant.parse("2026-04-09T12:34:56Z"));
+
+        assertEquals("Basic ZGVtby11c2VyOmRlbW8tcGFzcw==", request.headers().firstValue("Authorization").orElse(null));
+    }
+
+    public void testBuildRangeQueryRequestAddsAwsSigV4Headers() {
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+        PrometheusDirectQueryExecutor.ResolvedPrometheusDataSource resolved = PrometheusDirectQueryExecutor.ResolvedPrometheusDataSource
+            .builder()
+            .prometheusBaseUri("https://aps-workspaces.us-west-2.amazonaws.com")
+            .authType(PrometheusDirectQueryExecutor.PrometheusAuthType.AWSSIGV4)
+            .region("us-west-2")
+            .accessKey("AKIDEXAMPLE")
+            .secretKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+            .build();
+
+        HttpRequest request = executor
+            .buildRangeQueryRequest(
+                resolved,
+                "rate(http_requests_total[5m])",
+                1700000000000L,
+                1700000060000L,
+                60L,
+                Instant.parse("2026-04-09T12:34:56Z")
+            );
+
+        assertEquals("20260409T123456Z", request.headers().firstValue("x-amz-date").orElse(null));
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            request.headers().firstValue("x-amz-content-sha256").orElse(null)
+        );
+        assertEquals("aps-workspaces.us-west-2.amazonaws.com", request.uri().getHost());
+
+        String authorization = request.headers().firstValue("Authorization").orElse(null);
+        assertNotNull(authorization);
+        assertTrue(authorization.startsWith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260409/us-west-2/aps/aws4_request"));
+        assertTrue(authorization.contains("SignedHeaders=host;x-amz-content-sha256;x-amz-date"));
+        assertTrue(authorization.matches(".*Signature=[0-9a-f]{64}$"));
+    }
+
+    public void testResolvePrometheusDataSourcePropertiesRejectsMissingSigV4Region() {
+        PrometheusDirectQueryExecutor executor = new PrometheusDirectQueryExecutor(
+            mock(Client.class),
+            mock(SecurityClientUtil.class),
+            mock(HttpClient.class)
+        );
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("prometheus.uri", "https://aps-workspaces.us-west-2.amazonaws.com");
+        properties.put("prometheus.auth.type", "awssigv4");
+        properties.put("prometheus.auth.access_key", "AKIDEXAMPLE");
+        properties.put("prometheus.auth.secret_key", "secret");
+
+        IllegalArgumentException error = expectThrows(
+            IllegalArgumentException.class,
+            () -> executor.resolvePrometheusDataSourceProperties(properties, "prome-sigv4")
+        );
+
+        assertTrue(error.getMessage().contains("prometheus.auth.region"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String encryptCredential(String plainText) {
+        try {
+            Class<?> commitmentPolicyClass = Class.forName("com.amazonaws.encryptionsdk.CommitmentPolicy");
+            Object commitmentPolicy = Enum
+                .valueOf((Class<? extends Enum>) commitmentPolicyClass.asSubclass(Enum.class), "RequireEncryptRequireDecrypt");
+
+            Class<?> awsCryptoClass = Class.forName("com.amazonaws.encryptionsdk.AwsCrypto");
+            Object builder = awsCryptoClass.getMethod("builder").invoke(null);
+            builder.getClass().getMethod("withCommitmentPolicy", commitmentPolicyClass).invoke(builder, commitmentPolicy);
+            Object crypto = builder.getClass().getMethod("build").invoke(builder);
+
+            Class<?> jceMasterKeyClass = Class.forName("com.amazonaws.encryptionsdk.jce.JceMasterKey");
+            Object jceMasterKey = jceMasterKeyClass
+                .getMethod("getInstance", java.security.Key.class, String.class, String.class, String.class)
+                .invoke(
+                    null,
+                    new SecretKeySpec(TEST_MASTER_KEY.getBytes(StandardCharsets.UTF_8), "AES"),
+                    "Custom",
+                    "opensearch.config.master.key",
+                    "AES/GCM/NoPadding"
+                );
+
+            Method encryptDataMethod = null;
+            for (Method method : crypto.getClass().getMethods()) {
+                if ("encryptData".equals(method.getName()) && method.getParameterCount() == 2) {
+                    encryptDataMethod = method;
+                    break;
+                }
+            }
+            if (encryptDataMethod == null) {
+                throw new NoSuchMethodException("encryptData");
+            }
+
+            Object encryptResult = encryptDataMethod.invoke(crypto, jceMasterKey, plainText.getBytes(StandardCharsets.UTF_8));
+            byte[] encryptedBytes = (byte[]) encryptResult.getClass().getMethod("getResult").invoke(encryptResult);
+            return java.util.Base64.getEncoder().encodeToString(encryptedBytes);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("failed to encrypt Prometheus datasource credential", e);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,8 +88,10 @@ import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
 import org.opensearch.timeseries.constant.CommonName;
+import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.model.PPLSource;
 import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.SecurityClientUtil;
 import org.opensearch.transport.client.Client;
@@ -255,6 +258,118 @@ public class SearchFeatureDaoTests {
         verify(listener).onResponse(captor.capture());
         Optional<Long> result = captor.getValue();
         assertEquals(epochTime, result.get().longValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getFeaturesForPeriod_usesPPLRuntimeExecutor() {
+        PPLDirectQueryExecutor pplDirectQueryExecutor = mock(PPLDirectQueryExecutor.class);
+        PrometheusDirectQueryExecutor prometheusDirectQueryExecutor = mock(PrometheusDirectQueryExecutor.class);
+        SearchFeatureDao pplSearchFeatureDao = new SearchFeatureDao(
+            client,
+            xContent,
+            clientUtil,
+            null,
+            null,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            clock,
+            1,
+            1,
+            60_000L,
+            prometheusDirectQueryExecutor,
+            pplDirectQueryExecutor
+        );
+        when(detector.getSourceType()).thenReturn(Config.SOURCE_TYPE_PPL);
+        when(detector.getPPLSource())
+            .thenReturn(
+                new PPLSource(
+                    "PPL",
+                    "source = sample-http-responses | where response_category = 'client_error' | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket"
+                )
+            );
+        when(detector.getEnabledFeatureIds()).thenReturn(Arrays.asList("f1", "f2"));
+
+        long start = 100L;
+        long end = 200L;
+        doAnswer(invocation -> {
+            ActionListener<Optional<double[]>> listener = invocation.getArgument(4);
+            listener.onResponse(Optional.of(new double[] { 42.0, 7.0 }));
+            return null;
+        })
+            .when(pplDirectQueryExecutor)
+            .executeMetricQuery(eq(detector), eq(start), eq(end), eq(AnalysisType.AD), any(ActionListener.class));
+
+        ActionListener<Optional<double[]>> listener = mock(ActionListener.class);
+        pplSearchFeatureDao.getFeaturesForPeriod(detector, start, end, listener);
+
+        ArgumentCaptor<Optional<double[]>> captor = ArgumentCaptor.forClass(Optional.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isPresent());
+        assertEquals(42.0, captor.getValue().get()[0], 0.001);
+        assertEquals(7.0, captor.getValue().get()[1], 0.001);
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getFeatureSamplesForPeriods_usesPPLRuntimeExecutor() throws Exception {
+        PPLDirectQueryExecutor pplDirectQueryExecutor = mock(PPLDirectQueryExecutor.class);
+        PrometheusDirectQueryExecutor prometheusDirectQueryExecutor = mock(PrometheusDirectQueryExecutor.class);
+        SearchFeatureDao pplSearchFeatureDao = new SearchFeatureDao(
+            client,
+            xContent,
+            clientUtil,
+            null,
+            null,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            clock,
+            1,
+            1,
+            60_000L,
+            prometheusDirectQueryExecutor,
+            pplDirectQueryExecutor
+        );
+        when(detector.getSourceType()).thenReturn(Config.SOURCE_TYPE_PPL);
+        when(detector.getPPLSource())
+            .thenReturn(
+                new PPLSource(
+                    "PPL",
+                    "source = sample-http-responses | where response_category = 'client_error' | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket"
+                )
+            );
+        when(detector.getEnabledFeatureIds()).thenReturn(Arrays.asList("f1", "f2"));
+
+        doAnswer(invocation -> {
+            long startTime = invocation.getArgument(1);
+            ActionListener<Optional<double[]>> listener = invocation.getArgument(4);
+            if (startTime == 100L) {
+                listener.onResponse(Optional.of(new double[] { 3.0, 5.0 }));
+            } else {
+                listener.onResponse(Optional.empty());
+            }
+            return null;
+        })
+            .when(pplDirectQueryExecutor)
+            .executeMetricQuery(eq(detector), any(Long.class), any(Long.class), eq(AnalysisType.AD), any(ActionListener.class));
+
+        ActionListener<List<Optional<double[]>>> listener = mock(ActionListener.class);
+        List<Map.Entry<Long, Long>> ranges = Arrays
+            .asList(
+                new java.util.AbstractMap.SimpleImmutableEntry<>(100L, 200L),
+                new java.util.AbstractMap.SimpleImmutableEntry<>(200L, 300L)
+            );
+        pplSearchFeatureDao.getFeatureSamplesForPeriods(detector, ranges, AnalysisType.AD, true, listener);
+
+        ArgumentCaptor<List<Optional<double[]>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(2, captor.getValue().size());
+        assertTrue(captor.getValue().get(0).isPresent());
+        assertEquals(3.0, captor.getValue().get(0).get()[0], 0.001);
+        assertEquals(5.0, captor.getValue().get(0).get()[1], 0.001);
+        assertTrue(captor.getValue().get(1).isPresent());
+        assertTrue(Double.isNaN(captor.getValue().get(1).get()[0]));
+        assertTrue(Double.isNaN(captor.getValue().get(1).get()[1]));
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
     }
 
     @Test

--- a/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
+++ b/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.model;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class PPLSourceTests extends OpenSearchTestCase {
+
+    public void testCompileSupportsCountAndPreservesPreStatsPipeline() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = sample-http-responses | eval error_code = status_code | where error_code >= 400 | stats count() as error_count, sum(http_5xx) as sum_http_5xx by span(timestamp, 60m) as bucket | sort bucket asc"
+            );
+
+        assertEquals("sample-http-responses", compiledQuery.getIndex());
+        assertEquals(2, compiledQuery.getPreStatsStages().size());
+        assertEquals("eval error_code = status_code", compiledQuery.getPreStatsStages().get(0));
+        assertEquals("where error_code >= 400", compiledQuery.getPreStatsStages().get(1));
+        assertEquals("timestamp", compiledQuery.getTimeField());
+        assertEquals(2, compiledQuery.getMetricCount());
+        assertEquals("error_count", compiledQuery.getFeatureNames().get(0));
+        assertEquals("sum_http_5xx", compiledQuery.getFeatureNames().get(1));
+        assertEquals(60L, compiledQuery.getInterval().getInterval());
+        assertEquals(java.time.temporal.ChronoUnit.MINUTES, compiledQuery.getInterval().getUnit());
+
+        String metricQuery = compiledQuery.buildMetricQueryForRange(1_000L, 2_000L);
+        assertTrue(metricQuery.startsWith("source = sample-http-responses | eval error_code = status_code | where error_code >= 400"));
+        assertTrue(metricQuery.contains("| where timestamp >= \"1970-01-01 00:00:01.000\" and timestamp < \"1970-01-01 00:00:02.000\""));
+        assertTrue(metricQuery.endsWith("| stats count() as error_count, sum(http_5xx) as sum_http_5xx"));
+    }
+
+    public void testCompileSupportsCountStarAndDerivedMetricExpressions() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = logs-* | where status >= 400 | stats count(*) as doc_count, avg(bytes / 1024) as avg_kb by span(`event.time`, 10m) as bucket"
+            );
+
+        assertEquals("logs-*", compiledQuery.getIndex());
+        assertEquals("event.time", compiledQuery.getTimeField());
+        assertEquals(2, compiledQuery.getMetricCount());
+        assertEquals("doc_count", compiledQuery.getFeatureNames().get(0));
+        assertEquals("avg_kb", compiledQuery.getFeatureNames().get(1));
+
+        String metricQuery = compiledQuery.buildMetricQueryForRange(60_000L, 120_000L);
+        assertTrue(metricQuery.contains("| stats count() as doc_count, avg(bytes / 1024) as avg_kb"));
+        assertTrue(metricQuery.contains("event.time >= \"1970-01-01 00:01:00.000\" and event.time < \"1970-01-01 00:02:00.000\""));
+    }
+
+    public void testCompileSupportsCountFieldAndQuotedIdentifiers() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = `logs-2026` | where `service.name` = 'checkout' | stats count(`error.code`) as error_code_count by span(`@timestamp`, 5m)"
+            );
+
+        assertEquals("logs-2026", compiledQuery.getIndex());
+        assertEquals("@timestamp", compiledQuery.getTimeField());
+        assertEquals(1, compiledQuery.getMetricCount());
+        assertEquals("error_code_count", compiledQuery.getFeatureNames().get(0));
+
+        String metricQuery = compiledQuery.buildMetricQueryForRange(300_000L, 600_000L);
+        assertTrue(metricQuery.contains("| stats count(`error.code`) as error_code_count"));
+        assertTrue(metricQuery.contains("`@timestamp` >= \"1970-01-01 00:05:00.000\" and `@timestamp` < \"1970-01-01 00:10:00.000\""));
+    }
+
+    public void testCompilePreservesDerivedTimeFieldForAuxiliaryQueries() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile("source = logs | eval bucket_time = @timestamp | stats count() as error_count by span(bucket_time, 10m)");
+
+        assertEquals(
+            "source = logs | eval bucket_time = @timestamp | stats max(bucket_time) as latest_time",
+            compiledQuery.buildLatestTimeQuery()
+        );
+        assertEquals(
+            "source = logs | eval bucket_time = @timestamp | stats min(bucket_time) as min_time",
+            compiledQuery.buildMinTimeQuery()
+        );
+        assertEquals(
+            "source = logs | eval bucket_time = @timestamp | stats min(bucket_time) as min_time, max(bucket_time) as max_time",
+            compiledQuery.buildDateRangeQuery()
+        );
+    }
+
+    public void testCompileRejectsDuplicateMetricAliases() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats count() as dup, sum(bytes) as dup by span(timestamp, 10m)")
+        );
+        assertTrue(exception.getMessage().contains("Duplicate metric alias [dup]"));
+    }
+
+    public void testCompileRejectsNonSortStageAfterFinalStats() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats count() as error_count by span(timestamp, 10m) | head 5")
+        );
+        assertTrue(exception.getMessage().contains("after the final stats stage"));
+    }
+}


### PR DESCRIPTION
## Summary
This PR combines the Prometheus direct-query detector work and the PPL runtime detector work into one backend change set.

It adds direct-query detector runtime support for two non-DSL data-source paths:
- Prometheus-backed detectors and preview execution
- PPL-backed detectors that execute PPL at runtime rather than translating detector execution into source DSL

The PPL path is intentionally scoped to detector-friendly single-stream queries. It persists the original `ppl_source` query, derives detector metadata from it at create time, and executes PPL directly for preview/runtime feature fetches.

## What changed
- add Prometheus direct-query detector execution and preview plumbing
- add `source_type = PPL` with persisted `ppl_source`
- add `PPLSource` parsing/compilation for detector-friendly PPL shapes
- add `PPLDirectQueryExecutor` for runtime PPL execution
- support `count()`, `count(*)`, multiple metrics, and pre-`stats` stages like `where`/`eval`
- derive `detection_interval` from `span(...)` when omitted for PPL detectors
- add REST and model test coverage for preview/create/start/profile flows
- fix preview CI regressions for empty sample ranges
- install `opensearch-sql` in integ test clusters so PPL runtime tests execute against the real plugin
- align the local PPL transport request wire format with the upstream SQL plugin
- add secure inline-preview coverage for PPL detectors

## Verification
Ran locally:
- `./gradlew spotlessApply`
- `./gradlew integTest --tests 'org.opensearch.ad.e2e.PreviewMissingSingleFeatureIT'`
- `./gradlew integTest --tests 'org.opensearch.ad.rest.AnomalyDetectorRestApiIT.testPreviewPPLAnomalyDetectorWithoutExplicitDetectionInterval'`
- `./gradlew integTest --tests 'org.opensearch.ad.rest.AnomalyDetectorRestApiIT.testCreateStartAndProfilePPLAnomalyDetectorWithoutExplicitDetectionInterval' --tests 'org.opensearch.ad.rest.AnomalyDetectorRestApiIT.testCreatePPLAnomalyDetectorRejectsUnsupportedPostStatsStage'`
- `./gradlew integTest -Dsecurity=true -Dhttps=true --tests 'org.opensearch.ad.rest.SecureADRestIT.testPreviewInlinePPLAnomalyDetector'`
- `./gradlew integTest -Dsecurity=true -Dhttps=true -Dresource_sharing.enabled=true --tests 'org.opensearch.ad.rest.SecureADRestIT.testPreviewInlinePPLAnomalyDetector'`

## Notes
- This PR intentionally supersedes the scope of #1699 and #1712, while leaving those PRs unchanged.
- The PPL support in this PR is still single-stream only and intentionally limited to detector-friendly query shapes.