### PR TITLE
Add PPL source support for detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 3.x](https://github.com/opensearch-project/anomaly-detection/compare/3.7...HEAD)
 
 ### Features
+- Add runtime PPL-backed anomaly detector source support ([#1718](https://github.com/opensearch-project/anomaly-detection/pull/1718))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/build.gradle
+++ b/build.gradle
@@ -487,7 +487,10 @@ testClusters.integTest {
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
     configureClusterPlugins(delegate, jobSchedulerFile, securityPluginFile, securityEnabled)
-    plugin(provider(sqlPluginFile))
+    // Benchmark jobs exercise existing DSL model paths and do not need the SQL/PPL plugin.
+    if (!Boolean.getBoolean("model-benchmark")) {
+        plugin(provider(sqlPluginFile))
+    }
     nodes.each { it.jvmArgs("-Xms1g", "-Xmx1g") }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,7 @@ dependencies {
 
     opensearchPlugin "org.opensearch.plugin:opensearch-job-scheduler:${opensearch_build}@zip"
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${opensearch_build}@zip"
+    opensearchPlugin "org.opensearch.plugin:opensearch-sql-plugin:${opensearch_build}@zip"
     testImplementation 'org.reflections:reflections:0.10.2'
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -475,6 +476,7 @@ ext.resolvePluginFile = { pluginId ->
 }
 def jobSchedulerFile = resolvePluginFile("opensearch-job-scheduler")
 def securityPluginFile = resolvePluginFile("opensearch-security")
+def sqlPluginFile = resolvePluginFile("opensearch-sql-plugin")
 
 // === Setup security test ===
 // This flag indicates the existence of security plugin
@@ -485,6 +487,7 @@ testClusters.integTest {
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
     configureClusterPlugins(delegate, jobSchedulerFile, securityPluginFile, securityEnabled)
+    plugin(provider(sqlPluginFile))
     nodes.each { it.jvmArgs("-Xms1g", "-Xmx1g") }
 }
 

--- a/src/main/java/org/opensearch/ad/model/ADTask.java
+++ b/src/main/java/org/opensearch/ad/model/ADTask.java
@@ -348,7 +348,9 @@ public class ADTask extends TimeSeriesTask {
                 detector.getFlattenResultIndexMapping(),
                 detector.getLastBreakingUIChangeTime(),
                 detector.getFrequency(),
-                detector.getAutoCreated()
+                detector.getAutoCreated(),
+                detector.getSourceType(),
+                detector.getPPLSource()
             );
         return new Builder()
             .taskId(parsedTaskId)

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -44,6 +45,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.timeseries.annotation.Generated;
 import org.opensearch.timeseries.common.exception.ValidationException;
+import org.opensearch.timeseries.common.exception.VersionException;
 import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.constant.CommonValue;
 import org.opensearch.timeseries.dataprocessor.ImputationOption;
@@ -51,6 +53,7 @@ import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.DateRange;
 import org.opensearch.timeseries.model.Feature;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.model.PPLSource;
 import org.opensearch.timeseries.model.ShingleGetter;
 import org.opensearch.timeseries.model.TimeConfiguration;
 import org.opensearch.timeseries.model.ValidationAspect;
@@ -189,6 +192,74 @@ public class AnomalyDetector extends Config {
         TimeConfiguration frequency,
         Boolean autoCreated
     ) {
+        this(
+            detectorId,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            detectionInterval,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            categoryFields,
+            user,
+            resultIndex,
+            imputationOption,
+            recencyEmphasis,
+            seasonIntervals,
+            historyIntervals,
+            rules,
+            customResultIndexMinSize,
+            customResultIndexMinAge,
+            customResultIndexTTL,
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime,
+            frequency,
+            autoCreated,
+            null,
+            null
+        );
+    }
+
+    public AnomalyDetector(
+        String detectorId,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration detectionInterval,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime,
+        List<String> categoryFields,
+        User user,
+        String resultIndex,
+        ImputationOption imputationOption,
+        Integer recencyEmphasis,
+        Integer seasonIntervals,
+        Integer historyIntervals,
+        List<Rule> rules,
+        Integer customResultIndexMinSize,
+        Integer customResultIndexMinAge,
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime,
+        TimeConfiguration frequency,
+        Boolean autoCreated,
+        String sourceType,
+        PPLSource pplSource
+    ) {
         super(
             detectorId,
             version,
@@ -206,7 +277,7 @@ public class AnomalyDetector extends Config {
             categoryFields,
             user,
             resultIndex,
-            detectionInterval,
+            resolveDetectionInterval(detectionInterval, sourceType, pplSource),
             imputationOption,
             recencyEmphasis,
             seasonIntervals,
@@ -218,15 +289,31 @@ public class AnomalyDetector extends Config {
             flattenResultIndexMapping,
             lastBreakingUIChangeTime,
             frequency,
-            autoCreated
+            autoCreated,
+            sourceType,
+            pplSource
         );
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
 
-        if (detectionInterval == null) {
+        if (isPPLSourceConfig(this.sourceType, this.pplSource) && detectionInterval != null) {
+            IntervalTimeConfiguration pplInterval = getCompiledPPLInterval(this.pplSource);
+            if (pplInterval != null && !sameDuration(detectionInterval, pplInterval)) {
+                errorMessage = String
+                    .format(
+                        Locale.ROOT,
+                        "detection_interval must match ppl_source span interval (%s) when source_type is PPL.",
+                        pplInterval
+                    );
+                issueType = ValidationIssueType.DETECTION_INTERVAL;
+            }
+        }
+
+        TimeConfiguration resolvedDetectionInterval = this.interval;
+        if (resolvedDetectionInterval == null) {
             errorMessage = ADCommonMessages.NULL_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;
-        } else if (((IntervalTimeConfiguration) detectionInterval).getInterval() <= 0) {
+        } else if (((IntervalTimeConfiguration) resolvedDetectionInterval).getInterval() <= 0) {
             errorMessage = ADCommonMessages.INVALID_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;
         }
@@ -236,8 +323,7 @@ public class AnomalyDetector extends Config {
             errorMessage = CommonMessages.getTooManyCategoricalFieldErr(maxCategoryFields);
             issueType = ValidationIssueType.CATEGORY;
         }
-
-        validateRules(features, rules);
+        validateRules(featureAttributes, rules);
 
         checkAndThrowValidationErrors(ValidationAspect.DETECTOR);
 
@@ -305,6 +391,21 @@ public class AnomalyDetector extends Config {
             this.frequency = null;
         }
         this.autoCreated = input.readOptionalBoolean();
+        if (supportsExternalSourceTransport(input.getVersion())) {
+            this.sourceType = normalizeSerializedSourceType(input.readOptionalString());
+            if (this.sourceType == null) {
+                this.sourceType = SOURCE_TYPE_OPENSEARCH;
+            }
+            if (input.readBoolean()) {
+                this.pplSource = new PPLSource(input);
+                this.sourceType = SOURCE_TYPE_PPL;
+            } else {
+                this.pplSource = null;
+            }
+        } else {
+            this.sourceType = SOURCE_TYPE_OPENSEARCH;
+            this.pplSource = null;
+        }
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -318,6 +419,19 @@ public class AnomalyDetector extends Config {
      */
     @Override
     public void writeTo(StreamOutput output) throws IOException {
+        if (!supportsExternalSourceTransport(output.getVersion()) && isExternalSourceConfig()) {
+            throw new VersionException(
+                id,
+                String
+                    .format(
+                        Locale.ROOT,
+                        "Cannot serialize [%s] source detector to node before [%s].",
+                        sourceType,
+                        EXTERNAL_SOURCE_TRANSPORT_VERSION
+                    )
+            );
+        }
+
         output.writeOptionalString(id);
         output.writeOptionalLong(version);
         output.writeString(name);
@@ -379,6 +493,15 @@ public class AnomalyDetector extends Config {
             output.writeBoolean(false);
         }
         output.writeOptionalBoolean(autoCreated);
+        if (supportsExternalSourceTransport(output.getVersion())) {
+            output.writeOptionalString(sourceType);
+            if (pplSource != null) {
+                output.writeBoolean(true);
+                pplSource.writeTo(output);
+            } else {
+                output.writeBoolean(false);
+            }
+        }
     }
 
     @Override
@@ -453,6 +576,7 @@ public class AnomalyDetector extends Config {
         TimeConfiguration detectionInterval = defaultDetectionInterval == null
             ? null
             : new IntervalTimeConfiguration(defaultDetectionInterval.getMinutes(), ChronoUnit.MINUTES);
+        boolean detectionIntervalProvided = false;
         TimeConfiguration windowDelay = defaultDetectionWindowDelay == null
             ? null
             : new IntervalTimeConfiguration(defaultDetectionWindowDelay.getSeconds(), ChronoUnit.SECONDS);
@@ -479,6 +603,8 @@ public class AnomalyDetector extends Config {
         // by default, frequency is the same as interval when not set
         TimeConfiguration frequency = null;
         Boolean autoCreated = null;
+        String sourceType = null;
+        PPLSource pplSource = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -526,6 +652,7 @@ public class AnomalyDetector extends Config {
                 case DETECTION_INTERVAL_FIELD:
                     try {
                         detectionInterval = TimeConfiguration.parse(parser);
+                        detectionIntervalProvided = true;
                     } catch (Exception e) {
                         if (e instanceof IllegalArgumentException && e.getMessage().contains(CommonMessages.NEGATIVE_TIME_CONFIGURATION)) {
                             throw new ValidationException(
@@ -636,10 +763,20 @@ public class AnomalyDetector extends Config {
                 case AUTO_CREATED_FIELD:
                     autoCreated = onlyParseBooleanValue(parser);
                     break;
+                case SOURCE_TYPE_FIELD:
+                    sourceType = parser.textOrNull();
+                    break;
+                case PPL_SOURCE_FIELD:
+                    pplSource = PPLSource.parse(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
+        }
+
+        if (isPPLSourceConfig(sourceType, pplSource) && !detectionIntervalProvided) {
+            detectionInterval = null;
         }
 
         AnomalyDetector detector = new AnomalyDetector(
@@ -671,10 +808,61 @@ public class AnomalyDetector extends Config {
             flattenResultIndexMapping,
             lastBreakingUIChangeTime,
             frequency,
-            autoCreated
+            autoCreated,
+            sourceType,
+            pplSource
         );
         detector.setDetectionDateRange(detectionDateRange);
         return detector;
+    }
+
+    private static TimeConfiguration resolveDetectionInterval(TimeConfiguration detectionInterval, String sourceType, PPLSource pplSource) {
+        if (detectionInterval != null || !isPPLSourceConfig(sourceType, pplSource)) {
+            return detectionInterval;
+        }
+
+        IntervalTimeConfiguration compiledInterval = getCompiledPPLInterval(pplSource);
+        return compiledInterval == null ? detectionInterval : compiledInterval;
+    }
+
+    private static IntervalTimeConfiguration getCompiledPPLInterval(PPLSource pplSource) {
+        if (pplSource == null) {
+            return null;
+        }
+
+        try {
+            return pplSource.compile().getInterval();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static boolean sameDuration(TimeConfiguration left, IntervalTimeConfiguration right) {
+        if (!(left instanceof IntervalTimeConfiguration) || right == null) {
+            return false;
+        }
+        return ((IntervalTimeConfiguration) left).toDuration().equals(right.toDuration());
+    }
+
+    private static boolean isPPLSourceConfig(String sourceType, PPLSource pplSource) {
+        String normalizedSourceType = normalizeSerializedSourceType(sourceType);
+        if (pplSource != null && normalizedSourceType == null) {
+            return true;
+        }
+        return SOURCE_TYPE_PPL.equals(normalizedSourceType);
+    }
+
+    private static String normalizeSerializedSourceType(String sourceType) {
+        if (sourceType == null) {
+            return null;
+        }
+        String normalized = sourceType.trim();
+        return normalized.isEmpty() ? null : normalized.toUpperCase(Locale.ROOT);
+    }
+
+    private boolean isExternalSourceConfig() {
+        String normalizedSourceType = normalizeSerializedSourceType(sourceType);
+        return SOURCE_TYPE_PPL.equals(normalizedSourceType) || pplSource != null;
     }
 
     public String getDetectorType() {

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -190,72 +190,6 @@ public class AnomalyDetector extends Config {
         Boolean flattenResultIndexMapping,
         Instant lastBreakingUIChangeTime,
         TimeConfiguration frequency,
-        Boolean autoCreated
-    ) {
-        this(
-            detectorId,
-            version,
-            name,
-            description,
-            timeField,
-            indices,
-            features,
-            filterQuery,
-            detectionInterval,
-            windowDelay,
-            shingleSize,
-            uiMetadata,
-            schemaVersion,
-            lastUpdateTime,
-            categoryFields,
-            user,
-            resultIndex,
-            imputationOption,
-            recencyEmphasis,
-            seasonIntervals,
-            historyIntervals,
-            rules,
-            customResultIndexMinSize,
-            customResultIndexMinAge,
-            customResultIndexTTL,
-            flattenResultIndexMapping,
-            lastBreakingUIChangeTime,
-            frequency,
-            autoCreated,
-            null,
-            null
-        );
-    }
-
-    public AnomalyDetector(
-        String detectorId,
-        Long version,
-        String name,
-        String description,
-        String timeField,
-        List<String> indices,
-        List<Feature> features,
-        QueryBuilder filterQuery,
-        TimeConfiguration detectionInterval,
-        TimeConfiguration windowDelay,
-        Integer shingleSize,
-        Map<String, Object> uiMetadata,
-        Integer schemaVersion,
-        Instant lastUpdateTime,
-        List<String> categoryFields,
-        User user,
-        String resultIndex,
-        ImputationOption imputationOption,
-        Integer recencyEmphasis,
-        Integer seasonIntervals,
-        Integer historyIntervals,
-        List<Rule> rules,
-        Integer customResultIndexMinSize,
-        Integer customResultIndexMinAge,
-        Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping,
-        Instant lastBreakingUIChangeTime,
-        TimeConfiguration frequency,
         Boolean autoCreated,
         String sourceType,
         PPLSource pplSource
@@ -309,7 +243,7 @@ public class AnomalyDetector extends Config {
             }
         }
 
-        TimeConfiguration resolvedDetectionInterval = this.interval;
+        TimeConfiguration resolvedDetectionInterval = detectionInterval != null ? detectionInterval : this.interval;
         if (resolvedDetectionInterval == null) {
             errorMessage = ADCommonMessages.NULL_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;

--- a/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyDetector.java
@@ -243,11 +243,10 @@ public class AnomalyDetector extends Config {
             }
         }
 
-        TimeConfiguration resolvedDetectionInterval = detectionInterval != null ? detectionInterval : this.interval;
-        if (resolvedDetectionInterval == null) {
+        if (this.interval == null) {
             errorMessage = ADCommonMessages.NULL_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;
-        } else if (((IntervalTimeConfiguration) resolvedDetectionInterval).getInterval() <= 0) {
+        } else if (((IntervalTimeConfiguration) this.interval).getInterval() <= 0) {
             errorMessage = ADCommonMessages.INVALID_DETECTION_INTERVAL;
             issueType = ValidationIssueType.DETECTION_INTERVAL;
         }

--- a/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/org/opensearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.ad.constant.ADCommonMessages;
 import org.opensearch.ad.model.AnomalyDetector;
@@ -42,6 +43,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.action.RestResponseListener;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.common.exception.ValidationException;
 import org.opensearch.transport.client.node.NodeClient;
 
 import com.google.common.collect.ImmutableList;
@@ -75,7 +77,13 @@ public class RestIndexAnomalyDetectorAction extends AbstractAnomalyDetectorActio
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         // TODO: check detection interval < modelTTL
-        AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId, null, detectionInterval, detectionWindowDelay);
+        AnomalyDetector detector;
+        try {
+            detector = AnomalyDetector.parse(parser, detectorId, null, detectionInterval, detectionWindowDelay);
+        } catch (ValidationException e) {
+            logger.error("validation error", e);
+            throw new OpenSearchStatusException(e.getMessage(), RestStatus.BAD_REQUEST);
+        }
 
         long seqNo = request.paramAsLong(IF_SEQ_NO, SequenceNumbers.UNASSIGNED_SEQ_NO);
         long primaryTerm = request.paramAsLong(IF_PRIMARY_TERM, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);

--- a/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
+++ b/src/main/java/org/opensearch/ad/rest/handler/AbstractAnomalyDetectorActionHandler.java
@@ -252,7 +252,9 @@ public abstract class AbstractAnomalyDetectorActionHandler<T extends ActionRespo
             config.getFlattenResultIndexMapping(),
             breakingUIChange ? Instant.now() : config.getLastBreakingUIChangeTime(),
             config.getFrequency(),
-            detector.getAutoCreated()
+            detector.getAutoCreated(),
+            config.getSourceType(),
+            config.getPPLSource()
         );
     }
 

--- a/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/org/opensearch/ad/task/ADBatchTaskRunner.java
@@ -66,13 +66,9 @@ import org.opensearch.commons.InjectSecurity;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilder;
-import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
-import org.opensearch.search.aggregations.metrics.InternalMax;
-import org.opensearch.search.aggregations.metrics.InternalMin;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.timeseries.AnalysisType;
@@ -84,7 +80,6 @@ import org.opensearch.timeseries.common.exception.LimitExceededException;
 import org.opensearch.timeseries.common.exception.ResourceNotFoundException;
 import org.opensearch.timeseries.common.exception.TaskCancelledException;
 import org.opensearch.timeseries.common.exception.TimeSeriesException;
-import org.opensearch.timeseries.constant.CommonName;
 import org.opensearch.timeseries.feature.FeatureManager;
 import org.opensearch.timeseries.feature.SearchFeatureDao;
 import org.opensearch.timeseries.function.ExecutorFunction;
@@ -939,40 +934,18 @@ public class ADBatchTaskRunner {
 
     private void getDateRangeOfSourceData(ADTask adTask, BiConsumer<Long, Long> consumer, ActionListener<String> internalListener) {
         String taskId = adTask.getTaskId();
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.min(CommonName.AGG_NAME_MIN_TIME).field(adTask.getDetector().getTimeField()))
-            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(adTask.getDetector().getTimeField()))
-            .size(0);
-        if (adTask.getEntity() != null && adTask.getEntity().getAttributes().size() > 0) {
-            BoolQueryBuilder query = new BoolQueryBuilder();
-            adTask
-                .getEntity()
-                .getAttributes()
-                .entrySet()
-                .forEach(entity -> query.filter(new TermQueryBuilder(entity.getKey(), entity.getValue())));
-            searchSourceBuilder.query(query);
+        Map<String, Object> topEntity = new HashMap<>();
+        if (adTask.getEntity() != null) {
+            topEntity.putAll(adTask.getEntity().getAttributes());
         }
-
-        SearchRequest request = new SearchRequest()
-            .indices(adTask.getDetector().getIndices().toArray(new String[0]))
-            .source(searchSourceBuilder);
-        final ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(r -> {
-            InternalMin minAgg = r.getAggregations().get(CommonName.AGG_NAME_MIN_TIME);
-            InternalMax maxAgg = r.getAggregations().get(CommonName.AGG_NAME_MAX_TIME);
-            double minValue = minAgg.getValue();
-            double maxValue = maxAgg.getValue();
-            // If time field not exist or there is no value, will return infinity value
-            if (minValue == Double.POSITIVE_INFINITY) {
-                internalListener.onFailure(new ResourceNotFoundException(adTask.getConfigId(), "There is no data in the time field"));
-                return;
-            }
+        searchFeatureDao.getDateRangeOfSourceData(adTask.getDetector(), adTask.getUser(), topEntity, ActionListener.wrap(minMax -> {
             long interval = ((IntervalTimeConfiguration) adTask.getDetector().getInterval()).toDuration().toMillis();
 
             DateRange detectionDateRange = adTask.getDetectionDateRange();
             long dataStartTime = detectionDateRange.getStartTime().toEpochMilli();
             long dataEndTime = detectionDateRange.getEndTime().toEpochMilli();
-            long minDate = (long) minValue;
-            long maxDate = (long) maxValue;
+            long minDate = minMax.getLeft();
+            long maxDate = minMax.getRight();
 
             if (minDate >= dataEndTime || maxDate <= dataStartTime) {
                 internalListener
@@ -995,19 +968,7 @@ public class ADBatchTaskRunner {
                 return;
             }
             consumer.accept(dataStartTime, dataEndTime);
-        }, e -> { internalListener.onFailure(e); });
-
-        // inject user role while searching.
-        clientUtil
-            .<SearchRequest, SearchResponse>asyncRequestWithInjectedSecurity(
-                request,
-                client::search,
-                // user is the one who started historical detector. Read AnomalyDetectorJobTransportAction.doExecute.
-                adTask.getUser(),
-                client,
-                AnalysisType.AD, // only meant for AD
-                searchResponseListener
-            );
+        }, internalListener::onFailure));
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportAction.java
@@ -111,13 +111,13 @@ public class PreviewAnomalyDetectorTransportAction extends
             // Call the verifyResourceAccessAndProcessRequest method
             verifyResourceAccessAndProcessRequest(
                 ADCommonName.AD_RESOURCE_TYPE,
-                () -> previewExecute(request, context, listener),
+                () -> previewExecute(request, context, user, listener),
                 () -> resolveUserAndExecute(
                     user,
                     detectorId,
                     filterByEnabled,
                     listener,
-                    ad -> previewExecute(request, context, listener),
+                    ad -> previewExecute(request, context, user, listener),
                     client,
                     clusterService,
                     xContentRegistry,
@@ -134,6 +134,7 @@ public class PreviewAnomalyDetectorTransportAction extends
     void previewExecute(
         PreviewAnomalyDetectorRequest request,
         ThreadContext.StoredContext context,
+        User user,
         ActionListener<PreviewAnomalyDetectorResponse> listener
     ) {
         if (adCircuitBreakerService.isOpen()) {
@@ -153,6 +154,9 @@ public class PreviewAnomalyDetectorTransportAction extends
                 Instant endTime = request.getEndTime();
                 ActionListener<PreviewAnomalyDetectorResponse> releaseListener = ActionListener.runAfter(listener, () -> lock.release());
                 if (detector != null) {
+                    if (detector.getUser() == null && user != null) {
+                        detector = copyDetectorWithUser(detector, user);
+                    }
                     String error = validateDetector(detector);
                     if (StringUtils.isNotBlank(error)) {
                         listener.onFailure(new OpenSearchStatusException(error, RestStatus.BAD_REQUEST));
@@ -178,6 +182,44 @@ public class PreviewAnomalyDetectorTransportAction extends
             logger.error(e);
             listener.onFailure(e);
         }
+    }
+
+    private AnomalyDetector copyDetectorWithUser(AnomalyDetector detector, User user) {
+        AnomalyDetector copiedDetector = new AnomalyDetector(
+            detector.getId(),
+            detector.getVersion(),
+            detector.getName(),
+            detector.getDescription(),
+            detector.getTimeField(),
+            detector.getIndices(),
+            detector.getFeatureAttributes(),
+            detector.getFilterQuery(),
+            detector.getInterval(),
+            detector.getWindowDelay(),
+            detector.getShingleSize(),
+            detector.getUiMetadata(),
+            detector.getSchemaVersion(),
+            detector.getLastUpdateTime(),
+            detector.getCategoryFields(),
+            user,
+            detector.getCustomResultIndexOrAlias(),
+            detector.getImputationOption(),
+            detector.getRecencyEmphasis(),
+            detector.getSeasonIntervals(),
+            detector.getHistoryIntervals(),
+            detector.getRules(),
+            detector.getCustomResultIndexMinSize(),
+            detector.getCustomResultIndexMinAge(),
+            detector.getCustomResultIndexTTL(),
+            detector.getFlattenResultIndexMapping(),
+            detector.getLastBreakingUIChangeTime(),
+            detector.getFrequency(),
+            detector.getAutoCreated(),
+            detector.getSourceType(),
+            detector.getPPLSource()
+        );
+        copiedDetector.setDetectionDateRange(detector.getDetectionDateRange());
+        return copiedDetector;
     }
 
     private String validateDetector(AnomalyDetector detector) {

--- a/src/main/java/org/opensearch/forecast/model/Forecaster.java
+++ b/src/main/java/org/opensearch/forecast/model/Forecaster.java
@@ -169,7 +169,9 @@ public class Forecaster extends Config {
             flattenResultIndexMapping,
             lastBreakingUIChangeTime,
             frequency,
-            autoCreated
+            autoCreated,
+            null,
+            null
         );
 
         checkAndThrowValidationErrors(ValidationAspect.FORECASTER);

--- a/src/main/java/org/opensearch/timeseries/feature/FeatureManager.java
+++ b/src/main/java/org/opensearch/timeseries/feature/FeatureManager.java
@@ -298,6 +298,10 @@ public class FeatureManager {
         // TODO refactor this common lines so that these code can be run for 1 time for all entities
         Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
         List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
+        if (sampleRanges.isEmpty()) {
+            listener.onFailure(new IllegalArgumentException("No data available for preview."));
+            return;
+        }
         int stride = sampleRangeResults.getValue();
         int shingleSize = detector.getShingleSize();
 
@@ -340,6 +344,10 @@ public class FeatureManager {
         throws IOException {
         Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
         List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
+        if (sampleRanges.isEmpty()) {
+            listener.onFailure(new IllegalArgumentException("No data available for preview."));
+            return;
+        }
         int stride = sampleRangeResults.getValue();
         int shingleSize = detector.getShingleSize();
 

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -1,0 +1,345 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.feature;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ActionType;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.PPLSource;
+import org.opensearch.timeseries.util.SecurityClientUtil;
+import org.opensearch.transport.client.Client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Executes restricted single-stream PPL detector queries at runtime through the
+ * SQL plugin's internal PPL transport action.
+ */
+public class PPLDirectQueryExecutor {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final DateTimeFormatter PPL_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+        .appendPattern("yyyy-MM-dd HH:mm:ss")
+        .optionalStart()
+        .appendFraction(ChronoField.MILLI_OF_SECOND, 1, 9, true)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+    private static final ActionType<ActionResponse> PPL_QUERY_ACTION = new ActionType<>(
+        "cluster:admin/opensearch/ppl",
+        PPLTransportResponse::new
+    );
+    private static final String PPL_QUERY_PATH = "/_plugins/_ppl";
+    private static final String PPL_RESPONSE_FORMAT = "jdbc";
+
+    private final Client client;
+    private final SecurityClientUtil clientUtil;
+
+    public PPLDirectQueryExecutor(Client client, SecurityClientUtil clientUtil) {
+        this.client = client;
+        this.clientUtil = clientUtil;
+    }
+
+    public void executeMetricQuery(
+        Config config,
+        long startTimeMs,
+        long endTimeMs,
+        AnalysisType context,
+        ActionListener<Optional<double[]>> listener
+    ) {
+        final PPLSource.CompiledPPLQuery compiledQuery;
+        try {
+            compiledQuery = config.getPPLSource().compile();
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        executeQuery(
+            null,
+            config,
+            compiled -> compiledQuery.buildMetricQueryForRange(startTimeMs, endTimeMs),
+            context,
+            responseBody -> parseMetricValues(responseBody, compiledQuery.getMetricCount()),
+            listener
+        );
+    }
+
+    public void executeLatestDataTimeQuery(User user, Config config, AnalysisType context, ActionListener<Optional<Long>> listener) {
+        executeQuery(
+            user,
+            config,
+            PPLSource.CompiledPPLQuery::buildLatestTimeQuery,
+            context,
+            PPLDirectQueryExecutor::parseSingleTimestamp,
+            listener
+        );
+    }
+
+    public void executeMinDataTimeQuery(Config config, AnalysisType context, ActionListener<Optional<Long>> listener) {
+        executeQuery(
+            null,
+            config,
+            PPLSource.CompiledPPLQuery::buildMinTimeQuery,
+            context,
+            PPLDirectQueryExecutor::parseSingleTimestamp,
+            listener
+        );
+    }
+
+    public void executeDateRangeQuery(User user, Config config, AnalysisType context, ActionListener<Pair<Long, Long>> listener) {
+        executeQuery(
+            user,
+            config,
+            PPLSource.CompiledPPLQuery::buildDateRangeQuery,
+            context,
+            PPLDirectQueryExecutor::parseDateRange,
+            listener
+        );
+    }
+
+    private <T> void executeQuery(
+        User user,
+        Config config,
+        Function<PPLSource.CompiledPPLQuery, String> queryBuilder,
+        AnalysisType context,
+        ResponseParser<T> responseParser,
+        ActionListener<T> listener
+    ) {
+        if (config == null || config.getPPLSource() == null) {
+            listener.onFailure(new IllegalArgumentException("ppl_source must be set when source_type is PPL."));
+            return;
+        }
+
+        final PPLSource.CompiledPPLQuery compiledQuery;
+        try {
+            compiledQuery = config.getPPLSource().compile();
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        PPLTransportRequest request = new PPLTransportRequest(queryBuilder.apply(compiledQuery), PPL_RESPONSE_FORMAT, PPL_QUERY_PATH);
+        ActionListener<ActionResponse> queryResponseListener = ActionListener.wrap(response -> {
+            try {
+                listener.onResponse(responseParser.parse(PPLTransportResponse.fromActionResponse(response).getResult()));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, listener::onFailure);
+
+        if (user != null) {
+            clientUtil
+                .asyncRequestWithInjectedSecurity(
+                    request,
+                    (pplRequest, actionListener) -> client.execute(PPL_QUERY_ACTION, pplRequest, actionListener),
+                    user,
+                    client,
+                    context,
+                    queryResponseListener
+                );
+        } else {
+            clientUtil
+                .asyncRequestWithInjectedSecurity(
+                    request,
+                    (pplRequest, actionListener) -> client.execute(PPL_QUERY_ACTION, pplRequest, actionListener),
+                    config.getId(),
+                    client,
+                    context,
+                    queryResponseListener
+                );
+        }
+    }
+
+    private static Optional<double[]> parseMetricValues(String responseBody, int metricCount) throws IOException {
+        JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
+        if (!datarows.isArray() || datarows.isEmpty()) {
+            return Optional.empty();
+        }
+
+        JsonNode firstRow = datarows.get(0);
+        if (!firstRow.isArray() || firstRow.size() < metricCount) {
+            return Optional.empty();
+        }
+
+        double[] values = new double[metricCount];
+        for (int i = 0; i < metricCount; i++) {
+            JsonNode valueNode = firstRow.get(i);
+            if (valueNode == null || valueNode.isNull()) {
+                return Optional.empty();
+            }
+            if (valueNode.isNumber()) {
+                values[i] = valueNode.doubleValue();
+                continue;
+            }
+            if (valueNode.isTextual() && valueNode.textValue() != null && !valueNode.textValue().isBlank()) {
+                values[i] = Double.parseDouble(valueNode.textValue());
+                continue;
+            }
+            return Optional.empty();
+        }
+        return Optional.of(values);
+    }
+
+    private static Optional<Long> parseSingleTimestamp(String responseBody) throws IOException {
+        JsonNode valueNode = getFirstRowValue(responseBody, 0);
+        return parseTimestampValue(valueNode);
+    }
+
+    private static Pair<Long, Long> parseDateRange(String responseBody) throws IOException {
+        Optional<Long> minTime = parseTimestampValue(getFirstRowValue(responseBody, 0));
+        Optional<Long> maxTime = parseTimestampValue(getFirstRowValue(responseBody, 1));
+        if (minTime.isEmpty() || maxTime.isEmpty()) {
+            throw new IllegalStateException("PPL date range query did not return both min and max timestamps.");
+        }
+        return Pair.of(minTime.get(), maxTime.get());
+    }
+
+    private static JsonNode getFirstRowValue(String responseBody, int columnIndex) throws IOException {
+        JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
+        if (!datarows.isArray() || datarows.isEmpty()) {
+            return null;
+        }
+        JsonNode firstRow = datarows.get(0);
+        if (!firstRow.isArray() || firstRow.size() <= columnIndex) {
+            return null;
+        }
+        return firstRow.get(columnIndex);
+    }
+
+    private static Optional<Long> parseTimestampValue(JsonNode valueNode) {
+        if (valueNode == null || valueNode.isNull()) {
+            return Optional.empty();
+        }
+
+        if (valueNode.isNumber()) {
+            return Optional.of(valueNode.longValue());
+        }
+
+        if (valueNode.isTextual() && valueNode.textValue() != null && !valueNode.textValue().isBlank()) {
+            LocalDateTime localDateTime = LocalDateTime.parse(valueNode.textValue(), PPL_TIMESTAMP_FORMATTER);
+            return Optional.of(localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli());
+        }
+
+        return Optional.empty();
+    }
+
+    private interface ResponseParser<T> {
+        T parse(String responseBody) throws Exception;
+    }
+
+    private enum PPLJsonStyle {
+        PRETTY,
+        COMPACT
+    }
+
+    private static final class PPLTransportRequest extends ActionRequest {
+        private final String query;
+        private final String format;
+        private final String explainMode;
+        private final String jsonContent;
+        private final String path;
+        private final boolean sanitize;
+        private final boolean profile;
+        private final String queryId;
+
+        private PPLTransportRequest(String query, String format, String path) {
+            this.query = query;
+            this.format = format;
+            this.explainMode = null;
+            this.jsonContent = null;
+            this.path = path;
+            this.sanitize = true;
+            this.profile = false;
+            this.queryId = null;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalString(query);
+            out.writeOptionalString(format);
+            out.writeOptionalString(explainMode);
+            out.writeOptionalString(jsonContent);
+            out.writeOptionalString(path);
+            out.writeBoolean(sanitize);
+            out.writeEnum(PPLJsonStyle.COMPACT);
+            out.writeBoolean(profile);
+            out.writeOptionalString(queryId);
+        }
+    }
+
+    private static final class PPLTransportResponse extends ActionResponse {
+        private final String result;
+        private final String contentType;
+
+        private PPLTransportResponse(StreamInput in) throws IOException {
+            super(in);
+            this.result = in.readString();
+            this.contentType = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(result);
+            out.writeString(contentType);
+        }
+
+        private static PPLTransportResponse fromActionResponse(ActionResponse actionResponse) {
+            if (actionResponse instanceof PPLTransportResponse) {
+                return (PPLTransportResponse) actionResponse;
+            }
+
+            try (
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)
+            ) {
+                actionResponse.writeTo(output);
+                try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                    return new PPLTransportResponse(input);
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("failed to parse ActionResponse into local PPL transport response", e);
+            }
+        }
+
+        private String getResult() {
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -395,23 +395,6 @@ public class PPLDirectQueryExecutor {
             out.writeOptionalString(queryId);
         }
 
-        private static PPLTransportRequest fromActionRequest(ActionRequest actionRequest) {
-            if (actionRequest instanceof PPLTransportRequest) {
-                return (PPLTransportRequest) actionRequest;
-            }
-
-            try (
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)
-            ) {
-                actionRequest.writeTo(output);
-                try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
-                    return new PPLTransportRequest(input);
-                }
-            } catch (IOException e) {
-                throw new IllegalArgumentException("failed to parse ActionRequest into local PPL transport request", e);
-            }
-        }
     }
 
     private static final class PPLTransportResponse extends ActionResponse {

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -31,6 +32,8 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.ActionType;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
@@ -38,6 +41,7 @@ import org.opensearch.core.common.io.stream.InputStreamStreamInput;
 import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.PPLSource;
@@ -188,26 +192,34 @@ public class PPLDirectQueryExecutor {
             }
         }, listener::onFailure);
 
-        if (user != null) {
-            clientUtil
-                .asyncRequestWithInjectedSecurity(
-                    request,
-                    (pplRequest, actionListener) -> client.execute(PPL_QUERY_ACTION, pplRequest, actionListener),
+        SearchRequest sourceAccessRequest = new SearchRequest(compiledQuery.getIndex()).source(new SearchSourceBuilder().size(0));
+        ActionListener<SearchResponse> sourceAccessListener = ActionListener
+            .wrap(
+                response -> executeWithInjectedSecurity(
                     user,
-                    client,
-                    context,
-                    queryResponseListener
-                );
-        } else {
-            clientUtil
-                .asyncRequestWithInjectedSecurity(
+                    config,
                     request,
                     (pplRequest, actionListener) -> client.execute(PPL_QUERY_ACTION, pplRequest, actionListener),
-                    config.getId(),
-                    client,
                     context,
                     queryResponseListener
-                );
+                ),
+                listener::onFailure
+            );
+        executeWithInjectedSecurity(user, config, sourceAccessRequest, client::search, context, sourceAccessListener);
+    }
+
+    private <Request extends ActionRequest, Response extends ActionResponse> void executeWithInjectedSecurity(
+        User user,
+        Config config,
+        Request request,
+        BiConsumer<Request, ActionListener<Response>> consumer,
+        AnalysisType context,
+        ActionListener<Response> listener
+    ) {
+        if (user != null) {
+            clientUtil.asyncRequestWithInjectedSecurity(request, consumer, user, client, context, listener);
+        } else {
+            clientUtil.asyncRequestWithInjectedSecurity(request, consumer, config.getId(), client, context, listener);
         }
     }
 

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -19,7 +19,9 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -91,6 +93,31 @@ public class PPLDirectQueryExecutor {
             compiled -> compiledQuery.buildMetricQueryForRange(startTimeMs, endTimeMs),
             context,
             responseBody -> parseMetricValues(responseBody, compiledQuery.getMetricCount()),
+            listener
+        );
+    }
+
+    public void executeMetricQueryBySpan(
+        Config config,
+        long startTimeMs,
+        long endTimeMs,
+        AnalysisType context,
+        ActionListener<Map<Long, Optional<double[]>>> listener
+    ) {
+        final PPLSource.CompiledPPLQuery compiledQuery;
+        try {
+            compiledQuery = config.getPPLSource().compile();
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        executeQuery(
+            null,
+            config,
+            compiled -> compiledQuery.buildMetricQueryForRangeBySpan(startTimeMs, endTimeMs),
+            context,
+            responseBody -> parseMetricValuesBySpan(responseBody, compiledQuery.getMetricCount()),
             listener
         );
     }
@@ -192,9 +219,37 @@ public class PPLDirectQueryExecutor {
             return Optional.empty();
         }
 
+        return parseMetricRow(firstRow, metricCount);
+    }
+
+    private static Map<Long, Optional<double[]>> parseMetricValuesBySpan(String responseBody, int metricCount) throws IOException {
+        Map<Long, Optional<double[]>> valuesByBucket = new HashMap<>();
+        JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
+        if (!datarows.isArray() || datarows.isEmpty()) {
+            return valuesByBucket;
+        }
+
+        for (JsonNode row : datarows) {
+            if (!row.isArray() || row.size() <= metricCount) {
+                continue;
+            }
+            Optional<Long> bucketTime = parseTimestampValue(row.get(metricCount));
+            if (bucketTime.isEmpty()) {
+                continue;
+            }
+            valuesByBucket.put(bucketTime.get(), parseMetricRow(row, metricCount));
+        }
+        return valuesByBucket;
+    }
+
+    private static Optional<double[]> parseMetricRow(JsonNode row, int metricCount) {
+        if (!row.isArray() || row.size() < metricCount) {
+            return Optional.empty();
+        }
+
         double[] values = new double[metricCount];
         for (int i = 0; i < metricCount; i++) {
-            JsonNode valueNode = firstRow.get(i);
+            JsonNode valueNode = row.get(i);
             if (valueNode == null || valueNode.isNull()) {
                 return Optional.empty();
             }

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.ActionType;
@@ -50,6 +52,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * SQL plugin's internal PPL transport action.
  */
 public class PPLDirectQueryExecutor {
+    private static final Logger logger = LogManager.getLogger(PPLDirectQueryExecutor.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final DateTimeFormatter PPL_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
         .appendPattern("yyyy-MM-dd HH:mm:ss")
@@ -88,7 +91,7 @@ public class PPLDirectQueryExecutor {
         }
 
         executeQuery(
-            null,
+            config.getUser(),
             config,
             compiled -> compiledQuery.buildMetricQueryForRange(startTimeMs, endTimeMs),
             context,
@@ -113,7 +116,7 @@ public class PPLDirectQueryExecutor {
         }
 
         executeQuery(
-            null,
+            config.getUser(),
             config,
             compiled -> compiledQuery.buildMetricQueryForRangeBySpan(startTimeMs, endTimeMs),
             context,
@@ -135,7 +138,7 @@ public class PPLDirectQueryExecutor {
 
     public void executeMinDataTimeQuery(Config config, AnalysisType context, ActionListener<Optional<Long>> listener) {
         executeQuery(
-            null,
+            config.getUser(),
             config,
             PPLSource.CompiledPPLQuery::buildMinTimeQuery,
             context,
@@ -216,6 +219,7 @@ public class PPLDirectQueryExecutor {
 
         JsonNode firstRow = datarows.get(0);
         if (!firstRow.isArray() || firstRow.size() < metricCount) {
+            logger.warn("Skipping malformed PPL metric row. Expected {} metric column(s), got [{}].", metricCount, firstRow);
             return Optional.empty();
         }
 
@@ -231,10 +235,17 @@ public class PPLDirectQueryExecutor {
 
         for (JsonNode row : datarows) {
             if (!row.isArray() || row.size() <= metricCount) {
+                logger
+                    .warn(
+                        "Skipping malformed PPL metric row. Expected {} metric column(s) plus a bucket column, got [{}].",
+                        metricCount,
+                        row
+                    );
                 continue;
             }
             Optional<Long> bucketTime = parseTimestampValue(row.get(metricCount));
             if (bucketTime.isEmpty()) {
+                logger.warn("Skipping PPL metric row without a valid bucket timestamp: [{}].", row);
                 continue;
             }
             valuesByBucket.put(bucketTime.get(), parseMetricRow(row, metricCount));
@@ -251,7 +262,8 @@ public class PPLDirectQueryExecutor {
         for (int i = 0; i < metricCount; i++) {
             JsonNode valueNode = row.get(i);
             if (valueNode == null || valueNode.isNull()) {
-                return Optional.empty();
+                values[i] = Double.NaN;
+                continue;
             }
             if (valueNode.isNumber()) {
                 values[i] = valueNode.doubleValue();
@@ -261,7 +273,7 @@ public class PPLDirectQueryExecutor {
                 values[i] = Double.parseDouble(valueNode.textValue());
                 continue;
             }
-            return Optional.empty();
+            values[i] = Double.NaN;
         }
         return Optional.of(values);
     }
@@ -339,6 +351,19 @@ public class PPLDirectQueryExecutor {
             this.queryId = null;
         }
 
+        private PPLTransportRequest(StreamInput in) throws IOException {
+            super(in);
+            this.query = in.readOptionalString();
+            this.format = in.readOptionalString();
+            this.explainMode = in.readOptionalString();
+            this.jsonContent = in.readOptionalString();
+            this.path = in.readOptionalString();
+            this.sanitize = in.readBoolean();
+            in.readEnum(PPLJsonStyle.class);
+            this.profile = in.readBoolean();
+            this.queryId = in.readOptionalString();
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             return null;
@@ -356,6 +381,24 @@ public class PPLDirectQueryExecutor {
             out.writeEnum(PPLJsonStyle.COMPACT);
             out.writeBoolean(profile);
             out.writeOptionalString(queryId);
+        }
+
+        private static PPLTransportRequest fromActionRequest(ActionRequest actionRequest) {
+            if (actionRequest instanceof PPLTransportRequest) {
+                return (PPLTransportRequest) actionRequest;
+            }
+
+            try (
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)
+            ) {
+                actionRequest.writeTo(output);
+                try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                    return new PPLTransportRequest(input);
+                }
+            } catch (IOException e) {
+                throw new IllegalArgumentException("failed to parse ActionRequest into local PPL transport request", e);
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
@@ -94,6 +94,7 @@ public class SearchFeatureDao extends AbstractRetriever {
     private final int minimumDocCountForPreview;
     private long previewTimeoutInMilliseconds;
     private Clock clock;
+    private final PPLDirectQueryExecutor pplDirectQueryExecutor;
 
     // used for testing as we can mock clock
     public SearchFeatureDao(
@@ -106,6 +107,32 @@ public class SearchFeatureDao extends AbstractRetriever {
         int maxEntitiesForPreview,
         int pageSize,
         long previewTimeoutInMilliseconds
+    ) {
+        this(
+            client,
+            xContent,
+            clientUtil,
+            clusterService,
+            minimumDocCount,
+            clock,
+            maxEntitiesForPreview,
+            pageSize,
+            previewTimeoutInMilliseconds,
+            null
+        );
+    }
+
+    SearchFeatureDao(
+        Client client,
+        NamedXContentRegistry xContent,
+        SecurityClientUtil clientUtil,
+        ClusterService clusterService,
+        int minimumDocCount,
+        Clock clock,
+        int maxEntitiesForPreview,
+        int pageSize,
+        long previewTimeoutInMilliseconds,
+        PPLDirectQueryExecutor pplDirectQueryExecutor
     ) {
         this.client = client;
         this.xContent = xContent;
@@ -121,6 +148,9 @@ public class SearchFeatureDao extends AbstractRetriever {
         this.minimumDocCountForPreview = minimumDocCount;
         this.previewTimeoutInMilliseconds = previewTimeoutInMilliseconds;
         this.clock = clock;
+        this.pplDirectQueryExecutor = pplDirectQueryExecutor != null
+            ? pplDirectQueryExecutor
+            : new PPLDirectQueryExecutor(client, clientUtil);
     }
 
     /**
@@ -177,6 +207,15 @@ public class SearchFeatureDao extends AbstractRetriever {
         AnalysisType context,
         ActionListener<Optional<Long>> listener
     ) {
+        if (isPPLConfig(config)) {
+            if (entity.isPresent()) {
+                listener.onFailure(new IllegalArgumentException("PPL source_type does not support entity-scoped latest time queries."));
+                return;
+            }
+            pplDirectQueryExecutor.executeLatestDataTimeQuery(user, config, context, listener);
+            return;
+        }
+
         BoolQueryBuilder internalFilterQuery = QueryBuilders.boolQuery();
         if (entity.isPresent()) {
             for (TermQueryBuilder term : entity.get().getTermQueryForCustomerIndex()) {
@@ -221,6 +260,21 @@ public class SearchFeatureDao extends AbstractRetriever {
         Map<String, Object> topEntity,
         ActionListener<Pair<Long, Long>> internalListener
     ) {
+        if (isPPLConfig(config)) {
+            if (topEntity != null && !topEntity.isEmpty()) {
+                internalListener.onFailure(new IllegalArgumentException("PPL source_type does not support categorical entity filters."));
+                return;
+            }
+            pplDirectQueryExecutor
+                .executeDateRangeQuery(
+                    user,
+                    config,
+                    config instanceof AnomalyDetector ? AnalysisType.AD : AnalysisType.FORECAST,
+                    internalListener
+                );
+            return;
+        }
+
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
             .aggregation(AggregationBuilders.min(CommonName.AGG_NAME_MIN_TIME).field(config.getTimeField()))
             .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(config.getTimeField()))
@@ -549,6 +603,15 @@ public class SearchFeatureDao extends AbstractRetriever {
      * @param listener listener to return back the requested timestamps
      */
     public void getMinDataTime(Config config, Optional<Entity> entity, AnalysisType context, ActionListener<Optional<Long>> listener) {
+        if (isPPLConfig(config)) {
+            if (entity.isPresent()) {
+                listener.onFailure(new IllegalArgumentException("PPL source_type does not support entity-scoped min time queries."));
+                return;
+            }
+            pplDirectQueryExecutor.executeMinDataTimeQuery(config, context, listener);
+            return;
+        }
+
         BoolQueryBuilder internalFilterQuery = QueryBuilders.boolQuery();
 
         if (entity.isPresent()) {
@@ -596,6 +659,11 @@ public class SearchFeatureDao extends AbstractRetriever {
      * @param listener onResponse is called with features for the given time period.
      */
     public void getFeaturesForPeriod(AnomalyDetector detector, long startTime, long endTime, ActionListener<Optional<double[]>> listener) {
+        if (isPPLConfig(detector)) {
+            pplDirectQueryExecutor.executeMetricQuery(detector, startTime, endTime, AnalysisType.AD, listener);
+            return;
+        }
+
         SearchRequest searchRequest = createFeatureSearchRequest(detector, startTime, endTime, Optional.empty());
         final ActionListener<SearchResponse> searchResponseListener = ActionListener
             .wrap(response -> listener.onResponse(parseResponse(response, detector.getEnabledFeatureIds(), true)), listener::onFailure);
@@ -619,6 +687,11 @@ public class SearchFeatureDao extends AbstractRetriever {
         long endTime,
         ActionListener<Map<Long, Optional<double[]>>> listener
     ) throws IOException {
+        if (isPPLConfig(detector)) {
+            listener.onFailure(new IllegalArgumentException("PPL source_type only supports single-stream detectors."));
+            return;
+        }
+
         SearchSourceBuilder searchSourceBuilder = batchFeatureQuery(detector, entity, startTime, endTime, xContent);
         logger.debug("Batch query for detector {}: {} ", detector.getId(), searchSourceBuilder);
 
@@ -683,6 +756,11 @@ public class SearchFeatureDao extends AbstractRetriever {
         boolean keepMissingValues,
         ActionListener<List<Optional<double[]>>> listener
     ) throws IOException {
+        if (isPPLConfig(config)) {
+            getPPLFeatureSamplesForPeriods(config, ranges, Optional.empty(), context, keepMissingValues, listener);
+            return;
+        }
+
         SearchRequest request = createRangeSearchRequest(config, ranges);
         final ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(response -> {
             Aggregations aggs = response.getAggregations();
@@ -772,6 +850,11 @@ public class SearchFeatureDao extends AbstractRetriever {
         AnalysisType context,
         ActionListener<List<Optional<double[]>>> listener
     ) {
+        if (isPPLConfig(config)) {
+            getPPLFeatureSamplesForPeriods(config, ranges, entity, context, false, listener);
+            return;
+        }
+
         SearchRequest request = createColdStartFeatureSearchRequest(config, ranges, entity);
         final ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(response -> {
             listener.onResponse(parseColdStartSampleResp(response, includesEmptyBucket, config));
@@ -1166,5 +1249,64 @@ public class SearchFeatureDao extends AbstractRetriever {
         Collections.reverse(sampleRanges);
 
         return sampleRanges;
+    }
+
+    private boolean isPPLConfig(Config config) {
+        return config != null && Config.SOURCE_TYPE_PPL.equals(config.getSourceType()) && config.getPPLSource() != null;
+    }
+
+    private void getPPLFeatureSamplesForPeriods(
+        Config config,
+        List<Entry<Long, Long>> ranges,
+        Optional<Entity> entity,
+        AnalysisType context,
+        boolean keepMissingValues,
+        ActionListener<List<Optional<double[]>>> listener
+    ) {
+        if (entity.isPresent()) {
+            listener.onFailure(new IllegalArgumentException("PPL source_type only supports single-stream detectors."));
+            return;
+        }
+        if (ranges == null || ranges.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+
+        List<Optional<double[]>> results = new ArrayList<>(ranges.size());
+        fetchPPLFeatureSample(config, ranges, 0, context, keepMissingValues, results, listener);
+    }
+
+    private void fetchPPLFeatureSample(
+        Config config,
+        List<Entry<Long, Long>> ranges,
+        int index,
+        AnalysisType context,
+        boolean keepMissingValues,
+        List<Optional<double[]>> results,
+        ActionListener<List<Optional<double[]>>> listener
+    ) {
+        if (index >= ranges.size()) {
+            listener.onResponse(results);
+            return;
+        }
+
+        Entry<Long, Long> range = ranges.get(index);
+        pplDirectQueryExecutor.executeMetricQuery(config, range.getKey(), range.getValue(), context, ActionListener.wrap(value -> {
+            if (value.isPresent()) {
+                results.add(value);
+            } else if (keepMissingValues) {
+                results.add(Optional.of(createMissingFeatureVector(config)));
+            } else {
+                results.add(Optional.empty());
+            }
+            fetchPPLFeatureSample(config, ranges, index + 1, context, keepMissingValues, results, listener);
+        }, listener::onFailure));
+    }
+
+    private double[] createMissingFeatureVector(Config config) {
+        int featureCount = config.getEnabledFeatureIds().size();
+        double[] missingValues = new double[featureCount];
+        Arrays.fill(missingValues, Double.NaN);
+        return missingValues;
     }
 }

--- a/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
@@ -106,31 +106,6 @@ public class SearchFeatureDao extends AbstractRetriever {
         Clock clock,
         int maxEntitiesForPreview,
         int pageSize,
-        long previewTimeoutInMilliseconds
-    ) {
-        this(
-            client,
-            xContent,
-            clientUtil,
-            clusterService,
-            minimumDocCount,
-            clock,
-            maxEntitiesForPreview,
-            pageSize,
-            previewTimeoutInMilliseconds,
-            null
-        );
-    }
-
-    SearchFeatureDao(
-        Client client,
-        NamedXContentRegistry xContent,
-        SecurityClientUtil clientUtil,
-        ClusterService clusterService,
-        int minimumDocCount,
-        Clock clock,
-        int maxEntitiesForPreview,
-        int pageSize,
         long previewTimeoutInMilliseconds,
         PPLDirectQueryExecutor pplDirectQueryExecutor
     ) {
@@ -180,7 +155,8 @@ public class SearchFeatureDao extends AbstractRetriever {
             Clock.systemUTC(),
             MAX_ENTITIES_FOR_PREVIEW.get(settings),
             AD_PAGE_SIZE.get(settings),
-            PREVIEW_TIMEOUT_IN_MILLIS
+            PREVIEW_TIMEOUT_IN_MILLIS,
+            null
         );
     }
 

--- a/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
+++ b/src/main/java/org/opensearch/timeseries/feature/SearchFeatureDao.java
@@ -688,7 +688,11 @@ public class SearchFeatureDao extends AbstractRetriever {
         ActionListener<Map<Long, Optional<double[]>>> listener
     ) throws IOException {
         if (isPPLConfig(detector)) {
-            listener.onFailure(new IllegalArgumentException("PPL source_type only supports single-stream detectors."));
+            if (entity != null) {
+                listener.onFailure(new IllegalArgumentException("PPL source_type only supports single-stream detectors."));
+                return;
+            }
+            pplDirectQueryExecutor.executeMetricQueryBySpan(detector, startTime, endTime, AnalysisType.AD, listener);
             return;
         }
 

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -22,6 +23,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
+import org.opensearch.Version;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -88,6 +90,12 @@ public abstract class Config implements Writeable, ToXContentObject {
     // We cannot use last update time as it would change whenever other fields like name changes.
     public static final String BREAKING_UI_CHANGE_TIME = "last_ui_breaking_change_time";
     public static final String FREQUENCY_FIELD = "frequency";
+    public static final String SOURCE_TYPE_FIELD = "source_type";
+    public static final String PPL_SOURCE_FIELD = "ppl_source";
+    public static final String SOURCE_TYPE_OPENSEARCH = "OPENSEARCH";
+    public static final String SOURCE_TYPE_PPL = "PPL";
+    public static final String PPL_QUERY_LANGUAGE = "PPL";
+    public static final Version EXTERNAL_SOURCE_TRANSPORT_VERSION = Version.V_3_7_0;
 
     protected String id;
     protected Long version;
@@ -131,6 +139,8 @@ public abstract class Config implements Writeable, ToXContentObject {
     protected Instant lastUIBreakingChangeTime;
     protected TimeConfiguration frequency;
     protected Boolean autoCreated;
+    protected String sourceType;
+    protected PPLSource pplSource;
 
     public static String INVALID_RESULT_INDEX_NAME_SIZE = "Result index name size must contains less than "
         + MAX_RESULT_INDEX_NAME_SIZE
@@ -167,20 +177,172 @@ public abstract class Config implements Writeable, ToXContentObject {
         TimeConfiguration frequency,
         Boolean autoCreated
     ) {
+        this(
+            id,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            categoryFields,
+            user,
+            resultIndex,
+            interval,
+            imputationOption,
+            recencyEmphasis,
+            seasonIntervals,
+            shingleGetter,
+            historyIntervals,
+            customResultIndexMinSize,
+            customResultIndexMinAge,
+            customResultIndexTTL,
+            flattenResultIndexMapping,
+            lastBreakingUIChangeTime,
+            frequency,
+            autoCreated,
+            null,
+            null
+        );
+    }
+
+    protected Config(
+        String id,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime,
+        List<String> categoryFields,
+        User user,
+        String resultIndex,
+        TimeConfiguration interval,
+        ImputationOption imputationOption,
+        Integer recencyEmphasis,
+        Integer seasonIntervals,
+        ShingleGetter shingleGetter,
+        Integer historyIntervals,
+        Integer customResultIndexMinSize,
+        Integer customResultIndexMinAge,
+        Integer customResultIndexTTL,
+        Boolean flattenResultIndexMapping,
+        Instant lastBreakingUIChangeTime,
+        TimeConfiguration frequency,
+        Boolean autoCreated,
+        String sourceType,
+        PPLSource pplSource
+    ) {
         if (Strings.isBlank(name)) {
             errorMessage = CommonMessages.EMPTY_NAME;
             issueType = ValidationIssueType.NAME;
             return;
         }
-        if (Strings.isBlank(timeField)) {
-            errorMessage = CommonMessages.NULL_TIME_FIELD;
-            issueType = ValidationIssueType.TIMEFIELD_FIELD;
+
+        String normalizedSourceType = normalizeSourceType(sourceType, pplSource);
+        if (normalizedSourceType == null) {
+            issueType = ValidationIssueType.GENERAL_SETTINGS;
+            errorMessage = "Unsupported source_type [" + sourceType + "]. Supported values are OPENSEARCH and PPL.";
             return;
         }
-        if (indices == null || indices.isEmpty()) {
-            errorMessage = CommonMessages.EMPTY_INDICES;
-            issueType = ValidationIssueType.INDICES;
-            return;
+
+        String resolvedTimeField = timeField;
+        List<String> resolvedIndices = indices;
+        List<Feature> resolvedFeatures = features;
+
+        if (isPPLSource(normalizedSourceType)) {
+            if (pplSource == null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "Must set ppl_source when source_type is PPL.";
+                return;
+            }
+            if (!PPL_QUERY_LANGUAGE.equalsIgnoreCase(pplSource.getQueryLanguage())) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "ppl_source.query_language must be PPL when source_type is PPL.";
+                return;
+            }
+            if (categoryFields != null && !categoryFields.isEmpty()) {
+                issueType = ValidationIssueType.CATEGORY;
+                errorMessage = "category_field must be empty when source_type is PPL.";
+                return;
+            }
+
+            PPLSource.CompiledPPLQuery compiledPPLQuery;
+            try {
+                compiledPPLQuery = pplSource.compile();
+            } catch (IllegalArgumentException e) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = e.getMessage();
+                return;
+            }
+
+            resolvedTimeField = compiledPPLQuery.getTimeField();
+            resolvedIndices = Collections.singletonList(compiledPPLQuery.getIndex());
+            resolvedFeatures = features == null || features.isEmpty() ? compiledPPLQuery.toPlaceholderFeatures() : features;
+
+            if (resolvedFeatures.size() != compiledPPLQuery.getMetricCount()) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = String
+                    .format(
+                        Locale.ROOT,
+                        "feature_attributes must contain exactly %d entries when source_type is PPL.",
+                        compiledPPLQuery.getMetricCount()
+                    );
+                return;
+            }
+
+            for (int i = 0; i < resolvedFeatures.size(); i++) {
+                if (!compiledPPLQuery.getFeatureNames().get(i).equals(resolvedFeatures.get(i).getName())) {
+                    issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                    errorMessage = "feature_attributes must match the metric aliases defined in ppl_source.query.";
+                    return;
+                }
+            }
+
+            long enabledFeatureCount = resolvedFeatures.stream().filter(Feature::getEnabled).count();
+            if (enabledFeatureCount != compiledPPLQuery.getMetricCount()) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = String
+                    .format(
+                        Locale.ROOT,
+                        "Exactly %d enabled feature(s) are required when source_type is PPL.",
+                        compiledPPLQuery.getMetricCount()
+                    );
+                return;
+            }
+        } else {
+            if (Strings.isBlank(resolvedTimeField)) {
+                errorMessage = CommonMessages.NULL_TIME_FIELD;
+                issueType = ValidationIssueType.TIMEFIELD_FIELD;
+                return;
+            }
+            if (resolvedIndices == null || resolvedIndices.isEmpty()) {
+                errorMessage = CommonMessages.EMPTY_INDICES;
+                issueType = ValidationIssueType.INDICES;
+                return;
+            }
+            if (resolvedFeatures != null && resolvedFeatures.stream().anyMatch(Feature::usesPlaceholderAggregation)) {
+                issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
+                errorMessage = "feature_attributes.aggregation_query must be set when source_type is OPENSEARCH.";
+                return;
+            }
+            if (pplSource != null) {
+                issueType = ValidationIssueType.GENERAL_SETTINGS;
+                errorMessage = "ppl_source must be empty when source_type is OPENSEARCH.";
+                return;
+            }
         }
 
         // shingle size
@@ -234,7 +396,7 @@ public abstract class Config implements Writeable, ToXContentObject {
             return;
         }
 
-        List<String> redundantNames = findRedundantNames(features);
+        List<String> redundantNames = findRedundantNames(resolvedFeatures);
         if (redundantNames.size() > 0) {
             issueType = ValidationIssueType.FEATURE_ATTRIBUTES;
             errorMessage = redundantNames + " appears more than once. Feature name has to be unique";
@@ -243,9 +405,9 @@ public abstract class Config implements Writeable, ToXContentObject {
 
         if (imputationOption != null && imputationOption.getMethod() == ImputationMethod.FIXED_VALUES) {
             // Calculate the number of enabled features
-            List<Feature> enabledFeatures = features == null
+            List<Feature> enabledFeatures = resolvedFeatures == null
                 ? null
-                : features.stream().filter(Feature::getEnabled).collect(Collectors.toList());
+                : resolvedFeatures.stream().filter(Feature::getEnabled).collect(Collectors.toList());
 
             Map<String, Double> defaultFill = imputationOption.getDefaultFill();
 
@@ -288,55 +450,50 @@ public abstract class Config implements Writeable, ToXContentObject {
             Duration frequencyDuration = ((IntervalTimeConfiguration) frequency).toDuration();
             Duration intervalDuration = ((IntervalTimeConfiguration) interval).toDuration();
 
-            if (intervalDuration.isZero()) {
-                // we will check for invalid interval in subclass constructor
-                // since the error message is different among different subclasses
-                // (e.g. AD using detection interval and Forecaster using forecast interval)
-                return;
-            }
+            if (!intervalDuration.isZero()) {
+                if (frequencyDuration.isZero()) {
+                    issueType = ValidationIssueType.FREQUENCY;
+                    errorMessage = "Frequency must be greater than 0.";
+                    return;
+                }
+                // Check if frequency is NOT a multiple of interval
+                if (!TimeUtil.isMultiple(frequencyDuration, intervalDuration)) {
+                    issueType = ValidationIssueType.FREQUENCY;
+                    errorMessage = String
+                        .format(
+                            Locale.ROOT,
+                            "Frequency (%s) must be a multiple of interval (%s), including the interval itself.",
+                            frequency.toString(),
+                            interval.toString()
+                        );
+                    return;
+                }
 
-            if (frequencyDuration.isZero()) {
-                issueType = ValidationIssueType.FREQUENCY;
-                errorMessage = "Frequency must be greater than 0.";
-                return;
-            }
-            // Check if frequency is NOT a multiple of interval
-            if (!TimeUtil.isMultiple(frequencyDuration, intervalDuration)) {
-                issueType = ValidationIssueType.FREQUENCY;
-                errorMessage = String
-                    .format(
-                        Locale.ROOT,
-                        "Frequency (%s) must be a multiple of interval (%s), including the interval itself.",
-                        frequency.toString(),
-                        interval.toString()
-                    );
-                return;
-            }
-
-            // Check if the multiple exceeds the maximum allowed value
-            long multiple = TimeUtil.getMultiple(frequencyDuration, intervalDuration);
-            if (multiple > TimeSeriesSettings.MAX_FREQUENCY_MULTIPLE) {
-                issueType = ValidationIssueType.FREQUENCY;
-                errorMessage = String
-                    .format(
-                        Locale.ROOT,
-                        "Frequency multiple (%d) exceeds the maximum allowed value (%d). Frequency: %s, Interval: %s.",
-                        multiple,
-                        TimeSeriesSettings.MAX_FREQUENCY_MULTIPLE,
-                        frequency.toString(),
-                        interval.toString()
-                    );
-                return;
+                // Check if the multiple exceeds the maximum allowed value
+                long multiple = TimeUtil.getMultiple(frequencyDuration, intervalDuration);
+                if (multiple > TimeSeriesSettings.MAX_FREQUENCY_MULTIPLE) {
+                    issueType = ValidationIssueType.FREQUENCY;
+                    errorMessage = String
+                        .format(
+                            Locale.ROOT,
+                            "Frequency multiple (%d) exceeds the maximum allowed value (%d). Frequency: %s, Interval: %s.",
+                            multiple,
+                            TimeSeriesSettings.MAX_FREQUENCY_MULTIPLE,
+                            frequency.toString(),
+                            interval.toString()
+                        );
+                    return;
+                }
             }
         }
         this.id = id;
         this.version = version;
         this.name = name;
         this.description = description;
-        this.timeField = timeField;
-        this.indices = indices;
+        this.timeField = Strings.isBlank(resolvedTimeField) ? "" : resolvedTimeField;
+        this.indices = resolvedIndices == null ? ImmutableList.of() : ImmutableList.copyOf(resolvedIndices);
         // we validate empty or no enabled features when starting config (Read IndexJobActionHandler.validateConfig)
-        this.featureAttributes = features == null ? ImmutableList.of() : ImmutableList.copyOf(features);
+        this.featureAttributes = resolvedFeatures == null ? ImmutableList.of() : ImmutableList.copyOf(resolvedFeatures);
         this.filterQuery = filterQuery;
         this.interval = interval;
         this.windowDelay = windowDelay;
@@ -361,6 +518,30 @@ public abstract class Config implements Writeable, ToXContentObject {
         this.lastUIBreakingChangeTime = lastBreakingUIChangeTime;
         this.frequency = frequency;
         this.autoCreated = autoCreated != null ? autoCreated : false;
+        this.sourceType = normalizedSourceType;
+        this.pplSource = pplSource;
+    }
+
+    private String normalizeSourceType(String sourceType, PPLSource pplSource) {
+        if (Strings.isBlank(sourceType)) {
+            if (pplSource != null) {
+                return SOURCE_TYPE_PPL;
+            }
+            return SOURCE_TYPE_OPENSEARCH;
+        }
+        String normalized = sourceType.trim().toUpperCase(Locale.ROOT);
+        if (SOURCE_TYPE_OPENSEARCH.equals(normalized) || SOURCE_TYPE_PPL.equals(normalized)) {
+            return normalized;
+        }
+        return null;
+    }
+
+    public static boolean supportsExternalSourceTransport(Version version) {
+        return version != null && version.onOrAfter(EXTERNAL_SOURCE_TRANSPORT_VERSION);
+    }
+
+    private boolean isPPLSource(String sourceType) {
+        return SOURCE_TYPE_PPL.equals(sourceType);
     }
 
     /**
@@ -465,6 +646,10 @@ public abstract class Config implements Writeable, ToXContentObject {
             this.frequency = null;
         }
         this.autoCreated = input.readOptionalBoolean();
+        // Source-specific transport fields live in subtype layouts. Forecaster
+        // appends horizon after Config, so Config must not consume trailing bytes.
+        this.sourceType = SOURCE_TYPE_OPENSEARCH;
+        this.pplSource = null;
     }
 
     /*
@@ -585,7 +770,9 @@ public abstract class Config implements Writeable, ToXContentObject {
             && Objects.equal(customResultIndexTTL, config.customResultIndexTTL)
             && Objects.equal(flattenResultIndexMapping, config.flattenResultIndexMapping)
             && Objects.equal(frequency, config.frequency)
-            && Objects.equal(autoCreated, config.autoCreated);
+            && Objects.equal(autoCreated, config.autoCreated)
+            && Objects.equal(sourceType, config.sourceType)
+            && Objects.equal(pplSource, config.pplSource);
     }
 
     @Generated
@@ -615,7 +802,9 @@ public abstract class Config implements Writeable, ToXContentObject {
                 customResultIndexTTL,
                 flattenResultIndexMapping,
                 frequency,
-                autoCreated
+                autoCreated,
+                sourceType,
+                pplSource
             );
     }
 
@@ -624,8 +813,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         builder
             .field(NAME_FIELD, name)
             .field(DESCRIPTION_FIELD, Encode.forHtml(description))
-            .field(TIMEFIELD_FIELD, timeField)
-            .field(INDICES_FIELD, indices.toArray())
             .field(FILTER_QUERY_FIELD, filterQuery)
             .field(WINDOW_DELAY_FIELD, windowDelay)
             .field(SHINGLE_SIZE_FIELD, shingleSize)
@@ -633,6 +820,15 @@ public abstract class Config implements Writeable, ToXContentObject {
             .field(FEATURE_ATTRIBUTES_FIELD, featureAttributes.toArray())
             .field(RECENCY_EMPHASIS_FIELD, recencyEmphasis)
             .field(HISTORY_INTERVAL_FIELD, historyIntervals);
+
+        builder.field(TIMEFIELD_FIELD, timeField);
+        builder.field(INDICES_FIELD, indices.toArray());
+        if (SOURCE_TYPE_PPL.equals(sourceType)) {
+            builder.field(SOURCE_TYPE_FIELD, sourceType);
+            if (pplSource != null) {
+                builder.field(PPL_SOURCE_FIELD, pplSource);
+            }
+        }
 
         if (uiMetadata != null && !uiMetadata.isEmpty()) {
             builder.field(UI_METADATA_FIELD, uiMetadata);
@@ -697,6 +893,14 @@ public abstract class Config implements Writeable, ToXContentObject {
 
     public List<String> getIndices() {
         return indices;
+    }
+
+    public String getSourceType() {
+        return sourceType;
+    }
+
+    public PPLSource getPPLSource() {
+        return pplSource;
     }
 
     public List<Feature> getFeatureAttributes() {

--- a/src/main/java/org/opensearch/timeseries/model/Config.java
+++ b/src/main/java/org/opensearch/timeseries/model/Config.java
@@ -175,72 +175,6 @@ public abstract class Config implements Writeable, ToXContentObject {
         Boolean flattenResultIndexMapping,
         Instant lastBreakingUIChangeTime,
         TimeConfiguration frequency,
-        Boolean autoCreated
-    ) {
-        this(
-            id,
-            version,
-            name,
-            description,
-            timeField,
-            indices,
-            features,
-            filterQuery,
-            windowDelay,
-            shingleSize,
-            uiMetadata,
-            schemaVersion,
-            lastUpdateTime,
-            categoryFields,
-            user,
-            resultIndex,
-            interval,
-            imputationOption,
-            recencyEmphasis,
-            seasonIntervals,
-            shingleGetter,
-            historyIntervals,
-            customResultIndexMinSize,
-            customResultIndexMinAge,
-            customResultIndexTTL,
-            flattenResultIndexMapping,
-            lastBreakingUIChangeTime,
-            frequency,
-            autoCreated,
-            null,
-            null
-        );
-    }
-
-    protected Config(
-        String id,
-        Long version,
-        String name,
-        String description,
-        String timeField,
-        List<String> indices,
-        List<Feature> features,
-        QueryBuilder filterQuery,
-        TimeConfiguration windowDelay,
-        Integer shingleSize,
-        Map<String, Object> uiMetadata,
-        Integer schemaVersion,
-        Instant lastUpdateTime,
-        List<String> categoryFields,
-        User user,
-        String resultIndex,
-        TimeConfiguration interval,
-        ImputationOption imputationOption,
-        Integer recencyEmphasis,
-        Integer seasonIntervals,
-        ShingleGetter shingleGetter,
-        Integer historyIntervals,
-        Integer customResultIndexMinSize,
-        Integer customResultIndexMinAge,
-        Integer customResultIndexTTL,
-        Boolean flattenResultIndexMapping,
-        Instant lastBreakingUIChangeTime,
-        TimeConfiguration frequency,
         Boolean autoCreated,
         String sourceType,
         PPLSource pplSource
@@ -1190,6 +1124,8 @@ public abstract class Config implements Writeable, ToXContentObject {
             .append("flattenResultIndexMapping", flattenResultIndexMapping)
             .append("frequency", frequency)
             .append("autoCreated", autoCreated)
+            .append("sourceType", sourceType)
+            .append("pplSource", pplSource)
             .toString();
     }
 

--- a/src/main/java/org/opensearch/timeseries/model/Feature.java
+++ b/src/main/java/org/opensearch/timeseries/model/Feature.java
@@ -25,6 +25,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.timeseries.annotation.Generated;
 import org.opensearch.timeseries.util.ParseUtils;
 
@@ -39,6 +40,8 @@ public class Feature implements Writeable, ToXContentObject {
     public static final String FEATURE_NAME_FIELD = "feature_name";
     private static final String FEATURE_ENABLED_FIELD = "feature_enabled";
     private static final String AGGREGATION_QUERY = "aggregation_query";
+    public static final String DIRECT_QUERY_PLACEHOLDER_AGG_NAME = "__direct_query_feature_value__";
+    private static final String DIRECT_QUERY_PLACEHOLDER_FIELD = "__direct_query_value__";
 
     private final String id;
     private final String name;
@@ -47,7 +50,7 @@ public class Feature implements Writeable, ToXContentObject {
 
     /**
      * Constructor function.
-     *  @param id      feature id
+     * @param id      feature id
      * @param name    feature name
      * @param enabled feature enabled or not
      * @param aggregation feature aggregation query
@@ -130,7 +133,16 @@ public class Feature implements Writeable, ToXContentObject {
                     break;
             }
         }
+        if (aggregation == null) {
+            aggregation = AggregationBuilders.avg(DIRECT_QUERY_PLACEHOLDER_AGG_NAME).field(DIRECT_QUERY_PLACEHOLDER_FIELD);
+        }
         return new Feature(id, name, enabled, aggregation);
+    }
+
+    public static Feature createDirectQueryPlaceholder(String id, String name, Boolean enabled) {
+        String suffix = id == null ? UUIDs.base64UUID() : id;
+        String aggregationName = DIRECT_QUERY_PLACEHOLDER_AGG_NAME + "_" + suffix.replaceAll("[^A-Za-z0-9_]+", "_");
+        return new Feature(id, name, enabled, AggregationBuilders.avg(aggregationName).field(DIRECT_QUERY_PLACEHOLDER_FIELD));
     }
 
     @Generated
@@ -169,6 +181,14 @@ public class Feature implements Writeable, ToXContentObject {
 
     public AggregationBuilder getAggregation() {
         return aggregation;
+    }
+
+    public boolean usesDirectQueryPlaceholderAggregation() {
+        return aggregation != null && aggregation.getName() != null && aggregation.getName().startsWith(DIRECT_QUERY_PLACEHOLDER_AGG_NAME);
+    }
+
+    public boolean usesPlaceholderAggregation() {
+        return usesDirectQueryPlaceholderAggregation();
     }
 
     @Override

--- a/src/main/java/org/opensearch/timeseries/model/PPLSource.java
+++ b/src/main/java/org/opensearch/timeseries/model/PPLSource.java
@@ -1,0 +1,800 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.model;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.logging.log4j.util.Strings;
+import org.opensearch.common.UUIDs;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.timeseries.annotation.Generated;
+
+import com.google.common.base.Objects;
+
+/**
+ * Stores the original PPL query for detectors created from a detector-friendly
+ * single-stream PPL form. The query is compiled into detector metadata at
+ * creation time, then executed through the PPL engine at runtime.
+ */
+public class PPLSource implements Writeable, ToXContentObject {
+
+    public static final String QUERY_LANGUAGE_FIELD = "query_language";
+    public static final String QUERY_FIELD = "query";
+    public static final String PPL_QUERY_LANGUAGE = "PPL";
+
+    private static final String STATS_ERROR_MESSAGE =
+        "Unsupported PPL stats clause. Expected a final stage shaped like: stats <agg>(...) [as <feature>][, ...] by span(<time_field>, <interval>), where interval uses s or m.";
+    private static final DateTimeFormatter QUERY_TIMESTAMP_FORMATTER = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ss.SSS", Locale.ROOT)
+        .withZone(ZoneOffset.UTC);
+
+    private final String queryLanguage;
+    private final String query;
+
+    public PPLSource(String queryLanguage, String query) {
+        this.queryLanguage = queryLanguage;
+        this.query = query;
+    }
+
+    public PPLSource(StreamInput in) throws IOException {
+        this.queryLanguage = in.readOptionalString();
+        this.query = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(queryLanguage);
+        out.writeOptionalString(query);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (queryLanguage != null) {
+            builder.field(QUERY_LANGUAGE_FIELD, queryLanguage);
+        }
+        if (query != null) {
+            builder.field(QUERY_FIELD, query);
+        }
+        return builder.endObject();
+    }
+
+    public static PPLSource parse(XContentParser parser) throws IOException {
+        String queryLanguage = null;
+        String query = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            switch (fieldName) {
+                case QUERY_LANGUAGE_FIELD:
+                    queryLanguage = parser.textOrNull();
+                    break;
+                case QUERY_FIELD:
+                    query = parser.textOrNull();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new PPLSource(queryLanguage, query);
+    }
+
+    public CompiledPPLQuery compile() {
+        return compile(query);
+    }
+
+    public static CompiledPPLQuery compile(String query) {
+        if (Strings.isBlank(query)) {
+            throw new IllegalArgumentException("ppl_source.query must be set when source_type is PPL.");
+        }
+
+        List<String> stages = splitTopLevel(query.trim(), '|');
+        if (stages.size() < 2) {
+            throw new IllegalArgumentException(
+                "Unsupported ppl_source.query. Expected a PPL pipeline that starts with source = <index> and ends with stats ... by span(...)."
+            );
+        }
+
+        SourceStage sourceStage = parseSourceStage(stages.get(0));
+        int statsStageIndex = findFinalStatsStageIndex(stages);
+        if (statsStageIndex <= 0) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        for (int i = statsStageIndex + 1; i < stages.size(); i++) {
+            String stage = stages.get(i);
+            if (!isSortStage(stage)) {
+                throw new IllegalArgumentException(
+                    "Unsupported PPL pipeline stage [" + stage + "] after the final stats stage. Only trailing sort stages are supported."
+                );
+            }
+        }
+
+        List<String> preStatsStages = new ArrayList<>(Math.max(0, statsStageIndex - 1));
+        for (int i = 1; i < statsStageIndex; i++) {
+            String stage = stages.get(i).trim();
+            if (stage.isEmpty()) {
+                continue;
+            }
+            if (isSourceStage(stage)) {
+                throw new IllegalArgumentException("PPL detector queries must contain exactly one source stage.");
+            }
+            if (isStatsStage(stage)) {
+                throw new IllegalArgumentException("Only one final stats stage is supported in ppl_source.query for detector creation.");
+            }
+            if (!isSupportedPreStatsStage(stage)) {
+                throw new IllegalArgumentException(
+                    "Unsupported PPL pipeline stage ["
+                        + stage
+                        + "] before the final stats stage. Supported pre-stats stages are where and eval."
+                );
+            }
+            preStatsStages.add(stage);
+        }
+
+        StatsStage statsStage = parseStatsStage(stages.get(statsStageIndex));
+        return new CompiledPPLQuery(
+            sourceStage.getIndex(),
+            Collections.unmodifiableList(preStatsStages),
+            statsStage.getTimeField(),
+            statsStage.getMetrics(),
+            statsStage.getInterval()
+        );
+    }
+
+    private static SourceStage parseSourceStage(String stage) {
+        String trimmed = stage.trim();
+        int equalsIndex = trimmed.indexOf('=');
+        if (!startsWithKeyword(trimmed, "source") || equalsIndex < 0) {
+            throw new IllegalArgumentException("Unsupported PPL source clause. Expected: source = <index>.");
+        }
+
+        String index = stripBackticks(trimmed.substring(equalsIndex + 1));
+        if (Strings.isBlank(index) || index.contains(",")) {
+            throw new IllegalArgumentException("PPL source must reference exactly one index or index pattern.");
+        }
+        return new SourceStage(index);
+    }
+
+    private static int findFinalStatsStageIndex(List<String> stages) {
+        int lastStatsStageIndex = -1;
+        for (int i = stages.size() - 1; i >= 1; i--) {
+            String stage = stages.get(i).trim();
+            if (stage.isEmpty()) {
+                continue;
+            }
+            if (isStatsStage(stage)) {
+                lastStatsStageIndex = i;
+                break;
+            }
+        }
+        return lastStatsStageIndex;
+    }
+
+    private static StatsStage parseStatsStage(String stage) {
+        String trimmed = stage.trim();
+        if (!isStatsStage(trimmed)) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String statsBody = trimmed.substring("stats".length()).trim();
+        int bySpanIndex = findTopLevelBySpanIndex(statsBody);
+        if (bySpanIndex < 0) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String metricsClause = statsBody.substring(0, bySpanIndex).trim();
+        String spanClause = statsBody.substring(bySpanIndex).trim();
+
+        if (!startsWithKeyword(spanClause, "by")) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+        spanClause = spanClause.substring(2).trim();
+        if (!startsWithKeyword(spanClause, "span")) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        int openParenIndex = spanClause.indexOf('(');
+        int closeParenIndex = findMatchingParen(spanClause, openParenIndex);
+        if (openParenIndex < 0 || closeParenIndex < 0) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String spanArgs = spanClause.substring(openParenIndex + 1, closeParenIndex).trim();
+        List<String> spanParts = splitTopLevel(spanArgs, ',');
+        if (spanParts.size() != 2) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String trailingSpanClause = spanClause.substring(closeParenIndex + 1).trim();
+        if (!trailingSpanClause.isEmpty()) {
+            int aliasSeparator = findTopLevelAsSeparator(trailingSpanClause);
+            if (aliasSeparator != 0 || trailingSpanClause.substring(aliasSeparator + 2).trim().isEmpty()) {
+                // `as bucket` is allowed, but we do not consume the alias.
+                throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+            }
+        }
+
+        String timeField = stripBackticks(spanParts.get(0));
+        if (Strings.isBlank(timeField) || timeField.contains(" ")) {
+            throw new IllegalArgumentException("PPL span time field must be a single field reference.");
+        }
+
+        List<MetricSpec> metrics = parseMetrics(metricsClause);
+        IntervalTimeConfiguration intervalConfiguration = parseInterval(spanParts.get(1).trim());
+        return new StatsStage(metrics, timeField, intervalConfiguration);
+    }
+
+    private static List<MetricSpec> parseMetrics(String metricsClause) {
+        List<String> metricExpressions = splitTopLevel(metricsClause, ',');
+        if (metricExpressions.isEmpty()) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        List<MetricSpec> metrics = new ArrayList<>(metricExpressions.size());
+        Set<String> seenFeatureNames = new HashSet<>();
+        for (String metricExpression : metricExpressions) {
+            MetricSpec metric = parseMetric(metricExpression.trim());
+            if (!seenFeatureNames.add(metric.getFeatureName())) {
+                throw new IllegalArgumentException(
+                    "Duplicate metric alias [" + metric.getFeatureName() + "] is not supported in ppl_source.query."
+                );
+            }
+            metrics.add(metric);
+        }
+        return Collections.unmodifiableList(metrics);
+    }
+
+    private static MetricSpec parseMetric(String metricExpression) {
+        int aliasSeparator = findTopLevelAsSeparator(metricExpression);
+        String metricCore = aliasSeparator >= 0 ? metricExpression.substring(0, aliasSeparator).trim() : metricExpression.trim();
+        String alias = aliasSeparator >= 0 ? stripBackticks(metricExpression.substring(aliasSeparator + 2).trim()) : null;
+
+        int openParenIndex = metricCore.indexOf('(');
+        int closeParenIndex = findMatchingParen(metricCore, openParenIndex);
+        if (openParenIndex <= 0 || closeParenIndex != metricCore.length() - 1) {
+            throw new IllegalArgumentException(STATS_ERROR_MESSAGE);
+        }
+
+        String aggregationType = metricCore.substring(0, openParenIndex).trim().toLowerCase(Locale.ROOT);
+        if (!isSupportedAggregationType(aggregationType)) {
+            throw new IllegalArgumentException(
+                "Unsupported aggregation ["
+                    + aggregationType
+                    + "] in ppl_source.query. Supported aggregations are count, sum, avg, min, and max."
+            );
+        }
+
+        String argumentExpression = metricCore.substring(openParenIndex + 1, closeParenIndex).trim();
+        boolean countAll = "count".equals(aggregationType) && (argumentExpression.isEmpty() || "*".equals(argumentExpression));
+        if (!countAll && Strings.isBlank(argumentExpression)) {
+            throw new IllegalArgumentException("PPL aggregation arguments cannot be empty unless using count().");
+        }
+
+        String normalizedArgument = countAll ? null : argumentExpression;
+        String resolvedFeatureName = Strings.isBlank(alias) ? defaultFeatureName(aggregationType, normalizedArgument, countAll) : alias;
+
+        return new MetricSpec(aggregationType, normalizedArgument, resolvedFeatureName, countAll);
+    }
+
+    private static boolean isSupportedAggregationType(String aggregationType) {
+        return "count".equals(aggregationType)
+            || "sum".equals(aggregationType)
+            || "avg".equals(aggregationType)
+            || "min".equals(aggregationType)
+            || "max".equals(aggregationType);
+    }
+
+    private static String defaultFeatureName(String aggregationType, String argumentExpression, boolean countAll) {
+        if (countAll) {
+            return "count_all";
+        }
+        String sanitized = sanitizeIdentifier(stripBackticks(argumentExpression));
+        return aggregationType + "_" + (sanitized.isEmpty() ? "value" : sanitized);
+    }
+
+    private static String sanitizeIdentifier(String value) {
+        return (value == null ? "" : value).replaceAll("[^A-Za-z0-9_]+", "_").replaceAll("^_+|_+$", "");
+    }
+
+    private static List<String> splitTopLevel(String value, char delimiter) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            char previous = i > 0 ? value.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth = Math.max(0, depth - 1);
+                }
+            }
+
+            if (ch == delimiter && depth == 0 && !inSingleQuote && !inDoubleQuote && !inBackticks) {
+                String part = current.toString().trim();
+                if (!part.isEmpty()) {
+                    parts.add(part);
+                }
+                current.setLength(0);
+                continue;
+            }
+
+            current.append(ch);
+        }
+
+        String part = current.toString().trim();
+        if (!part.isEmpty()) {
+            parts.add(part);
+        }
+        return parts;
+    }
+
+    private static int findTopLevelBySpanIndex(String statsBody) {
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = 0; i < statsBody.length(); i++) {
+            char ch = statsBody.charAt(i);
+            char previous = i > 0 ? statsBody.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth = Math.max(0, depth - 1);
+                }
+            }
+
+            if (depth == 0 && !inSingleQuote && !inDoubleQuote && !inBackticks && matchesKeywordWithLeadingWhitespace(statsBody, i, "by")) {
+                String tail = statsBody.substring(i).trim();
+                if (tail.length() >= 2 && startsWithKeyword(tail, "by")) {
+                    String afterBy = tail.substring(2).trim();
+                    if (startsWithKeyword(afterBy, "span")) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static int findTopLevelAsSeparator(String value) {
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = 0; i <= value.length() - 2; i++) {
+            char ch = value.charAt(i);
+            char previous = i > 0 ? value.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth = Math.max(0, depth - 1);
+                }
+            }
+
+            if (depth == 0 && !inSingleQuote && !inDoubleQuote && !inBackticks && matchesKeywordWithWhitespace(value, i, "as")) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findMatchingParen(String value, int openParenIndex) {
+        if (openParenIndex < 0 || openParenIndex >= value.length() || value.charAt(openParenIndex) != '(') {
+            return -1;
+        }
+
+        int depth = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+
+        for (int i = openParenIndex; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            char previous = i > 0 ? value.charAt(i - 1) : '\0';
+
+            if (ch == '\'' && !inDoubleQuote && !inBackticks && previous != '\\') {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks && previous != '\\') {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    depth++;
+                } else if (ch == ')') {
+                    depth--;
+                    if (depth == 0) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static boolean matchesKeywordWithWhitespace(String value, int startIndex, String keyword) {
+        int endIndex = startIndex + keyword.length();
+        if (endIndex > value.length()) {
+            return false;
+        }
+        if (!value.regionMatches(true, startIndex, keyword, 0, keyword.length())) {
+            return false;
+        }
+
+        boolean validLeft = startIndex == 0 || Character.isWhitespace(value.charAt(startIndex - 1));
+        boolean validRight = endIndex == value.length() || Character.isWhitespace(value.charAt(endIndex));
+        return validLeft && validRight;
+    }
+
+    private static boolean matchesKeywordWithLeadingWhitespace(String value, int startIndex, String keyword) {
+        if (!matchesKeywordWithWhitespace(value, startIndex, keyword)) {
+            return false;
+        }
+        return startIndex == 0 || Character.isWhitespace(value.charAt(startIndex - 1));
+    }
+
+    private static IntervalTimeConfiguration parseInterval(String interval) {
+        String trimmed = interval == null ? "" : interval.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Unsupported PPL span interval [" + interval + "].");
+        }
+
+        int numericEnd = 0;
+        while (numericEnd < trimmed.length() && Character.isDigit(trimmed.charAt(numericEnd))) {
+            numericEnd++;
+        }
+        if (numericEnd == 0) {
+            throw new IllegalArgumentException("Unsupported PPL span interval [" + interval + "].");
+        }
+
+        String numericText = trimmed.substring(0, numericEnd);
+        String unitText = trimmed.substring(numericEnd).trim().toLowerCase(Locale.ROOT);
+        if (unitText.length() != 1) {
+            throw new IllegalArgumentException("Unsupported PPL span interval [" + interval + "].");
+        }
+
+        int value = Integer.parseInt(numericText);
+        if (value <= 0) {
+            throw new IllegalArgumentException("PPL span interval must be positive.");
+        }
+
+        switch (unitText.charAt(0)) {
+            case 's':
+                return new IntervalTimeConfiguration(value, ChronoUnit.SECONDS);
+            case 'm':
+                return new IntervalTimeConfiguration(value, ChronoUnit.MINUTES);
+            default:
+                throw new IllegalArgumentException(
+                    "Unsupported PPL span interval unit [" + unitText + "]. Only seconds (s) and minutes (m) are supported."
+                );
+        }
+    }
+
+    private static boolean startsWithKeyword(String value, String keyword) {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.length() < keyword.length()) {
+            return false;
+        }
+        if (!trimmed.regionMatches(true, 0, keyword, 0, keyword.length())) {
+            return false;
+        }
+        return trimmed.length() == keyword.length()
+            || Character.isWhitespace(trimmed.charAt(keyword.length()))
+            || trimmed.charAt(keyword.length()) == '='
+            || trimmed.charAt(keyword.length()) == '(';
+    }
+
+    private static boolean isSourceStage(String stage) {
+        return startsWithKeyword(stage, "source");
+    }
+
+    private static boolean isWhereStage(String stage) {
+        return startsWithKeyword(stage, "where");
+    }
+
+    private static boolean isEvalStage(String stage) {
+        return startsWithKeyword(stage, "eval");
+    }
+
+    private static boolean isSupportedPreStatsStage(String stage) {
+        return isWhereStage(stage) || isEvalStage(stage);
+    }
+
+    private static boolean isStatsStage(String stage) {
+        return startsWithKeyword(stage, "stats");
+    }
+
+    private static boolean isSortStage(String stage) {
+        return startsWithKeyword(stage, "sort");
+    }
+
+    private static String stripBackticks(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.startsWith("`") && trimmed.endsWith("`") && trimmed.length() >= 2) {
+            return trimmed.substring(1, trimmed.length() - 1).trim();
+        }
+        return trimmed;
+    }
+
+    public String getQueryLanguage() {
+        return queryLanguage;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PPLSource that = (PPLSource) o;
+        return Objects.equal(queryLanguage, that.queryLanguage) && Objects.equal(query, that.query);
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(queryLanguage, query);
+    }
+
+    public static class CompiledPPLQuery {
+        private final String index;
+        private final List<String> preStatsStages;
+        private final String timeField;
+        private final List<MetricSpec> metrics;
+        private final IntervalTimeConfiguration interval;
+
+        CompiledPPLQuery(
+            String index,
+            List<String> preStatsStages,
+            String timeField,
+            List<MetricSpec> metrics,
+            IntervalTimeConfiguration interval
+        ) {
+            this.index = index;
+            this.preStatsStages = preStatsStages;
+            this.timeField = timeField;
+            this.metrics = metrics;
+            this.interval = interval;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+
+        public List<String> getPreStatsStages() {
+            return preStatsStages;
+        }
+
+        public String getTimeField() {
+            return timeField;
+        }
+
+        public List<MetricSpec> getMetrics() {
+            return metrics;
+        }
+
+        public int getMetricCount() {
+            return metrics.size();
+        }
+
+        public List<String> getFeatureNames() {
+            List<String> featureNames = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                featureNames.add(metric.getFeatureName());
+            }
+            return Collections.unmodifiableList(featureNames);
+        }
+
+        public IntervalTimeConfiguration getInterval() {
+            return interval;
+        }
+
+        public List<Feature> toPlaceholderFeatures() {
+            List<Feature> features = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                features.add(Feature.createDirectQueryPlaceholder(UUIDs.base64UUID(), metric.getFeatureName(), true));
+            }
+            return features;
+        }
+
+        public String buildMetricQueryForRange(long startTimeMs, long endTimeMs) {
+            List<String> metricsExpressions = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                metricsExpressions.add(metric.toStatsExpression());
+            }
+            return buildStatsQuery(
+                String.join(", ", metricsExpressions),
+                String
+                    .format(
+                        Locale.ROOT,
+                        "%s >= \"%s\" and %s < \"%s\"",
+                        maybeQuote(timeField),
+                        formatQueryTimestamp(startTimeMs),
+                        maybeQuote(timeField),
+                        formatQueryTimestamp(endTimeMs)
+                    )
+            );
+        }
+
+        public String buildLatestTimeQuery() {
+            return buildStatsQuery("max(" + maybeQuote(timeField) + ") as latest_time", null);
+        }
+
+        public String buildMinTimeQuery() {
+            return buildStatsQuery("min(" + maybeQuote(timeField) + ") as min_time", null);
+        }
+
+        public String buildDateRangeQuery() {
+            return buildStatsQuery("min(" + maybeQuote(timeField) + ") as min_time, max(" + maybeQuote(timeField) + ") as max_time", null);
+        }
+
+        private String buildStatsQuery(String statsExpression, String appendedWhereClause) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("source = ").append(maybeQuote(index));
+            for (String stage : preStatsStages) {
+                builder.append(" | ").append(stage);
+            }
+            if (!Strings.isBlank(appendedWhereClause)) {
+                builder.append(" | where ").append(appendedWhereClause);
+            }
+            builder.append(" | stats ").append(statsExpression);
+            return builder.toString();
+        }
+
+        private static String formatQueryTimestamp(long epochMillis) {
+            return QUERY_TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(epochMillis));
+        }
+
+        private static String maybeQuote(String identifier) {
+            if (identifier == null) {
+                return null;
+            }
+            String trimmed = identifier.trim();
+            return trimmed.matches("[A-Za-z0-9_.*:-]+") ? trimmed : "`" + trimmed.replace("`", "\\`") + "`";
+        }
+    }
+
+    public static class MetricSpec {
+        private final String aggregationType;
+        private final String aggregationField;
+        private final String featureName;
+        private final boolean countAll;
+
+        MetricSpec(String aggregationType, String aggregationField, String featureName, boolean countAll) {
+            this.aggregationType = aggregationType;
+            this.aggregationField = aggregationField;
+            this.featureName = featureName;
+            this.countAll = countAll;
+        }
+
+        public String getAggregationType() {
+            return aggregationType;
+        }
+
+        public String getAggregationField() {
+            return aggregationField;
+        }
+
+        public String getFeatureName() {
+            return featureName;
+        }
+
+        public boolean isCountAll() {
+            return countAll;
+        }
+
+        private String toStatsExpression() {
+            if (countAll) {
+                return "count() as " + CompiledPPLQuery.maybeQuote(featureName);
+            }
+            return aggregationType + "(" + aggregationField + ") as " + CompiledPPLQuery.maybeQuote(featureName);
+        }
+    }
+
+    private static class SourceStage {
+        private final String index;
+
+        SourceStage(String index) {
+            this.index = index;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+    }
+
+    private static class StatsStage {
+        private final List<MetricSpec> metrics;
+        private final String timeField;
+        private final IntervalTimeConfiguration interval;
+
+        StatsStage(List<MetricSpec> metrics, String timeField, IntervalTimeConfiguration interval) {
+            this.metrics = metrics;
+            this.timeField = timeField;
+            this.interval = interval;
+        }
+
+        public List<MetricSpec> getMetrics() {
+            return metrics;
+        }
+
+        public String getTimeField() {
+            return timeField;
+        }
+
+        public IntervalTimeConfiguration getInterval() {
+            return interval;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/timeseries/model/PPLSource.java
+++ b/src/main/java/org/opensearch/timeseries/model/PPLSource.java
@@ -687,6 +687,30 @@ public class PPLSource implements Writeable, ToXContentObject {
             );
         }
 
+        public String buildMetricQueryForRangeBySpan(long startTimeMs, long endTimeMs) {
+            List<String> metricsExpressions = new ArrayList<>(metrics.size());
+            for (MetricSpec metric : metrics) {
+                metricsExpressions.add(metric.toStatsExpression());
+            }
+            return buildStatsQuery(
+                String.join(", ", metricsExpressions)
+                    + " by span("
+                    + maybeQuote(timeField)
+                    + ", "
+                    + intervalToPPLLiteral(interval)
+                    + ") as bucket",
+                String
+                    .format(
+                        Locale.ROOT,
+                        "%s >= \"%s\" and %s < \"%s\"",
+                        maybeQuote(timeField),
+                        formatQueryTimestamp(startTimeMs),
+                        maybeQuote(timeField),
+                        formatQueryTimestamp(endTimeMs)
+                    )
+            ) + " | sort bucket asc";
+        }
+
         public String buildLatestTimeQuery() {
             return buildStatsQuery("max(" + maybeQuote(timeField) + ") as latest_time", null);
         }
@@ -714,6 +738,11 @@ public class PPLSource implements Writeable, ToXContentObject {
 
         private static String formatQueryTimestamp(long epochMillis) {
             return QUERY_TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(epochMillis));
+        }
+
+        private static String intervalToPPLLiteral(IntervalTimeConfiguration interval) {
+            String unit = interval.getUnit() == ChronoUnit.SECONDS ? "s" : "m";
+            return interval.getInterval() + unit;
         }
 
         private static String maybeQuote(String identifier) {

--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -1152,6 +1152,10 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             listener.onFailure(new OpenSearchStatusException(error, RestStatus.BAD_REQUEST));
             return;
         }
+        if (isPPLSourceConfig()) {
+            checkConfigNameExists(id, indexingDryRun, listener);
+            return;
+        }
         // checking runtime error from feature query
         ActionListener<MergeableList<Optional<double[]>>> validateFeatureQueriesListener = ActionListener.wrap(response -> {
             checkConfigNameExists(id, indexingDryRun, listener);
@@ -1204,6 +1208,10 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             });
             clientUtil.asyncRequestWithInjectedSecurity(searchRequest, client::search, user, client, context, searchResponseListener);
         }
+    }
+
+    protected boolean isPPLSourceConfig() {
+        return config != null && Config.SOURCE_TYPE_PPL.equals(config.getSourceType());
     }
 
     /**

--- a/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
+++ b/src/main/java/org/opensearch/timeseries/rest/handler/AbstractTimeSeriesActionHandler.java
@@ -1153,7 +1153,14 @@ public abstract class AbstractTimeSeriesActionHandler<T extends ActionResponse, 
             return;
         }
         if (isPPLSourceConfig()) {
-            checkConfigNameExists(id, indexingDryRun, listener);
+            ActionListener<Optional<Long>> validatePPLQueryListener = ActionListener.wrap(response -> {
+                checkConfigNameExists(id, indexingDryRun, listener);
+            },
+                exception -> {
+                    listener.onFailure(createValidationException(exception.getMessage(), ValidationIssueType.GENERAL_SETTINGS));
+                }
+            );
+            searchFeatureDao.getLatestDataTime(user, config, Optional.empty(), context, validatePPLQueryListener);
             return;
         }
         // checking runtime error from feature query

--- a/src/main/resources/mappings/config.json
+++ b/src/main/resources/mappings/config.json
@@ -1,11 +1,27 @@
 {
     "dynamic": false,
     "_meta": {
-        "schema_version": 9
+        "schema_version": 10
     },
     "properties": {
         "schema_version": {
             "type": "integer"
+        },
+        "source_type": {
+            "type": "keyword"
+        },
+        "ppl_source": {
+            "type": "object",
+            "dynamic": "strict",
+            "properties": {
+                "query_language": {
+                    "type": "keyword"
+                },
+                "query": {
+                    "type": "text",
+                    "index": false
+                }
+            }
         },
         "name": {
             "type": "text",

--- a/src/main/resources/resource-access-levels.yml
+++ b/src/main/resources/resource-access-levels.yml
@@ -9,6 +9,7 @@ resource_types:
         - 'cluster:admin/opendistro/ad/detector/preview'
         - 'cluster:admin/opendistro/ad/detectors/get'
         - 'cluster:admin/opendistro/ad/result/topAnomalies'
+        - 'cluster:admin/opensearch/ppl'
 
     ad_read_write:
       allowed_actions:
@@ -16,6 +17,7 @@ resource_types:
         - 'cluster:monitor/*'
         - "cluster:admin/ingest/pipeline/delete"
         - "cluster:admin/ingest/pipeline/put"
+        - 'cluster:admin/opensearch/ppl'
 
     ad_full_access:
       allowed_actions:
@@ -24,6 +26,7 @@ resource_types:
         - "cluster:admin/opendistro/ad/*"
         - 'cluster:monitor/*'
         - "cluster:admin/security/resource/share"
+        - 'cluster:admin/opensearch/ppl'
 
   forecaster:
     forecast_read_only:
@@ -32,6 +35,7 @@ resource_types:
         - 'cluster:admin/plugin/forecast/forecaster/stats'
         - 'cluster:admin/plugin/forecast/forecaster/suggest'
         - 'cluster:admin/plugin/forecast/forecaster/validate'
+        - 'cluster:admin/plugin/forecast/forecaster/preview'
         - 'cluster:admin/plugin/forecast/forecasters/get'
         - 'cluster:admin/plugin/forecast/forecasters/info'
         - 'cluster:admin/plugin/forecast/result/topForecasts'

--- a/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
+++ b/src/test/java/org/opensearch/action/admin/indices/mapping/get/IndexAnomalyDetectorActionHandlerTests.java
@@ -879,6 +879,8 @@ public class IndexAnomalyDetectorActionHandlerTests extends AbstractTimeSeriesTe
                         false,
                         Instant.now(),
                         detector.getFrequency(),
+                        null,
+                        null,
                         null
                     );
                     try {

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -213,6 +213,18 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             );
     }
 
+    protected Response previewAnomalyDetector(RestClient client, String requestBody) throws IOException {
+        return TestHelpers
+            .makeRequest(
+                client,
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/_preview",
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(requestBody),
+                null
+            );
+    }
+
     public AnomalyDetector getConfig(String detectorId, RestClient client) throws IOException {
         return (AnomalyDetector) getConfig(detectorId, false, client)[0];
     }

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -103,13 +103,16 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             TestHelpers.createIndexWithTimeField(client(), detector.getIndices().get(0), detector.getTimeField());
             TestHelpers
                 .makeRequest(
-                    client,
+                    client(),
                     "POST",
                     "/" + detector.getIndices().get(0) + "/_doc/" + randomAlphaOfLength(5) + "?refresh=true",
                     ImmutableMap.of(),
                     // avoid validation error as validation API will check at least 1 document and the timestamp field
                     // exists in index mapping
-                    TestHelpers.toHttpEntity("{\"name\": \"test\", \"" + detector.getTimeField() + "\" : \"1661386754000\"}"),
+                    TestHelpers
+                        .toHttpEntity(
+                            "{\"name\": \"test\", \"" + detector.getTimeField() + "\" : \"" + Instant.now().toEpochMilli() + "\"}"
+                        ),
                     null,
                     false
                 );
@@ -434,6 +437,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                     .toHttpEntity(
                         "{\n"
                             + "\"cluster_permissions\": [\n"
+                            + "\"indices:data/write/bulk*\"\n"
                             + "],\n"
                             + "\"index_permissions\": [\n"
                             + "{\n"
@@ -442,13 +446,25 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                             + index
                             + "\"\n"
                             + "],\n"
-                            + "\"dls\": \"\",\n"
                             + "\"fls\": [],\n"
                             + "\"masked_fields\": [],\n"
                             + "\"allowed_actions\": [\n"
-                            + "\"crud\",\n"
+                            + "\"indices:data/read/field_caps*\",\n"
+                            + "\"indices:data/read/get\",\n"
+                            + "\"indices:data/read/search\",\n"
+                            + "\"indices:data/write/bulk*\",\n"
+                            + "\"indices:data/write/delete\",\n"
+                            + "\"indices:data/write/index\",\n"
+                            + "\"indices:data/write/update\",\n"
                             + "\"indices:admin/create\",\n"
-                            + "\"indices:admin/aliases\"\n"
+                            + "\"indices:admin/aliases\",\n"
+                            + "\"indices:admin/aliases/get\",\n"
+                            + "\"indices:admin/mapping/get\",\n"
+                            + "\"indices:admin/mapping/put\",\n"
+                            + "\"indices:admin/mappings/fields/get*\",\n"
+                            + "\"indices:admin/mappings/get\",\n"
+                            + "\"indices:admin/resolve/index\",\n"
+                            + "\"indices_monitor\"\n"
                             + "]\n"
                             + "}\n"
                             + "],\n"
@@ -478,7 +494,6 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                             + index
                             + "\"\n"
                             + "],\n"
-                            + "\"dls\": \"\",\n"
                             + "\"fls\": [],\n"
                             + "\"masked_fields\": [],\n"
                             + "\"allowed_actions\": [\n"
@@ -526,7 +541,6 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                             + "*"
                             + "\"\n"
                             + "],\n"
-                            + "\"dls\": \"\",\n"
                             + "\"fls\": [],\n"
                             + "\"masked_fields\": [],\n"
                             + "\"allowed_actions\": [\n"

--- a/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/org/opensearch/ad/AnomalyDetectorRestTestCase.java
@@ -335,7 +335,9 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getFlattenResultIndexMapping(),
                 detector.getLastBreakingUIChangeTime(),
                 detector.getFrequency(),
-                detector.getAutoCreated()
+                detector.getAutoCreated(),
+                null,
+                null
             ),
             detectorJob,
             historicalAdTask,
@@ -619,7 +621,9 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             anomalyDetector.getFlattenResultIndexMapping(),
             Instant.now(),
             anomalyDetector.getFrequency(),
-            anomalyDetector.getAutoCreated()
+            anomalyDetector.getAutoCreated(),
+            null,
+            null
         );
         return detector;
     }

--- a/src/test/java/org/opensearch/ad/correlation/AnomalyCorrelationScenariosTests.java
+++ b/src/test/java/org/opensearch/ad/correlation/AnomalyCorrelationScenariosTests.java
@@ -312,6 +312,8 @@ public class AnomalyCorrelationScenariosTests extends OpenSearchTestCase {
             null,
             null,
             null,
+            null,
+            null,
             null
         );
     }

--- a/src/test/java/org/opensearch/ad/ml/AbstractCosineDataTest.java
+++ b/src/test/java/org/opensearch/ad/ml/AbstractCosineDataTest.java
@@ -172,7 +172,8 @@ public class AbstractCosineDataTest extends AbstractTimeSeriesTest {
                 clock,
                 1,
                 1,
-                60_000L
+                60_000L,
+                null
             )
         );
 

--- a/src/test/java/org/opensearch/ad/ml/HCADModelPerfTests.java
+++ b/src/test/java/org/opensearch/ad/ml/HCADModelPerfTests.java
@@ -125,7 +125,8 @@ public class HCADModelPerfTests extends AbstractCosineDataTest {
                     clock,
                     1,
                     1,
-                    60_000L
+                    60_000L,
+                    null
                 )
             );
 

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorSerializationTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorSerializationTests.java
@@ -24,6 +24,8 @@ import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
+import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.IntervalTimeConfiguration;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,6 +76,37 @@ public class AnomalyDetectorSerializationTests extends OpenSearchSingleNodeTestC
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyDetector parsedDetector = new AnomalyDetector(input);
         assertTrue(String.format(Locale.ROOT, "expected %s, but got %s", detector, parsedDetector), detector.equals(parsedDetector));
+    }
+
+    public void testPPLSourceSerializationRoundTrip() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        BytesStreamOutput output = new BytesStreamOutput();
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+
+        assertEquals(detector, parsedDetector);
+        assertEquals(Config.SOURCE_TYPE_PPL, parsedDetector.getSourceType());
+        assertNotNull(parsedDetector.getPPLSource());
+        assertEquals("PPL", parsedDetector.getPPLSource().getQueryLanguage());
+        assertEquals(
+            "source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket",
+            parsedDetector.getPPLSource().getQuery()
+        );
+        assertEquals("timestamp", parsedDetector.getTimeField());
+        assertEquals(10L, ((IntervalTimeConfiguration) parsedDetector.getInterval()).getInterval());
     }
 
 }

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -1463,6 +1463,222 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
         assertNotNull(detector);
     }
 
+    public void testParsePPLAnomalyDetector() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals("PPL", detector.getPPLSource().getQueryLanguage());
+        assertEquals(1, detector.getFeatureAttributes().size());
+        assertEquals("sum_http_4xx", detector.getFeatureAttributes().get(0).getName());
+        assertTrue(detector.getFeatureAttributes().get(0).usesDirectQueryPlaceholderAggregation());
+        assertEquals(10L, ((IntervalTimeConfiguration) detector.getInterval()).getInterval());
+        assertEquals(ChronoUnit.MINUTES, ((IntervalTimeConfiguration) detector.getInterval()).getUnit());
+
+        String serialized = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        assertTrue(serialized.contains("\"source_type\":\"PPL\""));
+        assertTrue(serialized.contains("\"ppl_source\""));
+        assertTrue(serialized.contains("\"time_field\":\"timestamp\""));
+        assertTrue(serialized.contains("\"indices\":[\"sample-http-responses\"]"));
+    }
+
+    public void testParsePPLAnomalyDetectorSupportsWhereAndMultipleMetrics() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals(2, detector.getFeatureAttributes().size());
+        assertEquals("sum_http_4xx", detector.getFeatureAttributes().get(0).getName());
+        assertEquals("max_http_5xx", detector.getFeatureAttributes().get(1).getName());
+        assertTrue(detector.getFeatureAttributes().get(0).usesDirectQueryPlaceholderAggregation());
+        assertTrue(detector.getFeatureAttributes().get(1).usesDirectQueryPlaceholderAggregation());
+        assertNotEquals(
+            detector.getFeatureAttributes().get(0).getAggregation().getName(),
+            detector.getFeatureAttributes().get(1).getAggregation().getName()
+        );
+    }
+
+    public void testParsePPLAnomalyDetectorSupportsCountAndMatchingIntervals() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | stats count() as error_count by span(timestamp, 60m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals(1, detector.getFeatureAttributes().size());
+        assertEquals("error_count", detector.getFeatureAttributes().get(0).getName());
+        assertTrue(detector.getFeatureAttributes().get(0).usesDirectQueryPlaceholderAggregation());
+        assertEquals(60L, ((IntervalTimeConfiguration) detector.getInterval()).getInterval());
+        assertEquals(ChronoUnit.MINUTES, ((IntervalTimeConfiguration) detector.getInterval()).getUnit());
+    }
+
+    public void testParsePPLAnomalyDetectorDerivesIntervalWhenDefaultsAreProvided() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | eval total_metric = http_4xx + http_5xx | stats count(*) as error_count, avg(total_metric) as avg_total_metric by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector
+            .parse(TestHelpers.parser(detectorString), "detector-id", 1L, TimeValue.timeValueMinutes(1), TimeValue.timeValueMinutes(1));
+
+        assertEquals(Config.SOURCE_TYPE_PPL, detector.getSourceType());
+        assertEquals(ImmutableList.of("sample-http-responses"), detector.getIndices());
+        assertEquals("timestamp", detector.getTimeField());
+        assertNotNull(detector.getPPLSource());
+        assertEquals(2, detector.getFeatureAttributes().size());
+        assertEquals("error_count", detector.getFeatureAttributes().get(0).getName());
+        assertEquals("avg_total_metric", detector.getFeatureAttributes().get(1).getName());
+        assertEquals(10L, ((IntervalTimeConfiguration) detector.getInterval()).getInterval());
+        assertEquals(ChronoUnit.MINUTES, ((IntervalTimeConfiguration) detector.getInterval()).getUnit());
+    }
+
+    public void testParseStoredPPLAnomalyDetectorPreservesFeatureAttributes() throws IOException {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"description\":\"ppl detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | where status_code >= 400 | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"feature_attributes\":["
+            + "{"
+            + "\"feature_id\":\"feature-1\","
+            + "\"feature_name\":\"sum_http_4xx\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"__direct_query_feature_value__\":{\"avg\":{\"field\":\"__direct_query_value__\"}}}"
+            + "},"
+            + "{"
+            + "\"feature_id\":\"feature-2\","
+            + "\"feature_name\":\"max_http_5xx\","
+            + "\"feature_enabled\":true,"
+            + "\"aggregation_query\":{\"__direct_query_feature_value__\":{\"avg\":{\"field\":\"__direct_query_value__\"}}}"
+            + "}"
+            + "],"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        AnomalyDetector detector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(2, detector.getFeatureAttributes().size());
+        assertEquals("feature-1", detector.getFeatureAttributes().get(0).getId());
+        assertEquals("feature-2", detector.getFeatureAttributes().get(1).getId());
+        assertEquals("sum_http_4xx", detector.getFeatureAttributes().get(0).getName());
+        assertEquals("max_http_5xx", detector.getFeatureAttributes().get(1).getName());
+    }
+
+    public void testParsePPLAnomalyDetectorRejectsCategoryFields() {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"category_field\":[\"host\"],"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("category_field must be empty when source_type is PPL.", exception.getMessage());
+        assertEquals(ValidationIssueType.CATEGORY, exception.getType());
+    }
+
+    public void testParsePPLAnomalyDetectorRejectsDetectionIntervalMismatch() {
+        String detectorString = "{"
+            + "\"name\":\"ppl-detector\","
+            + "\"source_type\":\"PPL\","
+            + "\"ppl_source\":{"
+            + "\"query_language\":\"PPL\","
+            + "\"query\":\"source = sample-http-responses | stats sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket\""
+            + "},"
+            + "\"detection_interval\":{\"period\":{\"interval\":5,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals(
+            "detection_interval must match ppl_source span interval (10 minutes) when source_type is PPL.",
+            exception.getMessage()
+        );
+        assertEquals(ValidationIssueType.DETECTION_INTERVAL, exception.getType());
+    }
+
+    public void testParseOpenSearchAnomalyDetectorRequiresAggregationQuery() {
+        String detectorString = "{"
+            + "\"name\":\"os-detector\","
+            + "\"time_field\":\"timestamp\","
+            + "\"indices\":[\"source-index\"],"
+            + "\"feature_attributes\":[{"
+            + "\"feature_id\":\"f1\","
+            + "\"feature_name\":\"os_value\","
+            + "\"feature_enabled\":true"
+            + "}],"
+            + "\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+            + "\"last_update_time\":1700000000000"
+            + "}";
+
+        ValidationException exception = expectThrows(
+            ValidationException.class,
+            () -> AnomalyDetector.parse(TestHelpers.parser(detectorString))
+        );
+        assertEquals("feature_attributes.aggregation_query must be set when source_type is OPENSEARCH.", exception.getMessage());
+        assertEquals(ValidationIssueType.FEATURE_ATTRIBUTES, exception.getType());
+    }
+
     /**
      * Helper method to create a valid rule for testing.
      *

--- a/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/org/opensearch/ad/model/AnomalyDetectorTests.java
@@ -366,6 +366,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -406,6 +408,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -446,6 +450,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -486,6 +492,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -526,6 +534,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -566,6 +576,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -606,6 +618,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                     null,
                     Instant.now(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    null,
+                    null,
                     null
                 )
             );
@@ -645,6 +659,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 Instant.now(),
                 TestHelpers.randomIntervalTimeConfiguration(),
+                null,
+                null,
                 null
             )
         );
@@ -685,6 +701,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 Instant.now(),
                 new IntervalTimeConfiguration(0, ChronoUnit.MINUTES),
+                null,
+                null,
                 null
             )
         );
@@ -725,6 +743,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 Instant.now(),
                 new IntervalTimeConfiguration(3, ChronoUnit.MINUTES),
+                null,
+                null,
                 null
             )
         );
@@ -768,6 +788,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 Instant.now(),
                 TestHelpers.randomIntervalTimeConfiguration(),
+                null,
+                null,
                 null
             )
         );
@@ -822,6 +844,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
@@ -861,6 +885,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         // seasonalityIntervals is not null and custom shingle size is null, use seasonalityIntervals to deterine shingle size
@@ -895,6 +921,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         // seasonalityIntervals is null and custom shingle size is null, use default shingle size
@@ -932,6 +960,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         assertNotNull(anomalyDetector.getFeatureAttributes());
@@ -969,6 +999,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         String errorMessage = anomalyDetector.validateCustomResultIndex("abc");
@@ -1174,6 +1206,8 @@ public class AnomalyDetectorTests extends AbstractTimeSeriesTest {
                 null,
                 Instant.now(),
                 TestHelpers.randomIntervalTimeConfiguration(),
+                null,
+                null,
                 null
             )
         );

--- a/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
+++ b/src/test/java/org/opensearch/ad/rest/ADRestTestUtils.java
@@ -230,6 +230,8 @@ public class ADRestTestUtils {
             null,
             now,
             new IntervalTimeConfiguration(detectionIntervalInMinutes, ChronoUnit.MINUTES),
+            null,
+            null,
             null
         );
 

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -146,6 +146,77 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         return detector;
     }
 
+    private String createPPLRuntimeIndex(String indexName) throws IOException {
+        return createPPLRuntimeIndex(indexName, 40);
+    }
+
+    private String createPPLRuntimeIndex(String indexName, int documentCount) throws IOException {
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/" + indexName,
+                ImmutableMap.of(),
+                TestHelpers
+                    .toHttpEntity(
+                        "{\"mappings\":{\"properties\":{\"timestamp\":{\"type\":\"date\"},\"status_code\":{\"type\":\"integer\"},\"metric_a\":{\"type\":\"double\"},\"metric_b\":{\"type\":\"double\"},\"service\":{\"type\":\"keyword\"}}}}"
+                    ),
+                null
+            );
+
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        for (int i = 0; i < documentCount; i++) {
+            Instant timestamp = now.minus(i, ChronoUnit.MINUTES);
+            int statusCode = i % 12 == 0 ? 500 : (i % 5 == 0 ? 404 : 200);
+            int metricA = (i % 9) + 1;
+            int metricB = (i % 7) + 10;
+            TestHelpers
+                .ingestDataToIndex(
+                    client(),
+                    indexName,
+                    TestHelpers
+                        .toHttpEntity(
+                            String
+                                .format(
+                                    Locale.ROOT,
+                                    "{\"timestamp\":%d,\"status_code\":%d,\"metric_a\":%d,\"metric_b\":%d,\"service\":\"checkout\"}",
+                                    timestamp.toEpochMilli(),
+                                    statusCode,
+                                    metricA,
+                                    metricB
+                                )
+                        )
+                );
+        }
+
+        return indexName;
+    }
+
+    private String buildPPLPreviewBody(String indexName, Instant periodStart, Instant periodEnd) {
+        return String
+            .format(
+                Locale.ROOT,
+                "{\"period_start\":%d,\"period_end\":%d,\"detector\":{\"name\":\"preview-ppl\",\"source_type\":\"PPL\",\"ppl_source\":{\"query_language\":\"PPL\",\"query\":\"source = %s | where service = 'checkout' | eval total_metric = metric_a + metric_b | stats count(*) as doc_count, avg(total_metric) as avg_total_metric by span(timestamp, 1m) as bucket\"},\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}}}",
+                periodStart.toEpochMilli(),
+                periodEnd.toEpochMilli(),
+                indexName
+            );
+    }
+
+    private String buildPPLDetectorBody(String detectorName, String indexName, boolean includeDetectionInterval, String query) {
+        String detectionInterval = includeDetectionInterval
+            ? ",\"detection_interval\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}"
+            : "";
+        return String
+            .format(
+                Locale.ROOT,
+                "{\"name\":\"%s\",\"description\":\"ppl runtime detector\",\"source_type\":\"PPL\",\"ppl_source\":{\"query_language\":\"PPL\",\"query\":\"%s\"}%s,\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}}",
+                detectorName,
+                query.replace("\"", "\\\""),
+                detectionInterval
+            );
+    }
+
     public void testCreateAnomalyDetectorWithDuplicateName() throws Exception {
         AnomalyDetector detector = createIndexAndGetAnomalyDetector(INDEX_NAME);
         Feature feature = TestHelpers.randomFeature();
@@ -1149,6 +1220,126 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                         null
                     )
             );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testPreviewPPLAnomalyDetectorWithoutExplicitDetectionInterval() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-preview-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT), 430);
+        Instant periodEnd = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Instant periodStart = periodEnd.minus(410, ChronoUnit.MINUTES);
+
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/_preview",
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(buildPPLPreviewBody(indexName, periodStart, periodEnd)),
+                null,
+                false
+            );
+
+        assertEquals("Preview PPL detector failed", RestStatus.OK, TestHelpers.restStatus(response));
+        Map<String, Object> responseMap = entityAsMap(response);
+        List<Map<String, Object>> anomalyResults = (List<Map<String, Object>>) responseMap.get("anomaly_result");
+        assertNotNull(anomalyResults);
+        assertFalse(anomalyResults.isEmpty());
+
+        List<Map<String, Object>> featureData = (List<Map<String, Object>>) anomalyResults.get(0).get("feature_data");
+        assertNotNull(featureData);
+        assertEquals(2, featureData.size());
+        assertEquals("doc_count", featureData.get(0).get("feature_name"));
+        assertEquals("avg_total_metric", featureData.get(1).get("feature_name"));
+
+        Map<String, Object> detector = (Map<String, Object>) responseMap.get("anomaly_detector");
+        Map<String, Object> detectionInterval = (Map<String, Object>) detector.get("detection_interval");
+        Map<String, Object> period = (Map<String, Object>) detectionInterval.get("period");
+        assertEquals("PPL", detector.get("source_type"));
+        assertEquals(1, period.get("interval"));
+        assertEquals("Minutes", period.get("unit"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCreateStartAndProfilePPLAnomalyDetectorWithoutExplicitDetectionInterval() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-detector-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+        String detectorName = "ppl-runtime-" + randomAlphaOfLength(6);
+        String query = "source = "
+            + indexName
+            + " | where service = 'checkout' | eval total_metric = metric_a + metric_b | stats count() as doc_count, avg(total_metric) as avg_total_metric by span(timestamp, 1m) as bucket";
+
+        Response createResponse = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI,
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(buildPPLDetectorBody(detectorName, indexName, false, query)),
+                null
+            );
+
+        assertEquals("Create PPL detector failed", RestStatus.CREATED, TestHelpers.restStatus(createResponse));
+        Map<String, Object> createResponseMap = entityAsMap(createResponse);
+        String detectorId = (String) createResponseMap.get("_id");
+        Map<String, Object> detector = (Map<String, Object>) createResponseMap.get("anomaly_detector");
+        Map<String, Object> detectionInterval = (Map<String, Object>) detector.get("detection_interval");
+        Map<String, Object> period = (Map<String, Object>) detectionInterval.get("period");
+        List<Map<String, Object>> featureAttributes = (List<Map<String, Object>>) detector.get("feature_attributes");
+
+        assertNotNull(detectorId);
+        assertEquals("PPL", detector.get("source_type"));
+        assertEquals(2, featureAttributes.size());
+        assertEquals("doc_count", featureAttributes.get(0).get("feature_name"));
+        assertEquals("avg_total_metric", featureAttributes.get(1).get("feature_name"));
+        assertEquals(1, period.get("interval"));
+        assertEquals("Minutes", period.get("unit"));
+
+        String startDetectorPath = TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId + "/_start";
+        if (isResourceSharingFeatureEnabled()) {
+            TestHelpers
+                .assertFailWith(
+                    ResponseException.class,
+                    "no permissions for [cluster:admin/opendistro/ad/detector/jobmanagement]",
+                    () -> TestHelpers.makeRequest(client(), "POST", startDetectorPath, ImmutableMap.of(), "", null)
+                );
+            return;
+        }
+
+        Response startResponse = TestHelpers.makeRequest(client(), "POST", startDetectorPath, ImmutableMap.of(), "", null);
+        assertEquals("Start PPL detector failed", RestStatus.OK, TestHelpers.restStatus(startResponse));
+
+        Awaitility
+            .await("ppl detector profile to reach running")
+            .pollDelay(Duration.ZERO)
+            .pollInterval(Duration.ofSeconds(2))
+            .atMost(Duration.ofSeconds(30))
+            .untilAsserted(() -> {
+                Response profileResponse = getDetectorProfile(detectorId, true);
+                assertEquals(RestStatus.OK, TestHelpers.restStatus(profileResponse));
+                Map<String, Object> profileMap = entityAsMap(profileResponse);
+                assertEquals("RUNNING", profileMap.get("state"));
+                Map<String, Object> initProgress = (Map<String, Object>) profileMap.get("init_progress");
+                assertEquals("100%", initProgress.get("percentage"));
+            });
+    }
+
+    public void testCreatePPLAnomalyDetectorRejectsUnsupportedPostStatsStage() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-invalid-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+        String query = "source = " + indexName + " | stats count() as doc_count by span(timestamp, 1m) | head 5";
+
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> TestHelpers
+                .makeRequest(
+                    client(),
+                    "POST",
+                    TestHelpers.AD_BASE_DETECTORS_URI,
+                    ImmutableMap.of(),
+                    TestHelpers.toHttpEntity(buildPPLDetectorBody("invalid-ppl-detector", indexName, false, query)),
+                    null
+                )
+        );
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
+        assertThat(exception.getMessage(), containsString("Only trailing sort stages are supported"));
     }
 
     public void testSearchAnomalyResult() throws Exception {

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -251,6 +251,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             null,
             interval,
+            null,
+            null,
             null
         );
 
@@ -528,6 +530,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             false,
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
         Response updateResponse = TestHelpers
@@ -597,6 +601,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             true,
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
 
@@ -738,6 +744,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
         if (isResourceSharingFeatureEnabled()) {
@@ -811,6 +819,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
 
@@ -899,6 +909,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             detector1.getLastBreakingUIChangeTime(),
             detector1.getFrequency(),
+            null,
+            null,
             null
         );
 
@@ -951,6 +963,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             Instant.now(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
 
@@ -1009,6 +1023,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
 
@@ -1517,6 +1533,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             null,
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
+            null,
+            null,
             null
         );
 

--- a/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/HistoricalAnalysisRestApiIT.java
@@ -353,7 +353,9 @@ public class HistoricalAnalysisRestApiIT extends HistoricalAnalysisRestTestCase 
             detector.getFlattenResultIndexMapping(),
             detector.getLastBreakingUIChangeTime(),
             detector.getFrequency(),
-            detector.getAutoCreated()
+            detector.getAutoCreated(),
+            null,
+            null
         );
     }
 

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -77,6 +77,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
     private static final String READ_ONLY_AG = "ad_read_only";
     private static final String READ_WRITE_AG = "ad_read_write";
     private static final String FULL_ACCESS_AG = "ad_full_access";
+    private static final String PPL_ACCESS_ROLE = "ppl_access";
 
     String oceanUser = "ocean";
     RestClient oceanClient;
@@ -91,6 +92,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         createIndexRole(indexAllAccessRole, "*");
         String indexSearchAccessRole = "index_all_search";
         createSearchRole(indexSearchAccessRole, "*");
+        createPPLAccessRole(PPL_ACCESS_ROLE);
         String alicePassword = generatePassword(aliceUser);
         createUser(aliceUser, alicePassword, new ArrayList<>(Arrays.asList("odfe")));
         aliceClient = new SecureRestClientBuilder(getClusterHosts().toArray(new HttpHost[0]), isHttps(), aliceUser, alicePassword)
@@ -149,6 +151,7 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         createRoleMapping("anomaly_full_access", new ArrayList<>(Arrays.asList(aliceUser, catUser, dogUser, elkUser, fishUser, goatUser)));
         createRoleMapping(indexAllAccessRole, new ArrayList<>(Arrays.asList(aliceUser, bobUser, catUser, dogUser, fishUser, lionUser)));
         createRoleMapping(indexSearchAccessRole, new ArrayList<>(Arrays.asList(goatUser)));
+        createRoleMapping(PPL_ACCESS_ROLE, new ArrayList<>(Arrays.asList(aliceUser, catUser, goatUser)));
     }
 
     @After
@@ -186,6 +189,81 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Map<String, Object> responseMap = entityAsMap(resp);
         ArrayList<String> roles = (ArrayList<String>) responseMap.get("roles");
         assertTrue(roles.contains("all_access"));
+    }
+
+    private String createInlinePPLPreviewIndex() throws IOException {
+        String indexName = "secure-ppl-preview-" + System.nanoTime();
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/" + indexName,
+                ImmutableMap.of(),
+                TestHelpers
+                    .toHttpEntity(
+                        "{\"mappings\":{\"properties\":{\"timestamp\":{\"type\":\"date\"},\"status_code\":{\"type\":\"integer\"},\"metric_a\":{\"type\":\"double\"},\"metric_b\":{\"type\":\"double\"},\"service\":{\"type\":\"keyword\"}}}}"
+                    ),
+                null
+            );
+
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        for (int i = 0; i < 430; i++) {
+            Instant timestamp = now.minus(i, ChronoUnit.MINUTES);
+            int statusCode = i % 4 == 0 ? 500 : 200;
+            int metricA = (i % 5) + 1;
+            int metricB = (i % 7) + 10;
+            TestHelpers
+                .ingestDataToIndex(
+                    client(),
+                    indexName,
+                    TestHelpers
+                        .toHttpEntity(
+                            String
+                                .format(
+                                    Locale.ROOT,
+                                    "{\"timestamp\":%d,\"status_code\":%d,\"metric_a\":%d,\"metric_b\":%d,\"service\":\"checkout\"}",
+                                    timestamp.toEpochMilli(),
+                                    statusCode,
+                                    metricA,
+                                    metricB
+                                )
+                        )
+                );
+        }
+
+        return indexName;
+    }
+
+    private void createPPLAccessRole(String role) throws IOException {
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                "/_opendistro/_security/api/roles/" + role,
+                null,
+                TestHelpers
+                    .toHttpEntity(
+                        "{\n"
+                            + "\"cluster_permissions\": [\n"
+                            + "\"cluster:admin/opensearch/ppl\"\n"
+                            + "],\n"
+                            + "\"index_permissions\": [],\n"
+                            + "\"tenant_permissions\": []\n"
+                            + "}"
+                    ),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
+    }
+
+    private String buildInlinePPLPreviewBody(String indexName, Instant periodStart, Instant periodEnd) {
+        return String
+            .format(
+                Locale.ROOT,
+                "{\"period_start\":%d,\"period_end\":%d,\"detector\":{\"name\":\"secure-preview-ppl\",\"source_type\":\"PPL\",\"ppl_source\":{\"query_language\":\"PPL\",\"query\":\"source = %s | where service = 'checkout' | eval total_metric = metric_a + metric_b | stats count(*) as doc_count, avg(total_metric) as avg_total_metric by span(timestamp, 1m) as bucket\"},\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}}}}",
+                periodStart.toEpochMilli(),
+                periodEnd.toEpochMilli(),
+                indexName
+            );
     }
 
     public void testCreateAnomalyDetector() throws IOException {
@@ -949,6 +1027,39 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
 
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testPreviewInlinePPLAnomalyDetector() throws IOException {
+        String indexName = createInlinePPLPreviewIndex();
+        Instant periodEnd = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Instant periodStart = periodEnd.minus(410, ChronoUnit.MINUTES);
+        String requestBody = buildInlinePPLPreviewBody(indexName, periodStart, periodEnd);
+
+        Response response = previewAnomalyDetector(aliceClient, requestBody);
+        Assert.assertEquals(RestStatus.OK, TestHelpers.restStatus(response));
+        Map<String, Object> responseMap = entityAsMap(response);
+        List<Map<String, Object>> anomalyResults = (List<Map<String, Object>>) responseMap.get("anomaly_result");
+        Assert.assertNotNull(anomalyResults);
+        Assert.assertFalse(anomalyResults.isEmpty());
+
+        List<Map<String, Object>> featureData = (List<Map<String, Object>>) anomalyResults.get(0).get("feature_data");
+        Assert.assertEquals(2, featureData.size());
+        Assert.assertEquals("doc_count", featureData.get(0).get("feature_name"));
+        Assert.assertEquals("avg_total_metric", featureData.get(1).get("feature_name"));
+
+        Response catResponse = previewAnomalyDetector(catClient, requestBody);
+        Assert.assertEquals(RestStatus.OK, TestHelpers.restStatus(catResponse));
+
+        Response goatResponse = previewAnomalyDetector(goatClient, requestBody);
+        Assert.assertEquals(RestStatus.OK, TestHelpers.restStatus(goatResponse));
+
+        String noPermsMessage = "no permissions for [cluster:admin/opendistro/ad/detector/preview]";
+        Exception exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(bobClient, requestBody); });
+        Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
+
+        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(lionClient, requestBody); });
+        Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
     }
 
     public void testValidateAnomalyDetector() throws IOException {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -1072,20 +1072,54 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Exception exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(bobClient, requestBody); });
         Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
 
-        String adPreviewWithoutPPLRole = "ad_preview_without_ppl";
+        String noPPLUser = "no_ppl_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
+        String noPPLPassword = generatePassword(noPPLUser);
+        createUser(noPPLUser, noPPLPassword, new ArrayList<>());
+        RestClient noPPLClient = new SecureRestClientBuilder(
+            getClusterHosts().toArray(new HttpHost[0]),
+            isHttps(),
+            noPPLUser,
+            noPPLPassword
+        ).setSocketTimeout(60000).build();
+        String adPreviewWithoutPPLRole = "ad_preview_without_ppl_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
+        String noPPLSourceReadRole = "ad_preview_without_ppl_source_read_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
         createClusterRole(adPreviewWithoutPPLRole, Arrays.asList("cluster:admin/opendistro/ad/detector/preview"));
-        createRoleMapping(adPreviewWithoutPPLRole, new ArrayList<>(Arrays.asList(lionUser)));
-        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(lionClient, requestBody); });
-        Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opensearch/ppl]"));
+        createSearchRole(noPPLSourceReadRole, indexName);
+        createRoleMapping(adPreviewWithoutPPLRole, new ArrayList<>(Arrays.asList(noPPLUser)));
+        createRoleMapping(noPPLSourceReadRole, new ArrayList<>(Arrays.asList(noPPLUser)));
+        try {
+            exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(noPPLClient, requestBody); });
+            Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opensearch/ppl]"));
+        } finally {
+            noPPLClient.close();
+            deleteUser(noPPLUser);
+            deleteRoleMapping(adPreviewWithoutPPLRole);
+            deleteRoleMapping(noPPLSourceReadRole);
+        }
 
-        String adPreviewWithPPLRole = "ad_preview_with_ppl";
+        String noSourceReadUser = "no_source_read_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
+        String noSourceReadPassword = generatePassword(noSourceReadUser);
+        createUser(noSourceReadUser, noSourceReadPassword, new ArrayList<>());
+        RestClient noSourceReadClient = new SecureRestClientBuilder(
+            getClusterHosts().toArray(new HttpHost[0]),
+            isHttps(),
+            noSourceReadUser,
+            noSourceReadPassword
+        ).setSocketTimeout(60000).build();
+        String adPreviewWithPPLRole = "ad_preview_with_ppl_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
         createClusterRole(
             adPreviewWithPPLRole,
             Arrays.asList("cluster:admin/opendistro/ad/detector/preview", "cluster:admin/opensearch/ppl")
         );
-        createRoleMapping(adPreviewWithPPLRole, new ArrayList<>(Arrays.asList(oceanUser)));
-        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(oceanClient, requestBody); });
-        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
+        createRoleMapping(adPreviewWithPPLRole, new ArrayList<>(Arrays.asList(noSourceReadUser)));
+        try {
+            exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(noSourceReadClient, requestBody); });
+            Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
+        } finally {
+            noSourceReadClient.close();
+            deleteUser(noSourceReadUser);
+            deleteRoleMapping(adPreviewWithPPLRole);
+        }
 
     }
 

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -1078,14 +1078,6 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(lionClient, requestBody); });
         Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opensearch/ppl]"));
 
-        String adPreviewWithPPLRole = "ad_preview_with_ppl";
-        createClusterRole(
-            adPreviewWithPPLRole,
-            Arrays.asList("cluster:admin/opendistro/ad/detector/preview", "cluster:admin/opensearch/ppl")
-        );
-        createRoleMapping(adPreviewWithPPLRole, new ArrayList<>(Arrays.asList(elkUser)));
-        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(elkClient, requestBody); });
-        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
     }
 
     public void testValidateAnomalyDetector() throws IOException {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -234,7 +234,14 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         return indexName;
     }
 
-    private void createPPLAccessRole(String role) throws IOException {
+    private void createClusterRole(String role, List<String> clusterPermissions) throws IOException {
+        StringBuilder permissions = new StringBuilder();
+        for (int i = 0; i < clusterPermissions.size(); i++) {
+            if (i > 0) {
+                permissions.append(",\n");
+            }
+            permissions.append("\"").append(clusterPermissions.get(i)).append("\"");
+        }
         TestHelpers
             .makeRequest(
                 client(),
@@ -245,7 +252,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
                     .toHttpEntity(
                         "{\n"
                             + "\"cluster_permissions\": [\n"
-                            + "\"cluster:admin/opensearch/ppl\"\n"
+                            + permissions
+                            + "\n"
                             + "],\n"
                             + "\"index_permissions\": [],\n"
                             + "\"tenant_permissions\": []\n"
@@ -253,6 +261,10 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
                     ),
                 ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
             );
+    }
+
+    private void createPPLAccessRole(String role) throws IOException {
+        createClusterRole(role, Arrays.asList("cluster:admin/opensearch/ppl"));
     }
 
     private String buildInlinePPLPreviewBody(String indexName, Instant periodStart, Instant periodEnd) {
@@ -697,6 +709,8 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             null,
             Instant.now(),
             aliceDetector.getFrequency(),
+            null,
+            null,
             null
         );
 
@@ -1058,8 +1072,20 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         Exception exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(bobClient, requestBody); });
         Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
 
+        String adPreviewWithoutPPLRole = "ad_preview_without_ppl";
+        createClusterRole(adPreviewWithoutPPLRole, Arrays.asList("cluster:admin/opendistro/ad/detector/preview"));
+        createRoleMapping(adPreviewWithoutPPLRole, new ArrayList<>(Arrays.asList(lionUser)));
         exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(lionClient, requestBody); });
-        Assert.assertTrue(exception.getMessage().contains(noPermsMessage));
+        Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opensearch/ppl]"));
+
+        String adPreviewWithPPLRole = "ad_preview_with_ppl";
+        createClusterRole(
+            adPreviewWithPPLRole,
+            Arrays.asList("cluster:admin/opendistro/ad/detector/preview", "cluster:admin/opensearch/ppl")
+        );
+        createRoleMapping(adPreviewWithPPLRole, new ArrayList<>(Arrays.asList(elkUser)));
+        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(elkClient, requestBody); });
+        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
     }
 
     public void testValidateAnomalyDetector() throws IOException {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -1078,6 +1078,15 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
         exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(lionClient, requestBody); });
         Assert.assertTrue(exception.getMessage().contains("no permissions for [cluster:admin/opensearch/ppl]"));
 
+        String adPreviewWithPPLRole = "ad_preview_with_ppl";
+        createClusterRole(
+            adPreviewWithPPLRole,
+            Arrays.asList("cluster:admin/opendistro/ad/detector/preview", "cluster:admin/opensearch/ppl")
+        );
+        createRoleMapping(adPreviewWithPPLRole, new ArrayList<>(Arrays.asList(oceanUser)));
+        exception = expectThrows(IOException.class, () -> { previewAnomalyDetector(oceanClient, requestBody); });
+        Assert.assertTrue(exception.getMessage().contains("no permissions for [indices:data/read/search]"));
+
     }
 
     public void testValidateAnomalyDetector() throws IOException {

--- a/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
+++ b/src/test/java/org/opensearch/ad/rest/SecureADRestIT.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -42,6 +41,7 @@ import org.opensearch.ad.AnomalyDetectorRestTestCase;
 import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.ad.model.AnomalyDetector;
 import org.opensearch.ad.model.AnomalyDetectorExecutionInput;
+import org.opensearch.ad.model.AnomalyResult;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
@@ -1274,56 +1274,61 @@ public class SecureADRestIT extends AnomalyDetectorRestTestCase {
             AnomalyDetector aliceDetector = createAnomalyDetector(cloneDetector(baseDetector, customResultIndex), true, aliceClient);
             assertEquals(customResultIndex, aliceDetector.getCustomResultIndexOrAlias());
 
-            String startDetectorEndpoint = String.format(Locale.ROOT, TestHelpers.AD_BASE_START_DETECTOR_URL, aliceDetector.getId());
-            Response startDetectorResp = TestHelpers
-                .makeRequest(aliceClient, "POST", startDetectorEndpoint, ImmutableMap.of(), (HttpEntity) null, null);
-            assertEquals("Start detector failed", RestStatus.OK, TestHelpers.restStatus(startDetectorResp));
+            // Seed deterministic anomaly results directly. This test verifies Insights security/system-index behavior; relying on
+            // realtime detector execution to produce anomalies makes the test timing-sensitive in CI.
+            Instant anomalyStart = Instant.now().minus(10, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MILLIS);
+            Instant anomalyEnd = anomalyStart.plus(1, ChronoUnit.MINUTES);
+            AnomalyResult anomalyResult1 = TestHelpers
+                .randomHCADAnomalyDetectResult(
+                    aliceDetector.getId(),
+                    null,
+                    null,
+                    0.8,
+                    0.9,
+                    null,
+                    anomalyStart.toEpochMilli(),
+                    anomalyEnd.toEpochMilli()
+                );
+            AnomalyResult anomalyResult2 = TestHelpers
+                .randomHCADAnomalyDetectResult(
+                    aliceDetector.getId(),
+                    null,
+                    null,
+                    0.7,
+                    0.8,
+                    null,
+                    anomalyStart.toEpochMilli(),
+                    anomalyEnd.toEpochMilli()
+                );
+            TestHelpers.ingestDataToIndex(client(), customResultIndex, TestHelpers.toHttpEntity(anomalyResult1));
+            TestHelpers.ingestDataToIndex(client(), customResultIndex, TestHelpers.toHttpEntity(anomalyResult2));
 
-            // Wait briefly for anomaly results to appear in the custom result index.
-            // Insights correlation uses includeSingleton=false, so we want at least 2 anomalies to reduce flakiness.
-            boolean anomaliesAvailable = false;
-            int maxRetries = 30;
-            int retryIntervalMs = 2000;
-            for (int attempt = 0; attempt < maxRetries; attempt++) {
-                Response searchResultsResp = TestHelpers
-                    .makeRequest(
-                        aliceClient,
-                        "POST",
-                        "/" + customResultIndex + "*/_search",
-                        ImmutableMap.of(),
-                        new StringEntity(
-                            "{\"size\":0,\"track_total_hits\":true,\"query\":{\"match_all\":{}}}",
-                            ContentType.APPLICATION_JSON
-                        ),
-                        null
-                    );
-                Map<String, Object> searchResults = entityAsMap(searchResultsResp);
-                @SuppressWarnings("unchecked")
-                Map<String, Object> hitsObj = (Map<String, Object>) searchResults.get("hits");
-                Object totalObj = hitsObj == null ? null : hitsObj.get("total");
-                long totalHits = 0;
-                if (totalObj instanceof Number) {
-                    totalHits = ((Number) totalObj).longValue();
-                } else if (totalObj instanceof Map) {
-                    Object value = ((Map<String, Object>) totalObj).get("value");
-                    if (value instanceof Number) {
-                        totalHits = ((Number) value).longValue();
-                    }
-                }
-                if (totalHits >= 2) {
-                    anomaliesAvailable = true;
-                    break;
-                }
-                try {
-                    Thread.sleep(retryIntervalMs);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
+            Response searchResultsResp = TestHelpers
+                .makeRequest(
+                    aliceClient,
+                    "POST",
+                    "/" + customResultIndex + "*/_search",
+                    ImmutableMap.of(),
+                    new StringEntity("{\"size\":0,\"track_total_hits\":true,\"query\":{\"match_all\":{}}}", ContentType.APPLICATION_JSON),
+                    null
+                );
+            Map<String, Object> searchResults = entityAsMap(searchResultsResp);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> hitsObj = (Map<String, Object>) searchResults.get("hits");
+            Object totalObj = hitsObj == null ? null : hitsObj.get("total");
+            long totalHits = 0;
+            if (totalObj instanceof Number) {
+                totalHits = ((Number) totalObj).longValue();
+            } else if (totalObj instanceof Map) {
+                Object value = ((Map<String, Object>) totalObj).get("value");
+                if (value instanceof Number) {
+                    totalHits = ((Number) value).longValue();
                 }
             }
-            assertTrue("Expected at least 2 anomaly results to be generated before starting insights", anomaliesAvailable);
+            assertTrue("Expected at least 2 seeded anomaly results before starting insights", totalHits >= 2);
 
             // 2) Start insights job as alice
+            int retryIntervalMs = 2000;
             Response startResp = TestHelpers.makeRequest(aliceClient, "POST", startPath, ImmutableMap.of(), "", null);
             assertEquals("Start insights job failed", RestStatus.OK, TestHelpers.restStatus(startResp));
 

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -234,6 +234,8 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
     }
@@ -272,6 +274,8 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
     }

--- a/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ForwardADTaskRequestTests.java
@@ -91,6 +91,8 @@ public class ForwardADTaskRequestTests extends OpenSearchSingleNodeTestCase {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         ForwardADTaskRequest request = new ForwardADTaskRequest(detector, null, null, null, null, Version.V_2_1_0);

--- a/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/PreviewAnomalyDetectorTransportActionTests.java
@@ -60,6 +60,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.ConfigConstants;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
@@ -72,6 +73,7 @@ import org.opensearch.timeseries.breaker.CircuitBreakerService;
 import org.opensearch.timeseries.constant.CommonMessages;
 import org.opensearch.timeseries.feature.FeatureManager;
 import org.opensearch.timeseries.feature.Features;
+import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.util.RestHandlerUtils;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -181,6 +183,64 @@ public class PreviewAnomalyDetectorTransportActionTests extends OpenSearchSingle
             return null;
         }).when(featureManager).getPreviewFeatures(any(), anyLong(), anyLong(), any());
         action.doExecute(task, request, previewResponse);
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPreviewExecuteCopiesInlinePPLDetectorWithRequestUser() throws Exception {
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        AnomalyDetector detector = AnomalyDetector
+            .parse(
+                TestHelpers
+                    .parser(
+                        "{"
+                            + "\"name\":\"ppl-detector\","
+                            + "\"description\":\"ppl detector\","
+                            + "\"source_type\":\"PPL\","
+                            + "\"ppl_source\":{"
+                            + "\"query_language\":\"PPL\","
+                            + "\"query\":\"source = sample-http-responses | stats count() as doc_count by span(timestamp, 10m) as bucket\""
+                            + "},"
+                            + "\"window_delay\":{\"period\":{\"interval\":1,\"unit\":\"Minutes\"}},"
+                            + "\"last_update_time\":1700000000000"
+                            + "}"
+                    )
+            );
+        User requestUser = new User("alice", Collections.emptyList(), Collections.singletonList("odfe"), Collections.emptyList());
+        Instant startTime = Instant.now();
+        Instant endTime = startTime.plusSeconds(60);
+        PreviewAnomalyDetectorRequest request = new PreviewAnomalyDetectorRequest(detector, detector.getId(), startTime, endTime);
+
+        doReturn(TestHelpers.randomThresholdingResults()).when(modelManager).getPreviewResults(any(), any());
+        doAnswer(invocation -> {
+            AnomalyDetector copiedDetector = invocation.getArgument(0);
+            assertNotSame(detector, copiedDetector);
+            assertEquals(requestUser, copiedDetector.getUser());
+            assertEquals(Config.SOURCE_TYPE_PPL, copiedDetector.getSourceType());
+            assertEquals(detector.getPPLSource(), copiedDetector.getPPLSource());
+            assertEquals(detector.getDetectionDateRange(), copiedDetector.getDetectionDateRange());
+            ActionListener<Features> featureListener = invocation.getArgument(3);
+            featureListener.onResponse(TestHelpers.randomFeatures());
+            return null;
+        }).when(featureManager).getPreviewFeatures(any(), anyLong(), anyLong(), any());
+
+        ActionListener<PreviewAnomalyDetectorResponse> previewResponse = new ActionListener<PreviewAnomalyDetectorResponse>() {
+            @Override
+            public void onResponse(PreviewAnomalyDetectorResponse response) {
+                Assert.assertNotNull(response);
+                inProgressLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.fail(e.getMessage());
+            }
+        };
+
+        try (ThreadContext.StoredContext context = client().threadPool().getThreadContext().stashContext()) {
+            action.previewExecute(request, context, requestUser, previewResponse);
+        }
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
     }
 

--- a/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ValidateAnomalyDetectorTransportActionTests.java
@@ -410,6 +410,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");
@@ -463,6 +465,8 @@ public class ValidateAnomalyDetectorTransportActionTests extends ADIntegTestCase
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
         ingestTestDataValidate(anomalyDetector.getIndices().get(0), Instant.now().minus(1, ChronoUnit.DAYS), 1, "error");

--- a/src/test/java/org/opensearch/timeseries/TestHelpers.java
+++ b/src/test/java/org/opensearch/timeseries/TestHelpers.java
@@ -494,6 +494,8 @@ public class TestHelpers {
             null,
             lastUpdateTime,
             new IntervalTimeConfiguration(detectionIntervalInMinutes, ChronoUnit.MINUTES),
+            null,
+            null,
             null
         );
     }
@@ -552,6 +554,8 @@ public class TestHelpers {
             null,
             Instant.now(),
             new IntervalTimeConfiguration(detectionIntervalInMinutes, ChronoUnit.MINUTES),
+            null,
+            null,
             null
         );
     }
@@ -622,6 +626,8 @@ public class TestHelpers {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
     }
@@ -667,6 +673,8 @@ public class TestHelpers {
             null,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
     }
@@ -705,6 +713,8 @@ public class TestHelpers {
             true,
             Instant.now(),
             interval,
+            null,
+            null,
             null
         );
     }
@@ -742,6 +752,8 @@ public class TestHelpers {
             null,
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             interval,
+            null,
+            null,
             null
         );
     }
@@ -785,6 +797,8 @@ public class TestHelpers {
             null,
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             interval,
+            null,
+            null,
             null
         );
     }
@@ -972,7 +986,9 @@ public class TestHelpers {
                 null,
                 lastUpdateTime,
                 detectionInterval,
-                autoCreated
+                autoCreated,
+                null,
+                null
             );
         }
     }
@@ -1012,6 +1028,8 @@ public class TestHelpers {
             null,
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             interval,
+            null,
+            null,
             null
         );
     }

--- a/src/test/java/org/opensearch/timeseries/feature/NoPowermockSearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/NoPowermockSearchFeatureDaoTests.java
@@ -189,7 +189,8 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             clock,
             1,
             1,
-            60_000L
+            60_000L,
+            null
         );
 
         String app0 = "app_0";
@@ -374,7 +375,8 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             clock,
             2,
             1,
-            60_000L
+            60_000L,
+            null
         );
 
         searchFeatureDao.getHighestCountEntities(detector, 10L, 20L, listener);
@@ -418,7 +420,8 @@ public class NoPowermockSearchFeatureDaoTests extends AbstractTimeSeriesTest {
             clock,
             2,
             1,
-            timeoutMillis
+            timeoutMillis,
+            null
         );
 
         CountDownLatch clockInvoked = new CountDownLatch(2);

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.feature;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.timeseries.AnalysisType;
+import org.opensearch.timeseries.NodeStateManager;
+import org.opensearch.timeseries.model.Config;
+import org.opensearch.timeseries.model.PPLSource;
+import org.opensearch.timeseries.util.SecurityClientUtil;
+import org.opensearch.transport.client.Client;
+
+public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
+
+    private Client client;
+    private Config config;
+    private TestSecurityClientUtil clientUtil;
+    private PPLDirectQueryExecutor executor;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        config = mock(Config.class);
+        when(config.getId()).thenReturn("detector-id");
+        when(config.getPPLSource())
+            .thenReturn(
+                new PPLSource(
+                    "PPL",
+                    "source = logs | where status >= 400 | stats count() as error_count, sum(bytes) as byte_sum by span(timestamp, 1m)"
+                )
+            );
+        clientUtil = new TestSecurityClientUtil();
+        executor = new PPLDirectQueryExecutor(client, clientUtil);
+    }
+
+    public void testExecuteMetricQueryParsesNumericAndTextMetricValues() throws Exception {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[42.5,\"7.25\"]]}");
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertTrue(listener.response.isPresent());
+        assertArrayEquals(new double[] { 42.5, 7.25 }, listener.response.get(), 0.001);
+        assertEquals(1, clientUtil.configCallCount);
+        assertEquals("detector-id", clientUtil.capturedConfigId);
+        assertEquals(0, clientUtil.userCallCount);
+        assertSerializedRequestContains(clientUtil.capturedRequest, "timestamp >= \"1970-01-01 00:00:01.000\"");
+    }
+
+    public void testExecuteMetricQueryReturnsEmptyForMissingRows() {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[]}");
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertFalse(listener.response.isPresent());
+    }
+
+    public void testExecuteMetricQueryReturnsEmptyForNullMetricValue() {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[null,1]]}");
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertFalse(listener.response.isPresent());
+    }
+
+    public void testExecuteMetricQueryFailsOnInvalidMetricValue() {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[\"not-a-number\",1]]}");
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        assertNotNull(listener.failure);
+        assertTrue(listener.failure instanceof NumberFormatException);
+    }
+
+    public void testExecuteMetricQueryFailsWhenQueryCannotCompile() {
+        when(config.getPPLSource()).thenReturn(new PPLSource("PPL", ""));
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        assertNotNull(listener.failure);
+        assertTrue(listener.failure instanceof IllegalArgumentException);
+        assertEquals(0, clientUtil.configCallCount);
+        assertEquals(0, clientUtil.userCallCount);
+    }
+
+    public void testExecuteLatestDataTimeQueryUsesUserSecurityAndParsesTimestampText() throws Exception {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[\"1970-01-01 00:00:01.123\"]]}");
+        CapturingListener<Optional<Long>> listener = new CapturingListener<>();
+        User user = new User("alice", Collections.emptyList(), Collections.singletonList("role"), Collections.emptyList());
+
+        executor.executeLatestDataTimeQuery(user, config, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertTrue(listener.response.isPresent());
+        assertEquals(1_123L, listener.response.get().longValue());
+        assertEquals(1, clientUtil.userCallCount);
+        assertEquals(user, clientUtil.capturedUser);
+        assertEquals(0, clientUtil.configCallCount);
+        assertSerializedRequestContains(clientUtil.capturedRequest, "max(timestamp) as latest_time");
+    }
+
+    public void testExecuteMinDataTimeQueryParsesNumericTimestamp() {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[12345]]}");
+        CapturingListener<Optional<Long>> listener = new CapturingListener<>();
+
+        executor.executeMinDataTimeQuery(config, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertTrue(listener.response.isPresent());
+        assertEquals(12_345L, listener.response.get().longValue());
+        assertEquals(1, clientUtil.configCallCount);
+    }
+
+    public void testExecuteDateRangeQueryParsesTextAndNumericTimestamps() {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[\"1970-01-01 00:00:01\",2000]]}");
+        CapturingListener<Pair<Long, Long>> listener = new CapturingListener<>();
+
+        executor.executeDateRangeQuery(null, config, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertEquals(1_000L, listener.response.getLeft().longValue());
+        assertEquals(2_000L, listener.response.getRight().longValue());
+    }
+
+    public void testExecuteDateRangeQueryFailsWhenTimestampMissing() {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[1000]]}");
+        CapturingListener<Pair<Long, Long>> listener = new CapturingListener<>();
+
+        executor.executeDateRangeQuery(null, config, AnalysisType.AD, listener);
+
+        assertNotNull(listener.failure);
+        assertTrue(listener.failure instanceof IllegalStateException);
+        assertTrue(listener.failure.getMessage().contains("did not return both min and max"));
+    }
+
+    public void testExecuteQueryRejectsMissingPPLSource() {
+        when(config.getPPLSource()).thenReturn(null);
+        CapturingListener<Optional<Long>> listener = new CapturingListener<>();
+
+        executor.executeMinDataTimeQuery(config, AnalysisType.AD, listener);
+
+        assertNotNull(listener.failure);
+        assertTrue(listener.failure instanceof IllegalArgumentException);
+        assertTrue(listener.failure.getMessage().contains("ppl_source must be set"));
+    }
+
+    public void testExecuteQueryPropagatesSecurityFailure() {
+        clientUtil.failure = new IllegalStateException("security failed");
+        CapturingListener<Optional<Long>> listener = new CapturingListener<>();
+
+        executor.executeMinDataTimeQuery(config, AnalysisType.AD, listener);
+
+        assertSame(clientUtil.failure, listener.failure);
+    }
+
+    public void testPPLTransportResponseFromActionResponseSupportsSerializedAndDirectResponses() throws Exception {
+        Method fromActionResponse = pplTransportResponseClass().getDeclaredMethod("fromActionResponse", ActionResponse.class);
+        fromActionResponse.setAccessible(true);
+        Method getResult = pplTransportResponseClass().getDeclaredMethod("getResult");
+        getResult.setAccessible(true);
+
+        Object serializedResponse = fromActionResponse.invoke(null, new RawPPLActionResponse("{\"datarows\":[[1]]}"));
+        assertEquals("{\"datarows\":[[1]]}", getResult.invoke(serializedResponse));
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)) {
+            ((ActionResponse) serializedResponse).writeTo(output);
+        }
+        try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+            Object roundTrippedResponse = pplTransportResponseConstructor().newInstance(input);
+            assertEquals("{\"datarows\":[[1]]}", getResult.invoke(roundTrippedResponse));
+        }
+
+        Object directResponse = fromActionResponse.invoke(null, serializedResponse);
+        assertSame(serializedResponse, directResponse);
+    }
+
+    public void testPPLTransportResponseFromActionResponseFailsOnInvalidSerializedResponse() throws Exception {
+        Method fromActionResponse = pplTransportResponseClass().getDeclaredMethod("fromActionResponse", ActionResponse.class);
+        fromActionResponse.setAccessible(true);
+
+        InvocationTargetException exception = expectThrows(
+            InvocationTargetException.class,
+            () -> fromActionResponse.invoke(null, new FailingActionResponse())
+        );
+        assertTrue(exception.getCause() instanceof IllegalStateException);
+        assertTrue(exception.getCause().getMessage().contains("failed to parse ActionResponse"));
+    }
+
+    private static Constructor<?> pplTransportResponseConstructor() throws Exception {
+        Constructor<?> constructor = pplTransportResponseClass().getDeclaredConstructor(StreamInput.class);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+
+    private static Class<?> pplTransportResponseClass() throws ClassNotFoundException {
+        return Class.forName("org.opensearch.timeseries.feature.PPLDirectQueryExecutor$PPLTransportResponse");
+    }
+
+    private static void assertSerializedRequestContains(ActionRequest request, String expectedQueryFragment) throws Exception {
+        assertNotNull(request);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)) {
+            request.writeTo(output);
+        }
+
+        String query = (String) readPrivateField(request, "query");
+        assertTrue(query, query.contains(expectedQueryFragment));
+        assertEquals("jdbc", readPrivateField(request, "format"));
+        assertNull(readPrivateField(request, "explainMode"));
+        assertNull(readPrivateField(request, "jsonContent"));
+        assertEquals("/_plugins/_ppl", readPrivateField(request, "path"));
+        assertTrue((Boolean) readPrivateField(request, "sanitize"));
+    }
+
+    private static Object readPrivateField(Object target, String fieldName) throws Exception {
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    private static class CapturingListener<T> implements ActionListener<T> {
+        private T response;
+        private Exception failure;
+
+        @Override
+        public void onResponse(T response) {
+            this.response = response;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            this.failure = e;
+        }
+    }
+
+    private static class RawPPLActionResponse extends ActionResponse {
+        private final String result;
+
+        private RawPPLActionResponse(String result) {
+            this.result = result;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(result);
+            out.writeString("application/json");
+        }
+    }
+
+    private static class FailingActionResponse extends ActionResponse {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new IOException("cannot serialize");
+        }
+    }
+
+    private static class TestSecurityClientUtil extends SecurityClientUtil {
+        private ActionResponse response;
+        private Exception failure;
+        private ActionRequest capturedRequest;
+        private String capturedConfigId;
+        private User capturedUser;
+        private int configCallCount;
+        private int userCallCount;
+
+        private TestSecurityClientUtil() {
+            super(mock(NodeStateManager.class), Settings.EMPTY);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <Request extends ActionRequest, Response extends ActionResponse> void asyncRequestWithInjectedSecurity(
+            Request request,
+            BiConsumer<Request, ActionListener<Response>> consumer,
+            String configId,
+            Client client,
+            AnalysisType context,
+            ActionListener<Response> listener
+        ) {
+            capturedRequest = request;
+            capturedConfigId = configId;
+            configCallCount++;
+            respond(listener);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <Request extends ActionRequest, Response extends ActionResponse> void asyncRequestWithInjectedSecurity(
+            Request request,
+            BiConsumer<Request, ActionListener<Response>> consumer,
+            User user,
+            Client client,
+            AnalysisType context,
+            ActionListener<Response> listener
+        ) {
+            capturedRequest = request;
+            capturedUser = user;
+            userCallCount++;
+            respond(listener);
+        }
+
+        @SuppressWarnings("unchecked")
+        private <Response extends ActionResponse> void respond(ActionListener<Response> listener) {
+            if (failure != null) {
+                listener.onFailure(failure);
+            } else {
+                listener.onResponse((Response) response);
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -99,6 +100,23 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
 
         assertNull(listener.failure);
         assertFalse(listener.response.isPresent());
+    }
+
+    public void testExecuteMetricQueryBySpanParsesBucketedMetricValues() throws Exception {
+        clientUtil.response = new RawPPLActionResponse(
+            "{\"datarows\":[[42.5,\"7.25\",\"1970-01-01 00:01:00\"],[null,1,\"1970-01-01 00:02:00\"],[3,4,null],[5,6]]}"
+        );
+        CapturingListener<Map<Long, Optional<double[]>>> listener = new CapturingListener<>();
+
+        executor.executeMetricQueryBySpan(config, 60_000L, 180_000L, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertEquals(2, listener.response.size());
+        assertTrue(listener.response.get(60_000L).isPresent());
+        assertArrayEquals(new double[] { 42.5, 7.25 }, listener.response.get(60_000L).get(), 0.001);
+        assertFalse(listener.response.get(120_000L).isPresent());
+        assertSerializedRequestContains(clientUtil.capturedRequest, "by span(timestamp, 1m) as bucket");
+        assertSerializedRequestContains(clientUtil.capturedRequest, "| sort bucket asc");
     }
 
     public void testExecuteMetricQueryFailsOnInvalidMetricValue() {

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -28,6 +28,8 @@ import java.util.function.BiConsumer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -77,9 +79,10 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertNull(listener.failure);
         assertTrue(listener.response.isPresent());
         assertArrayEquals(new double[] { 42.5, 7.25 }, listener.response.get(), 0.001);
-        assertEquals(1, clientUtil.configCallCount);
+        assertEquals(2, clientUtil.configCallCount);
         assertEquals("detector-id", clientUtil.capturedConfigId);
         assertEquals(0, clientUtil.userCallCount);
+        assertSourceAccessRequestTargetsLogs();
         assertSerializedRequestContains(clientUtil.capturedRequest, "timestamp >= \"1970-01-01 00:00:01.000\"");
     }
 
@@ -134,9 +137,10 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
 
         assertNull(listener.failure);
         assertTrue(listener.response.isPresent());
-        assertEquals(1, clientUtil.userCallCount);
+        assertEquals(2, clientUtil.userCallCount);
         assertEquals(user, clientUtil.capturedUser);
         assertEquals(0, clientUtil.configCallCount);
+        assertSourceAccessRequestTargetsLogs();
     }
 
     public void testExecuteMetricQueryFailsOnInvalidMetricValue() {
@@ -171,9 +175,10 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertNull(listener.failure);
         assertTrue(listener.response.isPresent());
         assertEquals(1_123L, listener.response.get().longValue());
-        assertEquals(1, clientUtil.userCallCount);
+        assertEquals(2, clientUtil.userCallCount);
         assertEquals(user, clientUtil.capturedUser);
         assertEquals(0, clientUtil.configCallCount);
+        assertSourceAccessRequestTargetsLogs();
         assertSerializedRequestContains(clientUtil.capturedRequest, "max(timestamp) as latest_time");
     }
 
@@ -186,7 +191,8 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertNull(listener.failure);
         assertTrue(listener.response.isPresent());
         assertEquals(12_345L, listener.response.get().longValue());
-        assertEquals(1, clientUtil.configCallCount);
+        assertEquals(2, clientUtil.configCallCount);
+        assertSourceAccessRequestTargetsLogs();
     }
 
     public void testExecuteMinDataTimeQueryUsesUserSecurityWhenConfigHasUser() {
@@ -199,9 +205,10 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
 
         assertNull(listener.failure);
         assertTrue(listener.response.isPresent());
-        assertEquals(1, clientUtil.userCallCount);
+        assertEquals(2, clientUtil.userCallCount);
         assertEquals(user, clientUtil.capturedUser);
         assertEquals(0, clientUtil.configCallCount);
+        assertSourceAccessRequestTargetsLogs();
     }
 
     public void testExecuteDateRangeQueryParsesTextAndNumericTimestamps() {
@@ -382,6 +389,12 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertTrue((Boolean) readPrivateField(request, "sanitize"));
     }
 
+    private void assertSourceAccessRequestTargetsLogs() {
+        assertNotNull(clientUtil.capturedSourceAccessRequest);
+        assertArrayEquals(new String[] { "logs" }, clientUtil.capturedSourceAccessRequest.indices());
+        assertEquals(0, clientUtil.capturedSourceAccessRequest.source().size());
+    }
+
     private static Object readPrivateField(Object target, String fieldName) throws Exception {
         java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);
@@ -458,6 +471,7 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         private ActionResponse response;
         private Exception failure;
         private ActionRequest capturedRequest;
+        private SearchRequest capturedSourceAccessRequest;
         private String capturedConfigId;
         private User capturedUser;
         private int configCallCount;
@@ -480,7 +494,7 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
             capturedRequest = request;
             capturedConfigId = configId;
             configCallCount++;
-            respond(listener);
+            respond(request, listener);
         }
 
         @Override
@@ -496,13 +510,19 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
             capturedRequest = request;
             capturedUser = user;
             userCallCount++;
-            respond(listener);
+            respond(request, listener);
         }
 
         @SuppressWarnings("unchecked")
-        private <Response extends ActionResponse> void respond(ActionListener<Response> listener) {
+        private <Request extends ActionRequest, Response extends ActionResponse> void respond(
+            Request request,
+            ActionListener<Response> listener
+        ) {
             if (failure != null) {
                 listener.onFailure(failure);
+            } else if (request instanceof SearchRequest) {
+                capturedSourceAccessRequest = (SearchRequest) request;
+                listener.onResponse((Response) mock(SearchResponse.class));
             } else {
                 listener.onResponse((Response) response);
             }

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -27,6 +27,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -268,21 +269,59 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
     }
 
     public void testPPLTransportRequestFromActionRequestSupportsSerializedAndDirectRequests() throws Exception {
-        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[42.5,\"7.25\"]]}");
-        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
-
-        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+        ActionRequest capturedRequest = newPPLTransportRequest(
+            "source = logs | stats count() as count by span(timestamp, 1m) as bucket",
+            "jdbc",
+            "/_plugins/_ppl"
+        );
 
         Method fromActionRequest = pplTransportRequestClass().getDeclaredMethod("fromActionRequest", ActionRequest.class);
         fromActionRequest.setAccessible(true);
-        Object serializedRequest = fromActionRequest.invoke(null, clientUtil.capturedRequest);
+        Object serializedRequest = fromActionRequest.invoke(null, new DelegatingActionRequest(capturedRequest));
 
-        assertEquals(readPrivateField(clientUtil.capturedRequest, "query"), readPrivateField(serializedRequest, "query"));
-        assertEquals(readPrivateField(clientUtil.capturedRequest, "format"), readPrivateField(serializedRequest, "format"));
-        assertEquals(readPrivateField(clientUtil.capturedRequest, "path"), readPrivateField(serializedRequest, "path"));
-        assertEquals(readPrivateField(clientUtil.capturedRequest, "sanitize"), readPrivateField(serializedRequest, "sanitize"));
-        assertEquals(readPrivateField(clientUtil.capturedRequest, "profile"), readPrivateField(serializedRequest, "profile"));
-        assertSame(clientUtil.capturedRequest, fromActionRequest.invoke(null, serializedRequest));
+        assertEquals(readPrivateField(capturedRequest, "query"), readPrivateField(serializedRequest, "query"));
+        assertEquals(readPrivateField(capturedRequest, "format"), readPrivateField(serializedRequest, "format"));
+        assertEquals(readPrivateField(capturedRequest, "path"), readPrivateField(serializedRequest, "path"));
+        assertEquals(readPrivateField(capturedRequest, "sanitize"), readPrivateField(serializedRequest, "sanitize"));
+        assertEquals(readPrivateField(capturedRequest, "profile"), readPrivateField(serializedRequest, "profile"));
+        assertNull(((ActionRequest) serializedRequest).validate());
+        assertSame(serializedRequest, fromActionRequest.invoke(null, serializedRequest));
+    }
+
+    public void testPPLTransportRequestRoundTripsThroughStreamConstructor() throws Exception {
+        ActionRequest request = newPPLTransportRequest(
+            "source = logs | stats count() as count by span(timestamp, 1m) as bucket",
+            "jdbc",
+            "/_plugins/_ppl"
+        );
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)) {
+            request.writeTo(output);
+        }
+        try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+            Object roundTrippedRequest = pplTransportRequestStreamConstructor().newInstance(input);
+            assertEquals(readPrivateField(request, "query"), readPrivateField(roundTrippedRequest, "query"));
+            assertEquals(readPrivateField(request, "format"), readPrivateField(roundTrippedRequest, "format"));
+            assertNull(readPrivateField(roundTrippedRequest, "explainMode"));
+            assertNull(readPrivateField(roundTrippedRequest, "jsonContent"));
+            assertEquals(readPrivateField(request, "path"), readPrivateField(roundTrippedRequest, "path"));
+            assertTrue((Boolean) readPrivateField(roundTrippedRequest, "sanitize"));
+            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "profile"));
+            assertNull(readPrivateField(roundTrippedRequest, "queryId"));
+        }
+    }
+
+    public void testPPLTransportRequestFromActionRequestFailsOnInvalidSerializedRequest() throws Exception {
+        Method fromActionRequest = pplTransportRequestClass().getDeclaredMethod("fromActionRequest", ActionRequest.class);
+        fromActionRequest.setAccessible(true);
+
+        InvocationTargetException exception = expectThrows(
+            InvocationTargetException.class,
+            () -> fromActionRequest.invoke(null, new FailingActionRequest())
+        );
+        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertTrue(exception.getCause().getMessage().contains("failed to parse ActionRequest"));
     }
 
     public void testPPLTransportResponseFromActionResponseFailsOnInvalidSerializedResponse() throws Exception {
@@ -301,6 +340,22 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         Constructor<?> constructor = pplTransportResponseClass().getDeclaredConstructor(StreamInput.class);
         constructor.setAccessible(true);
         return constructor;
+    }
+
+    private static Constructor<?> pplTransportRequestConstructor() throws Exception {
+        Constructor<?> constructor = pplTransportRequestClass().getDeclaredConstructor(String.class, String.class, String.class);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+
+    private static Constructor<?> pplTransportRequestStreamConstructor() throws Exception {
+        Constructor<?> constructor = pplTransportRequestClass().getDeclaredConstructor(StreamInput.class);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+
+    private static ActionRequest newPPLTransportRequest(String query, String format, String path) throws Exception {
+        return (ActionRequest) pplTransportRequestConstructor().newInstance(query, format, path);
     }
 
     private static Class<?> pplTransportResponseClass() throws ClassNotFoundException {
@@ -363,6 +418,36 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
     }
 
     private static class FailingActionResponse extends ActionResponse {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new IOException("cannot serialize");
+        }
+    }
+
+    private static class DelegatingActionRequest extends ActionRequest {
+        private final ActionRequest delegate;
+
+        private DelegatingActionRequest(ActionRequest delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            delegate.writeTo(out);
+        }
+    }
+
+    private static class FailingActionRequest extends ActionRequest {
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             throw new IOException("cannot serialize");

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -92,14 +92,16 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertFalse(listener.response.isPresent());
     }
 
-    public void testExecuteMetricQueryReturnsEmptyForNullMetricValue() {
+    public void testExecuteMetricQueryReturnsNaNForNullMetricValue() {
         clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[null,1]]}");
         CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
 
         executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
 
         assertNull(listener.failure);
-        assertFalse(listener.response.isPresent());
+        assertTrue(listener.response.isPresent());
+        assertTrue(Double.isNaN(listener.response.get()[0]));
+        assertEquals(1.0, listener.response.get()[1], 0.001);
     }
 
     public void testExecuteMetricQueryBySpanParsesBucketedMetricValues() throws Exception {
@@ -114,9 +116,26 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertEquals(2, listener.response.size());
         assertTrue(listener.response.get(60_000L).isPresent());
         assertArrayEquals(new double[] { 42.5, 7.25 }, listener.response.get(60_000L).get(), 0.001);
-        assertFalse(listener.response.get(120_000L).isPresent());
+        assertTrue(listener.response.get(120_000L).isPresent());
+        assertTrue(Double.isNaN(listener.response.get(120_000L).get()[0]));
+        assertEquals(1.0, listener.response.get(120_000L).get()[1], 0.001);
         assertSerializedRequestContains(clientUtil.capturedRequest, "by span(timestamp, 1m) as bucket");
         assertSerializedRequestContains(clientUtil.capturedRequest, "| sort bucket asc");
+    }
+
+    public void testExecuteMetricQueryUsesUserSecurityWhenConfigHasUser() throws Exception {
+        User user = new User("alice", Collections.emptyList(), Collections.singletonList("role"), Collections.emptyList());
+        when(config.getUser()).thenReturn(user);
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[42.5,\"7.25\"]]}");
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertTrue(listener.response.isPresent());
+        assertEquals(1, clientUtil.userCallCount);
+        assertEquals(user, clientUtil.capturedUser);
+        assertEquals(0, clientUtil.configCallCount);
     }
 
     public void testExecuteMetricQueryFailsOnInvalidMetricValue() {
@@ -167,6 +186,21 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertTrue(listener.response.isPresent());
         assertEquals(12_345L, listener.response.get().longValue());
         assertEquals(1, clientUtil.configCallCount);
+    }
+
+    public void testExecuteMinDataTimeQueryUsesUserSecurityWhenConfigHasUser() {
+        User user = new User("alice", Collections.emptyList(), Collections.singletonList("role"), Collections.emptyList());
+        when(config.getUser()).thenReturn(user);
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[12345]]}");
+        CapturingListener<Optional<Long>> listener = new CapturingListener<>();
+
+        executor.executeMinDataTimeQuery(config, AnalysisType.AD, listener);
+
+        assertNull(listener.failure);
+        assertTrue(listener.response.isPresent());
+        assertEquals(1, clientUtil.userCallCount);
+        assertEquals(user, clientUtil.capturedUser);
+        assertEquals(0, clientUtil.configCallCount);
     }
 
     public void testExecuteDateRangeQueryParsesTextAndNumericTimestamps() {
@@ -233,6 +267,24 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertSame(serializedResponse, directResponse);
     }
 
+    public void testPPLTransportRequestFromActionRequestSupportsSerializedAndDirectRequests() throws Exception {
+        clientUtil.response = new RawPPLActionResponse("{\"datarows\":[[42.5,\"7.25\"]]}");
+        CapturingListener<Optional<double[]>> listener = new CapturingListener<>();
+
+        executor.executeMetricQuery(config, 1_000L, 2_000L, AnalysisType.AD, listener);
+
+        Method fromActionRequest = pplTransportRequestClass().getDeclaredMethod("fromActionRequest", ActionRequest.class);
+        fromActionRequest.setAccessible(true);
+        Object serializedRequest = fromActionRequest.invoke(null, clientUtil.capturedRequest);
+
+        assertEquals(readPrivateField(clientUtil.capturedRequest, "query"), readPrivateField(serializedRequest, "query"));
+        assertEquals(readPrivateField(clientUtil.capturedRequest, "format"), readPrivateField(serializedRequest, "format"));
+        assertEquals(readPrivateField(clientUtil.capturedRequest, "path"), readPrivateField(serializedRequest, "path"));
+        assertEquals(readPrivateField(clientUtil.capturedRequest, "sanitize"), readPrivateField(serializedRequest, "sanitize"));
+        assertEquals(readPrivateField(clientUtil.capturedRequest, "profile"), readPrivateField(serializedRequest, "profile"));
+        assertSame(clientUtil.capturedRequest, fromActionRequest.invoke(null, serializedRequest));
+    }
+
     public void testPPLTransportResponseFromActionResponseFailsOnInvalidSerializedResponse() throws Exception {
         Method fromActionResponse = pplTransportResponseClass().getDeclaredMethod("fromActionResponse", ActionResponse.class);
         fromActionResponse.setAccessible(true);
@@ -253,6 +305,10 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
 
     private static Class<?> pplTransportResponseClass() throws ClassNotFoundException {
         return Class.forName("org.opensearch.timeseries.feature.PPLDirectQueryExecutor$PPLTransportResponse");
+    }
+
+    private static Class<?> pplTransportRequestClass() throws ClassNotFoundException {
+        return Class.forName("org.opensearch.timeseries.feature.PPLDirectQueryExecutor$PPLTransportRequest");
     }
 
     private static void assertSerializedRequestContains(ActionRequest request, String expectedQueryFragment) throws Exception {

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -27,7 +27,6 @@ import java.util.function.BiConsumer;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.action.ActionRequest;
-import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
@@ -275,26 +274,6 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertSame(serializedResponse, directResponse);
     }
 
-    public void testPPLTransportRequestFromActionRequestSupportsSerializedAndDirectRequests() throws Exception {
-        ActionRequest capturedRequest = newPPLTransportRequest(
-            "source = logs | stats count() as count by span(timestamp, 1m) as bucket",
-            "jdbc",
-            "/_plugins/_ppl"
-        );
-
-        Method fromActionRequest = pplTransportRequestClass().getDeclaredMethod("fromActionRequest", ActionRequest.class);
-        fromActionRequest.setAccessible(true);
-        Object serializedRequest = fromActionRequest.invoke(null, new DelegatingActionRequest(capturedRequest));
-
-        assertEquals(readPrivateField(capturedRequest, "query"), readPrivateField(serializedRequest, "query"));
-        assertEquals(readPrivateField(capturedRequest, "format"), readPrivateField(serializedRequest, "format"));
-        assertEquals(readPrivateField(capturedRequest, "path"), readPrivateField(serializedRequest, "path"));
-        assertEquals(readPrivateField(capturedRequest, "sanitize"), readPrivateField(serializedRequest, "sanitize"));
-        assertEquals(readPrivateField(capturedRequest, "profile"), readPrivateField(serializedRequest, "profile"));
-        assertNull(((ActionRequest) serializedRequest).validate());
-        assertSame(serializedRequest, fromActionRequest.invoke(null, serializedRequest));
-    }
-
     public void testPPLTransportRequestRoundTripsThroughStreamConstructor() throws Exception {
         ActionRequest request = newPPLTransportRequest(
             "source = logs | stats count() as count by span(timestamp, 1m) as bucket",
@@ -317,18 +296,6 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
             assertFalse((Boolean) readPrivateField(roundTrippedRequest, "profile"));
             assertNull(readPrivateField(roundTrippedRequest, "queryId"));
         }
-    }
-
-    public void testPPLTransportRequestFromActionRequestFailsOnInvalidSerializedRequest() throws Exception {
-        Method fromActionRequest = pplTransportRequestClass().getDeclaredMethod("fromActionRequest", ActionRequest.class);
-        fromActionRequest.setAccessible(true);
-
-        InvocationTargetException exception = expectThrows(
-            InvocationTargetException.class,
-            () -> fromActionRequest.invoke(null, new FailingActionRequest())
-        );
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
-        assertTrue(exception.getCause().getMessage().contains("failed to parse ActionRequest"));
     }
 
     public void testPPLTransportResponseFromActionResponseFailsOnInvalidSerializedResponse() throws Exception {
@@ -431,36 +398,6 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
     }
 
     private static class FailingActionResponse extends ActionResponse {
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            throw new IOException("cannot serialize");
-        }
-    }
-
-    private static class DelegatingActionRequest extends ActionRequest {
-        private final ActionRequest delegate;
-
-        private DelegatingActionRequest(ActionRequest delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public ActionRequestValidationException validate() {
-            return null;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            delegate.writeTo(out);
-        }
-    }
-
-    private static class FailingActionRequest extends ActionRequest {
-        @Override
-        public ActionRequestValidationException validate() {
-            return null;
-        }
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             throw new IOException("cannot serialize");

--- a/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,8 +88,10 @@ import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
 import org.opensearch.timeseries.TimeSeriesAnalyticsPlugin;
 import org.opensearch.timeseries.constant.CommonName;
+import org.opensearch.timeseries.model.Config;
 import org.opensearch.timeseries.model.Entity;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
+import org.opensearch.timeseries.model.PPLSource;
 import org.opensearch.timeseries.settings.TimeSeriesSettings;
 import org.opensearch.timeseries.util.SecurityClientUtil;
 import org.opensearch.transport.client.Client;
@@ -255,6 +258,112 @@ public class SearchFeatureDaoTests {
         verify(listener).onResponse(captor.capture());
         Optional<Long> result = captor.getValue();
         assertEquals(epochTime, result.get().longValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getFeaturesForPeriod_usesPPLRuntimeExecutor() {
+        PPLDirectQueryExecutor pplDirectQueryExecutor = mock(PPLDirectQueryExecutor.class);
+        SearchFeatureDao pplSearchFeatureDao = new SearchFeatureDao(
+            client,
+            xContent,
+            clientUtil,
+            null,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            clock,
+            1,
+            1,
+            60_000L,
+            pplDirectQueryExecutor
+        );
+        when(detector.getSourceType()).thenReturn(Config.SOURCE_TYPE_PPL);
+        when(detector.getPPLSource())
+            .thenReturn(
+                new PPLSource(
+                    "PPL",
+                    "source = sample-http-responses | where response_category = 'client_error' | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket"
+                )
+            );
+        when(detector.getEnabledFeatureIds()).thenReturn(Arrays.asList("f1", "f2"));
+
+        long start = 100L;
+        long end = 200L;
+        doAnswer(invocation -> {
+            ActionListener<Optional<double[]>> listener = invocation.getArgument(4);
+            listener.onResponse(Optional.of(new double[] { 42.0, 7.0 }));
+            return null;
+        })
+            .when(pplDirectQueryExecutor)
+            .executeMetricQuery(eq(detector), eq(start), eq(end), eq(AnalysisType.AD), any(ActionListener.class));
+
+        ActionListener<Optional<double[]>> listener = mock(ActionListener.class);
+        pplSearchFeatureDao.getFeaturesForPeriod(detector, start, end, listener);
+
+        ArgumentCaptor<Optional<double[]>> captor = ArgumentCaptor.forClass(Optional.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().isPresent());
+        assertEquals(42.0, captor.getValue().get()[0], 0.001);
+        assertEquals(7.0, captor.getValue().get()[1], 0.001);
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getFeatureSamplesForPeriods_usesPPLRuntimeExecutor() throws Exception {
+        PPLDirectQueryExecutor pplDirectQueryExecutor = mock(PPLDirectQueryExecutor.class);
+        SearchFeatureDao pplSearchFeatureDao = new SearchFeatureDao(
+            client,
+            xContent,
+            clientUtil,
+            null,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            clock,
+            1,
+            1,
+            60_000L,
+            pplDirectQueryExecutor
+        );
+        when(detector.getSourceType()).thenReturn(Config.SOURCE_TYPE_PPL);
+        when(detector.getPPLSource())
+            .thenReturn(
+                new PPLSource(
+                    "PPL",
+                    "source = sample-http-responses | where response_category = 'client_error' | stats sum(http_4xx) as sum_http_4xx, max(http_5xx) as max_http_5xx by span(timestamp, 10m) as bucket"
+                )
+            );
+        when(detector.getEnabledFeatureIds()).thenReturn(Arrays.asList("f1", "f2"));
+
+        doAnswer(invocation -> {
+            long startTime = invocation.getArgument(1);
+            ActionListener<Optional<double[]>> listener = invocation.getArgument(4);
+            if (startTime == 100L) {
+                listener.onResponse(Optional.of(new double[] { 3.0, 5.0 }));
+            } else {
+                listener.onResponse(Optional.empty());
+            }
+            return null;
+        })
+            .when(pplDirectQueryExecutor)
+            .executeMetricQuery(eq(detector), any(Long.class), any(Long.class), eq(AnalysisType.AD), any(ActionListener.class));
+
+        ActionListener<List<Optional<double[]>>> listener = mock(ActionListener.class);
+        List<Map.Entry<Long, Long>> ranges = Arrays
+            .asList(
+                new java.util.AbstractMap.SimpleImmutableEntry<>(100L, 200L),
+                new java.util.AbstractMap.SimpleImmutableEntry<>(200L, 300L)
+            );
+        pplSearchFeatureDao.getFeatureSamplesForPeriods(detector, ranges, AnalysisType.AD, true, listener);
+
+        ArgumentCaptor<List<Optional<double[]>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(2, captor.getValue().size());
+        assertTrue(captor.getValue().get(0).isPresent());
+        assertEquals(3.0, captor.getValue().get(0).get()[0], 0.001);
+        assertEquals(5.0, captor.getValue().get(0).get()[1], 0.001);
+        assertTrue(captor.getValue().get(1).isPresent());
+        assertTrue(Double.isNaN(captor.getValue().get(1).get()[0]));
+        assertTrue(Double.isNaN(captor.getValue().get(1).get()[1]));
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
     }
 
     @Test

--- a/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/SearchFeatureDaoTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -363,6 +364,82 @@ public class SearchFeatureDaoTests {
         assertTrue(captor.getValue().get(1).isPresent());
         assertTrue(Double.isNaN(captor.getValue().get(1).get()[0]));
         assertTrue(Double.isNaN(captor.getValue().get(1).get()[1]));
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getFeaturesForPeriodByBatch_usesPPLRuntimeExecutorForSingleStream() throws Exception {
+        PPLDirectQueryExecutor pplDirectQueryExecutor = mock(PPLDirectQueryExecutor.class);
+        SearchFeatureDao pplSearchFeatureDao = new SearchFeatureDao(
+            client,
+            xContent,
+            clientUtil,
+            null,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            clock,
+            1,
+            1,
+            60_000L,
+            pplDirectQueryExecutor
+        );
+        when(detector.getSourceType()).thenReturn(Config.SOURCE_TYPE_PPL);
+        when(detector.getPPLSource())
+            .thenReturn(
+                new PPLSource(
+                    "PPL",
+                    "source = sample-http-responses | stats count() as doc_count, sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket"
+                )
+            );
+
+        Map<Long, Optional<double[]>> response = new HashMap<>();
+        response.put(100L, Optional.of(new double[] { 4.0, 5.0 }));
+        doAnswer(invocation -> {
+            ActionListener<Map<Long, Optional<double[]>>> listener = invocation.getArgument(4);
+            listener.onResponse(response);
+            return null;
+        })
+            .when(pplDirectQueryExecutor)
+            .executeMetricQueryBySpan(eq(detector), eq(100L), eq(200L), eq(AnalysisType.AD), any(ActionListener.class));
+
+        ActionListener<Map<Long, Optional<double[]>>> listener = mock(ActionListener.class);
+        pplSearchFeatureDao.getFeaturesForPeriodByBatch(detector, null, 100L, 200L, listener);
+
+        verify(listener).onResponse(response);
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getFeaturesForPeriodByBatch_rejectsPPLRuntimeExecutorForEntity() throws Exception {
+        PPLDirectQueryExecutor pplDirectQueryExecutor = mock(PPLDirectQueryExecutor.class);
+        SearchFeatureDao pplSearchFeatureDao = new SearchFeatureDao(
+            client,
+            xContent,
+            clientUtil,
+            null,
+            TimeSeriesSettings.NUM_SAMPLES_PER_TREE,
+            clock,
+            1,
+            1,
+            60_000L,
+            pplDirectQueryExecutor
+        );
+        when(detector.getSourceType()).thenReturn(Config.SOURCE_TYPE_PPL);
+        when(detector.getPPLSource())
+            .thenReturn(
+                new PPLSource("PPL", "source = sample-http-responses | stats count() as doc_count by span(timestamp, 10m) as bucket")
+            );
+
+        ActionListener<Map<Long, Optional<double[]>>> listener = mock(ActionListener.class);
+        pplSearchFeatureDao
+            .getFeaturesForPeriodByBatch(detector, Entity.createSingleAttributeEntity("service", "checkout"), 100L, 200L, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("PPL source_type only supports single-stream detectors."));
+        verify(pplDirectQueryExecutor, never())
+            .executeMetricQueryBySpan(any(Config.class), anyLong(), anyLong(), any(AnalysisType.class), any(ActionListener.class));
         verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
     }
 

--- a/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
+++ b/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.model;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class PPLSourceTests extends OpenSearchTestCase {
+
+    public void testCompileSupportsCountAndPreservesPreStatsPipeline() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = sample-http-responses | eval error_code = status_code | where error_code >= 400 | stats count() as error_count, sum(http_5xx) as sum_http_5xx by span(timestamp, 60m) as bucket | sort bucket asc"
+            );
+
+        assertEquals("sample-http-responses", compiledQuery.getIndex());
+        assertEquals(2, compiledQuery.getPreStatsStages().size());
+        assertEquals("eval error_code = status_code", compiledQuery.getPreStatsStages().get(0));
+        assertEquals("where error_code >= 400", compiledQuery.getPreStatsStages().get(1));
+        assertEquals("timestamp", compiledQuery.getTimeField());
+        assertEquals(2, compiledQuery.getMetricCount());
+        assertEquals("error_count", compiledQuery.getFeatureNames().get(0));
+        assertEquals("sum_http_5xx", compiledQuery.getFeatureNames().get(1));
+        assertEquals(60L, compiledQuery.getInterval().getInterval());
+        assertEquals(java.time.temporal.ChronoUnit.MINUTES, compiledQuery.getInterval().getUnit());
+
+        String metricQuery = compiledQuery.buildMetricQueryForRange(1_000L, 2_000L);
+        assertTrue(metricQuery.startsWith("source = sample-http-responses | eval error_code = status_code | where error_code >= 400"));
+        assertTrue(metricQuery.contains("| where timestamp >= \"1970-01-01 00:00:01.000\" and timestamp < \"1970-01-01 00:00:02.000\""));
+        assertTrue(metricQuery.endsWith("| stats count() as error_count, sum(http_5xx) as sum_http_5xx"));
+    }
+
+    public void testCompileSupportsCountStarAndDerivedMetricExpressions() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = logs-* | where status >= 400 | stats count(*) as doc_count, avg(bytes / 1024) as avg_kb by span(`event.time`, 10m) as bucket"
+            );
+
+        assertEquals("logs-*", compiledQuery.getIndex());
+        assertEquals("event.time", compiledQuery.getTimeField());
+        assertEquals(2, compiledQuery.getMetricCount());
+        assertEquals("doc_count", compiledQuery.getFeatureNames().get(0));
+        assertEquals("avg_kb", compiledQuery.getFeatureNames().get(1));
+
+        String metricQuery = compiledQuery.buildMetricQueryForRange(60_000L, 120_000L);
+        assertTrue(metricQuery.contains("| stats count() as doc_count, avg(bytes / 1024) as avg_kb"));
+        assertTrue(metricQuery.contains("event.time >= \"1970-01-01 00:01:00.000\" and event.time < \"1970-01-01 00:02:00.000\""));
+    }
+
+    public void testCompileSupportsCountFieldAndQuotedIdentifiers() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = `logs-2026` | where `service.name` = 'checkout' | stats count(`error.code`) as error_code_count by span(`@timestamp`, 5m)"
+            );
+
+        assertEquals("logs-2026", compiledQuery.getIndex());
+        assertEquals("@timestamp", compiledQuery.getTimeField());
+        assertEquals(1, compiledQuery.getMetricCount());
+        assertEquals("error_code_count", compiledQuery.getFeatureNames().get(0));
+
+        String metricQuery = compiledQuery.buildMetricQueryForRange(300_000L, 600_000L);
+        assertTrue(metricQuery.contains("| stats count(`error.code`) as error_code_count"));
+        assertTrue(metricQuery.contains("`@timestamp` >= \"1970-01-01 00:05:00.000\" and `@timestamp` < \"1970-01-01 00:10:00.000\""));
+    }
+
+    public void testCompilePreservesDerivedTimeFieldForAuxiliaryQueries() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile("source = logs | eval bucket_time = @timestamp | stats count() as error_count by span(bucket_time, 10m)");
+
+        assertEquals(
+            "source = logs | eval bucket_time = @timestamp | stats max(bucket_time) as latest_time",
+            compiledQuery.buildLatestTimeQuery()
+        );
+        assertEquals(
+            "source = logs | eval bucket_time = @timestamp | stats min(bucket_time) as min_time",
+            compiledQuery.buildMinTimeQuery()
+        );
+        assertEquals(
+            "source = logs | eval bucket_time = @timestamp | stats min(bucket_time) as min_time, max(bucket_time) as max_time",
+            compiledQuery.buildDateRangeQuery()
+        );
+    }
+
+    public void testCompileRejectsDuplicateMetricAliases() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats count() as dup, sum(bytes) as dup by span(timestamp, 10m)")
+        );
+        assertTrue(exception.getMessage().contains("Duplicate metric alias [dup]"));
+    }
+
+    public void testCompileRejectsNonSortStageAfterFinalStats() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats count() as error_count by span(timestamp, 10m) | head 5")
+        );
+        assertTrue(exception.getMessage().contains("after the final stats stage"));
+    }
+
+    public void testCompileRejectsUnsupportedPreStatsStage() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | head 5 | stats count() as error_count by span(timestamp, 10m)")
+        );
+        assertTrue(exception.getMessage().contains("before the final stats stage"));
+        assertTrue(exception.getMessage().contains("where and eval"));
+    }
+}

--- a/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
+++ b/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
@@ -11,6 +11,9 @@
 
 package org.opensearch.timeseries.model;
 
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
 import org.opensearch.test.OpenSearchTestCase;
 
 public class PPLSourceTests extends OpenSearchTestCase {
@@ -112,5 +115,97 @@ public class PPLSourceTests extends OpenSearchTestCase {
         );
         assertTrue(exception.getMessage().contains("before the final stats stage"));
         assertTrue(exception.getMessage().contains("where and eval"));
+    }
+
+    public void testCompileUsesDefaultFeatureNamesAndPlaceholderFeatures() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile("source = logs | stats count(*), max(bytes), min(bytes), avg(bytes), sum(bytes) by span(timestamp, 30s)");
+
+        assertEquals("count_all", compiledQuery.getFeatureNames().get(0));
+        assertEquals("max_bytes", compiledQuery.getFeatureNames().get(1));
+        assertEquals("min_bytes", compiledQuery.getFeatureNames().get(2));
+        assertEquals("avg_bytes", compiledQuery.getFeatureNames().get(3));
+        assertEquals("sum_bytes", compiledQuery.getFeatureNames().get(4));
+        assertEquals(30L, compiledQuery.getInterval().getInterval());
+        assertEquals(ChronoUnit.SECONDS, compiledQuery.getInterval().getUnit());
+
+        List<Feature> features = compiledQuery.toPlaceholderFeatures();
+        assertEquals(5, features.size());
+        assertEquals("count_all", features.get(0).getName());
+        assertTrue(features.get(0).getEnabled());
+        assertTrue(features.get(0).usesDirectQueryPlaceholderAggregation());
+    }
+
+    public void testCompileKeepsPipesAndCommasInsideQuotedPreStatsStages() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = logs | where message = 'a|b,c' | eval normalized = concat(\"x,y\", `service|name`) | stats count() by span(timestamp, 1m)"
+            );
+
+        assertEquals(2, compiledQuery.getPreStatsStages().size());
+        assertEquals("where message = 'a|b,c'", compiledQuery.getPreStatsStages().get(0));
+        assertEquals("eval normalized = concat(\"x,y\", `service|name`)", compiledQuery.getPreStatsStages().get(1));
+    }
+
+    public void testCompileRejectsBlankQuery() {
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> PPLSource.compile(" "));
+        assertTrue(exception.getMessage().contains("ppl_source.query must be set"));
+    }
+
+    public void testCompileRejectsMissingSourceStage() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("stats count() by span(timestamp, 1m)")
+        );
+        assertTrue(exception.getMessage().contains("starts with source"));
+    }
+
+    public void testCompileRejectsMultipleSourceReferences() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs-a,logs-b | stats count() by span(timestamp, 1m)")
+        );
+        assertTrue(exception.getMessage().contains("exactly one index"));
+    }
+
+    public void testCompileRejectsSourceStageBeforeStats() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs-a | source = logs-b | stats count() by span(timestamp, 1m)")
+        );
+        assertTrue(exception.getMessage().contains("exactly one source stage"));
+    }
+
+    public void testCompileRejectsMultipleStatsStages() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats count() by span(timestamp, 1m) | stats count() by span(timestamp, 1m)")
+        );
+        assertTrue(exception.getMessage().contains("Only one final stats stage"));
+    }
+
+    public void testCompileRejectsUnsupportedAggregation() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats median(bytes) as median_bytes by span(timestamp, 1m)")
+        );
+        assertTrue(exception.getMessage().contains("Unsupported aggregation [median]"));
+    }
+
+    public void testCompileRejectsEmptyNonCountAggregationArgument() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> PPLSource.compile("source = logs | stats sum() as sum_value by span(timestamp, 1m)")
+        );
+        assertTrue(exception.getMessage().contains("arguments cannot be empty"));
+    }
+
+    public void testCompileRejectsInvalidSpanClauses() {
+        expectThrows(IllegalArgumentException.class, () -> PPLSource.compile("source = logs | stats count() by timestamp"));
+        expectThrows(IllegalArgumentException.class, () -> PPLSource.compile("source = logs | stats count() by span(timestamp)"));
+        expectThrows(IllegalArgumentException.class, () -> PPLSource.compile("source = logs | stats count() by span(timestamp, 0m)"));
+        expectThrows(IllegalArgumentException.class, () -> PPLSource.compile("source = logs | stats count() by span(timestamp, 1h)"));
+        expectThrows(IllegalArgumentException.class, () -> PPLSource.compile("source = logs | stats count() by span(event time, 1m)"));
+        expectThrows(IllegalArgumentException.class, () -> PPLSource.compile("source = logs | stats count() by span(timestamp, 1m) as"));
     }
 }

--- a/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
+++ b/src/test/java/org/opensearch/timeseries/model/PPLSourceTests.java
@@ -58,6 +58,20 @@ public class PPLSourceTests extends OpenSearchTestCase {
         assertTrue(metricQuery.contains("event.time >= \"1970-01-01 00:01:00.000\" and event.time < \"1970-01-01 00:02:00.000\""));
     }
 
+    public void testBuildMetricQueryForRangeBySpanPreservesDetectorSpan() {
+        PPLSource.CompiledPPLQuery compiledQuery = PPLSource
+            .compile(
+                "source = sample-http-responses | where http_4xx >= 0 | stats count() as doc_count, sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket"
+            );
+
+        String batchQuery = compiledQuery.buildMetricQueryForRangeBySpan(1_000L, 2_000L);
+
+        assertEquals(
+            "source = sample-http-responses | where http_4xx >= 0 | where timestamp >= \"1970-01-01 00:00:01.000\" and timestamp < \"1970-01-01 00:00:02.000\" | stats count() as doc_count, sum(http_4xx) as sum_http_4xx by span(timestamp, 10m) as bucket | sort bucket asc",
+            batchQuery
+        );
+    }
+
     public void testCompileSupportsCountFieldAndQuotedIdentifiers() {
         PPLSource.CompiledPPLQuery compiledQuery = PPLSource
             .compile(


### PR DESCRIPTION
## Summary
- Add PPL as a single-stream detector source type 
- Compile supported PPL detector queries into detector metadata and execute runtime feature queries through the PPL transport action
- Support PPL-backed realtime, preview/cold-start, and historical batch feature retrieval for single-stream detectors
- Keep entity/HC PPL detector paths explicitly unsupported
- Add PPL create/preview/start validation and focused model/executor/DAO/REST coverage

## Testing
```
// preview detector
POST /_plugins/_anomaly_detection/detectors/_preview
{
  "period_start": 1768607344376,
  "period_end": 1771026484376,
  "detector": {
    "name": "preview-ppl-devtools",
    "source_type": "PPL",
    "ppl_source": {
      "query_language": "PPL",
      "query": "source = sample-http-responses | where http_4xx >= 0 | eval total_errors = http_4xx + http_5xx | stats count() as doc_count, sum(http_4xx) as sum_http_4xx, avg(total_errors) as avg_total_errors by span(timestamp, 10m) as bucket"
    },
    "window_delay": {
      "period": {
        "interval": 1,
        "unit": "Minutes"
      }
    }
  }
}

// create detector
POST /_plugins/_anomaly_detection/detectors?refresh=true
{
  "name": "ppl-devtools-detector",
  "description": "Verify PPL-backed detector creation from Dev Tools",
  "source_type": "PPL",
  "ppl_source": {
    "query_language": "PPL",
    "query": "source = sample-http-responses | where http_4xx >= 0 | eval total_errors = http_4xx + http_5xx | stats count() as doc_count, sum(http_4xx) as sum_http_4xx, avg(total_errors) as avg_total_errors by span(timestamp, 10m) as bucket"
  },
  "window_delay": {
    "period": {
      "interval": 1,
      "unit": "Minutes"
    }
  }
}

// get detector
GET /_plugins/_anomaly_detection/detectors/zSvxhJ4BbHLYr7yZHM3d
// start detector
POST /_plugins/_anomaly_detection/detectors/zSvxhJ4BbHLYr7yZHM3d/_start
// start historical
POST /_plugins/_anomaly_detection/detectors/zSvxhJ4BbHLYr7yZHM3d/_start?historical=true
{
  "start_time": 1451606400000,
  "end_time": 1772236800000
}
```