### PR TITLE
Add issues write permission to untriaged label workflow

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -7,6 +7,9 @@ on:
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
+permissions:
+  issues: write
+
 jobs:
   apply-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -14,7 +14,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
### Description
Add `permissions: issues: write` to the `add-untriaged.yml` workflow to fix 403 "Resource not accessible by integration" error when applying the 'untriaged' label to issues.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
