### PR TITLE
Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
     }
@@ -129,6 +130,7 @@ apply plugin: 'opensearch.java'
 repositories {
     mavenLocal()
     maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url = "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url = "https://plugins.gradle.org/m2/" }
     maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,12 @@
  * GitHub history for details.
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-anomaly-detection'


### PR DESCRIPTION
### Description

Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins, such as integration tests run against release candidates during the release process.

### Changes
- `settings.gradle` — Add `pluginManagement` block with CI mirror before Gradle Plugin Portal and Maven Central
- `build.gradle` — Add CI mirror before Maven Central for dependency resolution

### Testing
- Verified `./gradlew assemble` completes successfully
- Ran `git diff --check`