### PR TITLE
Fix AD CVEs on 2.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
         bwcFilePath = "src/test/resources/org/opensearch/ad/bwc/"
         bwcJobSchedulerPath = bwcFilePath + "job-scheduler/"
         bwcAnomalyDetectionPath = bwcFilePath + "anomaly-detection/"
-        jacksonVersion = "2.18.2"
+        jacksonVersion = "2.18.6"
         // gradle build won't print logs during test by default unless there is a failure.
         // It is useful to record intermediately information like prediction precision and recall.
         // This option turn on log printing during tests. 

--- a/dataGeneration/requirements.txt
+++ b/dataGeneration/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.32.4
+requests>=2.33.0
 numpy==1.26.4
 opensearch_py==3.0.0
 retry==0.9.2


### PR DESCRIPTION
### Description
Updates vulnerable dependencies on the 2.19 branch for the anomaly-detection plugin.

- Bump Jackson dependencies from 2.18.2 to 2.18.6 to address GHSA-72hv-8253-57qq for jackson-core.
- Bump the data generation Requests requirement from >=2.32.4 to >=2.33.0 to address CVE-2026-25645.

### Validation
- ./gradlew --no-daemon dependencyInsight --configuration runtimeClasspath --dependency jackson-core
- git diff --check

Resolved jackson-core as 2.18.6 (forced).