### PR TITLE
[Backport 2.19] Bump requests from >=2.32.4 to >=2.33.0

### DIFF
--- a/dataGeneration/requirements.txt
+++ b/dataGeneration/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.32.4
+requests>=2.33.0
 numpy==1.26.4
 opensearch_py==3.0.0
 retry==0.9.2


### PR DESCRIPTION
### Description
Backport of #1713. Bump `requests` from >=2.32.4 to >=2.33.0 to address CVE-2026-25645 (versions <2.33.0 are
  vulnerable).


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
