### PR TITLE
Bump urllib3 floor and align PPL request format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add runtime PPL-backed anomaly detector source support ([#1718](https://github.com/opensearch-project/anomaly-detection/pull/1718))
 ### Enhancements
 ### Bug Fixes
+- Keep PPL direct query transport serialization compatible with current SQL plugin request format ([#1756](https://github.com/opensearch-project/anomaly-detection/pull/1756))
 ### Infrastructure
 ### Documentation
 ### Maintenance
 ### Security
+- Bump urllib3 floor to 2.7.0 to address CVE-2026-44431 and CVE-2026-44432 ([#1756](https://github.com/opensearch-project/anomaly-detection/pull/1756))
 ### Refactoring

--- a/dataGeneration/requirements.txt
+++ b/dataGeneration/requirements.txt
@@ -4,4 +4,4 @@ numpy==1.26.4
 opensearch_py==3.1.0
 retry2==0.9.2
 scipy==1.16.1
-urllib3>=2.6.3
+urllib3>=2.7.0

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -350,6 +350,7 @@ public class PPLDirectQueryExecutor {
         private final String path;
         private final boolean sanitize;
         private final boolean profile;
+        private final boolean analyze;
         private final String queryId;
 
         private PPLTransportRequest(String query, String format, String path) {
@@ -360,6 +361,7 @@ public class PPLDirectQueryExecutor {
             this.path = path;
             this.sanitize = true;
             this.profile = false;
+            this.analyze = false;
             this.queryId = null;
         }
 
@@ -373,6 +375,7 @@ public class PPLDirectQueryExecutor {
             this.sanitize = in.readBoolean();
             in.readEnum(PPLJsonStyle.class);
             this.profile = in.readBoolean();
+            this.analyze = in.readBoolean();
             this.queryId = in.readOptionalString();
         }
 
@@ -392,6 +395,7 @@ public class PPLDirectQueryExecutor {
             out.writeBoolean(sanitize);
             out.writeEnum(PPLJsonStyle.COMPACT);
             out.writeBoolean(profile);
+            out.writeBoolean(analyze);
             out.writeOptionalString(queryId);
         }
 

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorIT.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorIT.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.timeseries.feature;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Constructor;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class PPLDirectQueryExecutorIT extends OpenSearchTestCase {
+
+    public void testPPLTransportRequestRoundTripsThroughStreamConstructor() throws Exception {
+        ActionRequest request = newPPLTransportRequest(
+            "source = logs | stats count() as count by span(timestamp, 1m) as bucket",
+            "jdbc",
+            "/_plugins/_ppl"
+        );
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (OutputStreamStreamOutput output = new OutputStreamStreamOutput(baos)) {
+            request.writeTo(output);
+        }
+        try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+            Object roundTrippedRequest = pplTransportRequestStreamConstructor().newInstance(input);
+            assertEquals(readPrivateField(request, "query"), readPrivateField(roundTrippedRequest, "query"));
+            assertEquals(readPrivateField(request, "format"), readPrivateField(roundTrippedRequest, "format"));
+            assertNull(readPrivateField(roundTrippedRequest, "explainMode"));
+            assertNull(readPrivateField(roundTrippedRequest, "jsonContent"));
+            assertEquals(readPrivateField(request, "path"), readPrivateField(roundTrippedRequest, "path"));
+            assertTrue((Boolean) readPrivateField(roundTrippedRequest, "sanitize"));
+            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "profile"));
+            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "analyze"));
+            assertNull(readPrivateField(roundTrippedRequest, "queryId"));
+        }
+    }
+
+    private static ActionRequest newPPLTransportRequest(String query, String format, String path) throws Exception {
+        return (ActionRequest) pplTransportRequestConstructor().newInstance(query, format, path);
+    }
+
+    private static Constructor<?> pplTransportRequestConstructor() throws Exception {
+        Constructor<?> constructor = pplTransportRequestClass().getDeclaredConstructor(String.class, String.class, String.class);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+
+    private static Constructor<?> pplTransportRequestStreamConstructor() throws Exception {
+        Constructor<?> constructor = pplTransportRequestClass().getDeclaredConstructor(StreamInput.class);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+
+    private static Class<?> pplTransportRequestClass() throws ClassNotFoundException {
+        return Class.forName("org.opensearch.timeseries.feature.PPLDirectQueryExecutor$PPLTransportRequest");
+    }
+
+    private static Object readPrivateField(Object target, String fieldName) throws Exception {
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -294,6 +294,7 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
             assertEquals(readPrivateField(request, "path"), readPrivateField(roundTrippedRequest, "path"));
             assertTrue((Boolean) readPrivateField(roundTrippedRequest, "sanitize"));
             assertFalse((Boolean) readPrivateField(roundTrippedRequest, "profile"));
+            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "analyze"));
             assertNull(readPrivateField(roundTrippedRequest, "queryId"));
         }
     }


### PR DESCRIPTION
## Summary
- Bumps the data generation `urllib3` lower bound from `2.6.3` to `2.7.0`.
- Addresses the current urllib3 advisories CVE-2026-44431 / GHSA-qccp-gfcp-xxvc and CVE-2026-44432 / GHSA-mf9v-mfxr-j63j.
- Confirms the Anomaly Detection OS plugin Gradle runtime/test dependency graph does not report OSV findings on the 3.8 branch.
- Aligns the PPL direct-query transport request serialization with the current SQL plugin request format used by CI snapshots.
- Adds integration-scope serialization coverage for the PPL request wire format so the `plugin_integtest` coverage gate remains green.

## Root cause
The 3.8 branch already has current Java dependency pins, but `dataGeneration/requirements.txt` still allowed `urllib3==2.6.3`. GitHub Advisory Database marks `urllib3` versions below `2.7.0` as affected for CVE-2026-44431 and CVE-2026-44432.

The initial CI failure was separate from the Python dependency bump. CI pulled a newer SQL plugin snapshot whose `TransportPPLQueryRequest` includes an `analyze` boolean between `profile` and `queryId`. AD has a local request class for direct PPL execution; the older wire format made SQL parse the query-id optional marker as `analyze` and then hit EOF while reading `queryId`, producing `failed to parse ActionRequest into TransportPPLQueryRequest` in PPL-backed detector tests.

## Validation
- OSV batch query for resolved Maven `runtimeClasspath` and `testRuntimeClasspath`: 0 findings
- OSV batch query for `dataGeneration/requirements.txt`: 0 findings after the bump
- `gh api /repos/opensearch-project/anomaly-detection/dependabot/alerts?state=open`: 0 open alerts
- `./gradlew precommit --console=plain`
- `./gradlew test --tests 'org.opensearch.timeseries.feature.PPLDirectQueryExecutorTests' --console=plain`
- `./gradlew ':integTest' --tests 'org.opensearch.timeseries.feature.PPLDirectQueryExecutorIT' -Dtests.security.manager=false -Druntime.java=21 --console=plain`
- `./gradlew jacocoIntegTestReport -x integTest --console=plain` and confirmed the added `analyze` serialization lines are covered in the integration JaCoCo XML
- `./gradlew ':integTest' --tests 'org.opensearch.ad.rest.AnomalyDetectorRestApiIT.testPreviewPPLAnomalyDetectorWithoutExplicitDetectionInterval' ... -Druntime.java=21`
- `./gradlew ':integTest' --tests 'org.opensearch.ad.rest.AnomalyDetectorRestApiIT.testCreateStartAndProfilePPLAnomalyDetectorWithoutExplicitDetectionInterval' ... -Druntime.java=21`
- `./gradlew ':integTest' --tests 'org.opensearch.ad.rest.SecureADRestIT.testPreviewInlinePPLAnomalyDetector' -Dsecurity=true -Dhttps=true ... -Druntime.java=21`
- `./gradlew ':integTest' --tests 'org.opensearch.ad.rest.SecureADRestIT.testPreviewInlinePPLAnomalyDetector' -Dsecurity=true -Dhttps=true -Dresource_sharing.enabled=true ... -Druntime.java=21`

## Note
A Python requirements dry-run is blocked before and after this change by an existing resolver issue: `retry2==0.9.2` is not available from the configured PyPI index. That is unrelated to the urllib3 CVE fix.
