### PR TITLE
[Backport 2.19] Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (anomaly-detection)

### DIFF
--- a/.github/workflows/test_build_multi_platform.yml
+++ b/.github/workflows/test_build_multi_platform.yml
@@ -29,6 +29,7 @@ jobs:
   Build-ad-windows:
     needs: spotless
     strategy:
+      fail-fast: false
       matrix:
         java: [ 11, 17, 21 ]
     name: Build and Test Anomaly Detection Plugin on Windows
@@ -46,7 +47,7 @@ jobs:
 
       - name: Build and Run Tests
         run: |
-          ./gradlew build -x spotlessJava
+          ./gradlew build
       - name: Publish to Maven Local
         run: |
           ./gradlew publishToMavenLocal
@@ -88,7 +89,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew assemble &&
-                               ./gradlew build -x spotlessJava &&
+                               ./gradlew build &&
                                ./gradlew publishToMavenLocal &&
                                ./gradlew integTest -PnumNodes=3"
 
@@ -119,7 +120,7 @@ jobs:
           ./gradlew assemble
       - name: Build and Run Tests
         run: |
-          ./gradlew build -x spotlessJava
+          ./gradlew build
       # coverage.gradle is only applied in single local node test
       - name: Upload Coverage Report
         uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,17 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
+        // Spotless 8.10.x requires a Java 17+ runtime to resolve its plugin. Only put it on the
+        // buildscript classpath on Java 17+ so the Java 11 CI matrix doesn't fail resolving it.
+        // The plugin is applied (also gated to Java 17+) further below only when available.
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+            classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
+        }
     }
 }
 
 plugins {
     id 'com.netflix.nebula.ospackage' version "11.5.0"
-    id "com.diffplug.spotless" version "6.25.0"
     id 'java-library'
     id 'org.gradle.test-retry' version '1.6.0'
 }
@@ -815,13 +820,30 @@ afterEvaluate {
     }
 }
 
+// Spotless 8.10.x (the pinned Eclipse-JDT toolchain) requires a Java 17+ runtime to even
+// resolve/apply its Gradle plugin. Skip it on older JDKs (e.g. the Java 11 CI matrix) so
+// non-spotless builds don't fail at configuration time. Formatting still runs on Java 17+.
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+apply plugin: "com.diffplug.spotless"
+
+// Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+// Gradle invocations (test, assemble) don't provision the formatter at configuration time.
+def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
 spotless {
     java {
         removeUnusedImports()
         importOrder 'java', 'javax', 'org', 'com'
 
-        eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
+        // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+        // formatter resolves from Maven Central through the mirror below instead of querying a
+        // P2 update site at configuration time. 4.29 keeps the formatting identical to the
+        // eclipse() default of the previous spotless 6.25.0 this branch used.
+        if (runningSpotlessTask) {
+            eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
+        }
     }
+}
 }
 
 // no need to validate pom, as we do not upload to maven/sonatype


### PR DESCRIPTION
Backport 2d3012be6fafe5e6d501f2da4047db0536035aee from #1772.