### PR TITLE
Advance to OpenSearch 3.9 and fix build and integration compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add runtime PPL-backed anomaly detector source support ([#1718](https://github.com/opensearch-project/anomaly-detection/pull/1718))
 ### Enhancements
 ### Bug Fixes
-- Align PPL transport requests with the SQL plugin's analyze and partial-result fields ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
+- Align PPL transport requests with the SQL plugin's analyze and partial-result fields ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))
 ### Infrastructure
-- Close regular and admin HTTPS test connections before shutting down REST clients to prevent selector assertions and thread leaks; provide valid timestamp mappings for featureless detector tests ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
+- Cover historical PPL analysis and verify serialized feature results in integration tests ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))
+- Close regular and admin HTTPS test connections before shutting down REST clients to prevent selector assertions and thread leaks; provide valid timestamp mappings for featureless detector tests ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))
 ### Documentation
 ### Maintenance
-- Increment version to 3.9.0-SNAPSHOT and declare the Jackson 2 core dependency required by PPL response parsing and Random Cut Forest serialization ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
+- Increment version to 3.9.0-SNAPSHOT and declare the Jackson 2 core dependency required by PPL response parsing and Random Cut Forest serialization ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))
 ### Security
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add runtime PPL-backed anomaly detector source support ([#1718](https://github.com/opensearch-project/anomaly-detection/pull/1718))
 ### Enhancements
 ### Bug Fixes
+- Align PPL transport requests with the SQL plugin's analyze and partial-result fields ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Increment version to 3.9.0-SNAPSHOT and declare the Jackson 2 core dependency required by PPL response parsing and Random Cut Forest serialization ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
 ### Security
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Align PPL transport requests with the SQL plugin's analyze and partial-result fields ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
 ### Infrastructure
+- Close HTTPS test connections before shutting down REST clients to prevent selector assertions and thread leaks ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
 ### Documentation
 ### Maintenance
 - Increment version to 3.9.0-SNAPSHOT and declare the Jackson 2 core dependency required by PPL response parsing and Random Cut Forest serialization ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add runtime PPL-backed anomaly detector source support ([#1718](https://github.com/opensearch-project/anomaly-detection/pull/1718))
 ### Enhancements
 ### Bug Fixes
+- Return detector statistics when the detector-type field is unmapped instead of failing with an aggregation cast error ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))
 - Align PPL transport requests with the SQL plugin's analyze and partial-result fields ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))
 ### Infrastructure
 - Cover historical PPL analysis and verify serialized feature results in integration tests ([#1775](https://github.com/opensearch-project/anomaly-detection/pull/1775))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Align PPL transport requests with the SQL plugin's analyze and partial-result fields ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
 ### Infrastructure
-- Close HTTPS test connections before shutting down REST clients to prevent selector assertions and thread leaks ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
+- Close regular and admin HTTPS test connections before shutting down REST clients to prevent selector assertions and thread leaks; provide valid timestamp mappings for featureless detector tests ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))
 ### Documentation
 ### Maintenance
 - Increment version to 3.9.0-SNAPSHOT and declare the Jackson 2 core dependency required by PPL response parsing and Random Cut Forest serialization ([#1760](https://github.com/opensearch-project/anomaly-detection/pull/1760))

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     ext {
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.8.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.9.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')

--- a/build.gradle
+++ b/build.gradle
@@ -165,9 +165,10 @@ dependencies {
     implementation 'software.amazon.randomcutforest:randomcutforest-core:4.4.0'
 
 
-    // we inherit jackson-core from opensearch core
+    // OpenSearch provides Jackson 3 core.
     implementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
-    // randomforest still uses Jackson 2.x
+    // PPL response parsing and Random Cut Forest serialization still use Jackson 2.x.
+    implementation("com.fasterxml.jackson.core:jackson-core:${versions.jackson}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
 

--- a/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -11,8 +11,6 @@
 
 package org.opensearch.ad.transport;
 
-import java.util.List;
-
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.ad.constant.ADCommonName;
@@ -23,7 +21,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.search.aggregations.AggregationBuilders;
-import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.timeseries.stats.StatNames;
@@ -75,12 +73,11 @@ public class StatsAnomalyDetectorTransportAction extends BaseStatsTransportActio
                 .source(new SearchSourceBuilder().aggregation(termsAgg).size(0).trackTotalHits(true));
 
             client.search(request, ActionListener.wrap(r -> {
-                StringTerms aggregation = r.getAggregations().get(DETECTOR_TYPE_AGG);
-                List<StringTerms.Bucket> buckets = aggregation.getBuckets();
+                Terms aggregation = r.getAggregations().get(DETECTOR_TYPE_AGG);
                 long totalDetectors = r.getHits().getTotalHits().value();
                 long totalSingleEntityDetectors = 0;
                 long totalMultiEntityDetectors = 0;
-                for (StringTerms.Bucket b : buckets) {
+                for (Terms.Bucket b : aggregation.getBuckets()) {
                     if (AnomalyDetectorType.SINGLE_ENTITY.name().equals(b.getKeyAsString())
                         || AnomalyDetectorType.REALTIME_SINGLE_ENTITY.name().equals(b.getKeyAsString())
                         || AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name().equals(b.getKeyAsString())) {

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -342,6 +342,7 @@ public class PPLDirectQueryExecutor {
         COMPACT
     }
 
+    // Keep the wire format aligned with SQL's TransportPPLQueryRequest.
     private static final class PPLTransportRequest extends ActionRequest {
         private final String query;
         private final String format;
@@ -350,7 +351,9 @@ public class PPLDirectQueryExecutor {
         private final String path;
         private final boolean sanitize;
         private final boolean profile;
+        private final boolean analyze;
         private final String queryId;
+        private final Boolean partialResult;
 
         private PPLTransportRequest(String query, String format, String path) {
             this.query = query;
@@ -360,7 +363,9 @@ public class PPLDirectQueryExecutor {
             this.path = path;
             this.sanitize = true;
             this.profile = false;
+            this.analyze = false;
             this.queryId = null;
+            this.partialResult = null;
         }
 
         private PPLTransportRequest(StreamInput in) throws IOException {
@@ -373,7 +378,9 @@ public class PPLDirectQueryExecutor {
             this.sanitize = in.readBoolean();
             in.readEnum(PPLJsonStyle.class);
             this.profile = in.readBoolean();
+            this.analyze = in.readBoolean();
             this.queryId = in.readOptionalString();
+            this.partialResult = in.readOptionalBoolean();
         }
 
         @Override
@@ -392,7 +399,9 @@ public class PPLDirectQueryExecutor {
             out.writeBoolean(sanitize);
             out.writeEnum(PPLJsonStyle.COMPACT);
             out.writeBoolean(profile);
+            out.writeBoolean(analyze);
             out.writeOptionalString(queryId);
+            out.writeOptionalBoolean(partialResult);
         }
 
     }

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -342,7 +342,8 @@ public class PPLDirectQueryExecutor {
         COMPACT
     }
 
-    // Keep the wire format aligned with SQL's TransportPPLQueryRequest.
+    // Outbound-only adapter: SQL's TransportPPLQueryRequest reads these bytes on the receiving node.
+    // Keep the wire format aligned with that request.
     private static final class PPLTransportRequest extends ActionRequest {
         private final String query;
         private final String format;
@@ -366,21 +367,6 @@ public class PPLDirectQueryExecutor {
             this.analyze = false;
             this.queryId = null;
             this.partialResult = null;
-        }
-
-        private PPLTransportRequest(StreamInput in) throws IOException {
-            super(in);
-            this.query = in.readOptionalString();
-            this.format = in.readOptionalString();
-            this.explainMode = in.readOptionalString();
-            this.jsonContent = in.readOptionalString();
-            this.path = in.readOptionalString();
-            this.sanitize = in.readBoolean();
-            in.readEnum(PPLJsonStyle.class);
-            this.profile = in.readBoolean();
-            this.analyze = in.readBoolean();
-            this.queryId = in.readOptionalString();
-            this.partialResult = in.readOptionalBoolean();
         }
 
         @Override

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1338,6 +1338,73 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             });
     }
 
+    @SuppressWarnings("unchecked")
+    public void testHistoricalPPLAnomalyDetectorCompletesWithFeatureResults() throws Exception {
+        String indexName = createPPLRuntimeIndex("ppl-historical-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT), 100);
+        String query = "source = "
+            + indexName
+            + " | where service = 'checkout' | stats count() as doc_count, avg(metric_a) as avg_metric by span(timestamp, 1m) as bucket";
+        Response createResponse = TestHelpers
+            .makeRequest(
+                adminClient(),
+                "POST",
+                TestHelpers.AD_BASE_DETECTORS_URI,
+                ImmutableMap.of(),
+                TestHelpers.toHttpEntity(buildPPLDetectorBody("historical-ppl-detector", indexName, false, query)),
+                null
+            );
+        assertEquals(RestStatus.CREATED, TestHelpers.restStatus(createResponse));
+        String detectorId = (String) entityAsMap(createResponse).get("_id");
+        Instant endTime = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Response startResponse = startAnomalyDetector(
+            detectorId,
+            new DateRange(endTime.minus(100, ChronoUnit.MINUTES), endTime),
+            adminClient()
+        );
+        String taskId = (String) entityAsMap(startResponse).get("_id");
+        assertNotNull(taskId);
+
+        Awaitility
+            .await("historical PPL analysis to finish")
+            .pollInterval(Duration.ofSeconds(2))
+            .atMost(Duration.ofMinutes(2))
+            .untilAsserted(() -> {
+                Response detectorResponse = TestHelpers
+                    .makeRequest(
+                        adminClient(),
+                        "GET",
+                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId + "?task=true",
+                        ImmutableMap.of(),
+                        "",
+                        null
+                    );
+                Map<String, Object> task = (Map<String, Object>) entityAsMap(detectorResponse).get("historical_analysis_task");
+                assertNotNull(task);
+                assertEquals(task.toString(), "FINISHED", task.get("state"));
+
+                Response resultResponse = TestHelpers
+                    .makeRequest(
+                        adminClient(),
+                        "GET",
+                        TestHelpers.AD_BASE_RESULT_URI + "/_search",
+                        ImmutableMap.of(),
+                        TestHelpers.toHttpEntity("{\"query\":{\"term\":{\"task_id\":\"" + taskId + "\"}},\"size\":1}"),
+                        null
+                    );
+                Map<String, Object> hits = (Map<String, Object>) entityAsMap(resultResponse).get("hits");
+                List<Map<String, Object>> results = (List<Map<String, Object>>) hits.get("hits");
+                assertFalse(results.isEmpty());
+                Map<String, Object> result = (Map<String, Object>) results.get(0).get("_source");
+                List<Map<String, Object>> features = (List<Map<String, Object>>) result.get("feature_data");
+                assertEquals(2, features.size());
+                assertEquals("doc_count", features.get(0).get("feature_name"));
+                assertEquals("avg_metric", features.get(1).get("feature_name"));
+                assertEquals(1.0, ((Number) features.get(0).get("data")).doubleValue(), 0.0);
+                double average = ((Number) features.get(1).get("data")).doubleValue();
+                assertTrue(average >= 1.0 && average <= 9.0);
+            });
+    }
+
     public void testCreatePPLAnomalyDetectorRejectsUnsupportedPostStatsStage() throws Exception {
         String indexName = createPPLRuntimeIndex("ppl-invalid-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
         String query = "source = " + indexName + " | stats count() as doc_count by span(timestamp, 1m) | head 5";

--- a/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1812,7 +1812,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
     public void testStartAdjobWithNullFeatures() throws Exception {
         AnomalyDetector detectorWithoutFeature = TestHelpers.randomAnomalyDetector(null, null, Instant.now());
         String indexName = detectorWithoutFeature.getIndices().get(0);
-        TestHelpers.createIndex(client(), indexName, TestHelpers.toHttpEntity("{\"name\": \"test\"}"));
+        TestHelpers.createIndexWithTimeField(client(), indexName, detectorWithoutFeature.getTimeField());
         AnomalyDetector detector = createAnomalyDetector(detectorWithoutFeature, true, client());
         TestHelpers
             .assertFailWith(
@@ -1833,7 +1833,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
     public void testStartAdjobWithEmptyFeatures() throws Exception {
         AnomalyDetector detectorWithoutFeature = TestHelpers.randomAnomalyDetector(ImmutableList.of(), null, Instant.now());
         String indexName = detectorWithoutFeature.getIndices().get(0);
-        TestHelpers.createIndex(client(), indexName, TestHelpers.toHttpEntity("{\"name\": \"test\"}"));
+        TestHelpers.createIndexWithTimeField(client(), indexName, detectorWithoutFeature.getTimeField());
         AnomalyDetector detector = createAnomalyDetector(detectorWithoutFeature, true, client());
         TestHelpers
             .assertFailWith(

--- a/src/test/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.opensearch.ad.ADIntegTestCase;
+import org.opensearch.ad.constant.ADCommonName;
 import org.opensearch.timeseries.TestHelpers;
 import org.opensearch.timeseries.stats.InternalStatNames;
 import org.opensearch.timeseries.stats.StatNames;
@@ -87,6 +88,26 @@ public class StatsAnomalyDetectorTransportActionTests extends ADIntegTestCase {
         assertEquals(0, statsMap.size());
         assertEquals(2L, clusterStats.get(StatNames.DETECTOR_COUNT.getName()));
         assertFalse(clusterStats.containsKey(StatNames.SINGLE_STREAM_DETECTOR_COUNT.getName()));
+    }
+
+    public void testStatsAnomalyDetectorWithUnmappedDetectorType() {
+        assertTrue(deleteDetectorIndex().isAcknowledged());
+        createIndex(ADCommonName.CONFIG_INDEX, "{}");
+
+        StatsRequest request = new StatsRequest(clusterService().localNode());
+        request.addStat(StatNames.DETECTOR_COUNT.getName());
+        request.addStat(StatNames.SINGLE_STREAM_DETECTOR_COUNT.getName());
+        request.addStat(StatNames.HC_DETECTOR_COUNT.getName());
+        for (long expectedCount = 0; expectedCount <= 1; expectedCount++) {
+            if (expectedCount == 1) {
+                indexDoc(ADCommonName.CONFIG_INDEX, ImmutableMap.of("name", "legacy-detector"));
+            }
+            StatsTimeSeriesResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, request).actionGet(5_000);
+            Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
+            assertEquals(expectedCount, clusterStats.get(StatNames.DETECTOR_COUNT.getName()));
+            assertEquals(0L, clusterStats.get(StatNames.SINGLE_STREAM_DETECTOR_COUNT.getName()));
+            assertEquals(0L, clusterStats.get(StatNames.HC_DETECTOR_COUNT.getName()));
+        }
     }
 
     public void testStatsAnomalyDetectorWithSingleEntityDetectorCount() {

--- a/src/test/java/org/opensearch/timeseries/ODFERestTestCase.java
+++ b/src/test/java/org/opensearch/timeseries/ODFERestTestCase.java
@@ -78,7 +78,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.commons.rest.SecureRestClientBuilder;
+import org.opensearch.commons.rest.TrustStore;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaType;
@@ -155,7 +155,9 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
                     throw new RuntimeException(e);
                 }
                 Path configPath = PathUtils.get(uri).getParent().toAbsolutePath();
-                return new SecureRestClientBuilder(settings, configPath, hosts).build();
+                configureAdminHttpsClient(builder, settings, configPath);
+                builder.setStrictDeprecationMode(strictDeprecationMode);
+                return builder.build();
             } else {
                 configureHttpsClient(builder, settings);
                 builder.setStrictDeprecationMode(strictDeprecationMode);
@@ -236,14 +238,9 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
                         }
                     })
                     .build();
-                final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
-                    .create()
-                    .setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE)
-                    .setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
-                    .setTlsStrategy(tlsStrategy)
-                    .build();
-                HTTPS_CONNECTION_MANAGERS.add(connectionManager);
-                return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).setConnectionManager(connectionManager);
+                return httpClientBuilder
+                    .setDefaultCredentialsProvider(credentialsProvider)
+                    .setConnectionManager(createHttpsConnectionManager(tlsStrategy));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -261,6 +258,55 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
         if (settings.hasValue(CLIENT_PATH_PREFIX)) {
             builder.setPathPrefix(settings.get(CLIENT_PATH_PREFIX));
         }
+    }
+
+    private static void configureAdminHttpsClient(RestClientBuilder builder, Settings settings, Path configPath) throws IOException {
+        try {
+            char[] storePassword = settings.get(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD).toCharArray();
+            char[] keyPassword = settings.get(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD).toCharArray();
+            TlsStrategy tlsStrategy = ClientTlsStrategyBuilder
+                .create()
+                .setSslContext(
+                    SSLContextBuilder
+                        .create()
+                        .loadTrustMaterial(
+                            new TrustStore(configPath.resolve(settings.get(OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH)).toString())
+                                .create(),
+                            null
+                        )
+                        .loadKeyMaterial(
+                            configPath.resolve(settings.get(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH)).toFile(),
+                            storePassword,
+                            keyPassword
+                        )
+                        .build()
+                )
+                .build();
+            builder
+                .setHttpClientConfigCallback(
+                    httpClientBuilder -> httpClientBuilder.setConnectionManager(createHttpsConnectionManager(tlsStrategy))
+                );
+            builder
+                .setRequestConfigCallback(
+                    config -> config
+                        .setConnectTimeout(Timeout.ofSeconds(5))
+                        .setResponseTimeout(Timeout.ofSeconds(10))
+                        .setConnectionRequestTimeout(Timeout.ofMinutes(3))
+                );
+        } catch (Exception e) {
+            throw new IOException("Failed to configure the HTTPS admin client", e);
+        }
+    }
+
+    private static PoolingAsyncClientConnectionManager createHttpsConnectionManager(TlsStrategy tlsStrategy) {
+        PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
+            .create()
+            .setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE)
+            .setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
+            .setTlsStrategy(tlsStrategy)
+            .build();
+        HTTPS_CONNECTION_MANAGERS.add(connectionManager);
+        return connectionManager;
     }
 
     @AfterClass

--- a/src/test/java/org/opensearch/timeseries/ODFERestTestCase.java
+++ b/src/test/java/org/opensearch/timeseries/ODFERestTestCase.java
@@ -33,7 +33,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 import javax.management.MBeanServerInvocationHandler;
@@ -59,6 +61,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.util.Timeout;
@@ -93,6 +96,7 @@ import com.google.gson.JsonArray;
 public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
 
     private static final Logger LOG = (Logger) LogManager.getLogger(ODFERestTestCase.class);
+    private static final Queue<PoolingAsyncClientConnectionManager> HTTPS_CONNECTION_MANAGERS = new ConcurrentLinkedQueue<>();
 
     protected boolean isHttps() {
         return Optional.ofNullable(System.getProperty("https")).map("true"::equalsIgnoreCase).orElse(false);
@@ -238,6 +242,7 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
                     .setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
                     .setTlsStrategy(tlsStrategy)
                     .build();
+                HTTPS_CONNECTION_MANAGERS.add(connectionManager);
                 return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider).setConnectionManager(connectionManager);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -255,6 +260,16 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
         });
         if (settings.hasValue(CLIENT_PATH_PREFIX)) {
             builder.setPathPrefix(settings.get(CLIENT_PATH_PREFIX));
+        }
+    }
+
+    @AfterClass
+    public static void closeHttpsConnections() {
+        // Close TLS connections before OpenSearchRestTestCase.closeClients shuts down the HTTP reactors.
+        // Otherwise TLS shutdown can leave selected keys behind and fail the selector's close assertion.
+        PoolingAsyncClientConnectionManager connectionManager;
+        while ((connectionManager = HTTPS_CONNECTION_MANAGERS.poll()) != null) {
+            connectionManager.close(CloseMode.IMMEDIATE);
         }
     }
 

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -294,7 +294,10 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
             assertEquals(readPrivateField(request, "path"), readPrivateField(roundTrippedRequest, "path"));
             assertTrue((Boolean) readPrivateField(roundTrippedRequest, "sanitize"));
             assertFalse((Boolean) readPrivateField(roundTrippedRequest, "profile"));
+            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "analyze"));
             assertNull(readPrivateField(roundTrippedRequest, "queryId"));
+            assertNull(readPrivateField(roundTrippedRequest, "partialResult"));
+            assertEquals(-1, input.read());
         }
     }
 

--- a/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
+++ b/src/test/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutorTests.java
@@ -37,6 +37,7 @@ import org.opensearch.core.common.io.stream.InputStreamStreamInput;
 import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.tasks.TaskId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.timeseries.AnalysisType;
 import org.opensearch.timeseries.NodeStateManager;
@@ -274,7 +275,7 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
         assertSame(serializedResponse, directResponse);
     }
 
-    public void testPPLTransportRequestRoundTripsThroughStreamConstructor() throws Exception {
+    public void testPPLTransportRequestWritesSqlWireFormat() throws Exception {
         ActionRequest request = newPPLTransportRequest(
             "source = logs | stats count() as count by span(timestamp, 1m) as bucket",
             "jdbc",
@@ -286,17 +287,18 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
             request.writeTo(output);
         }
         try (InputStreamStreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
-            Object roundTrippedRequest = pplTransportRequestStreamConstructor().newInstance(input);
-            assertEquals(readPrivateField(request, "query"), readPrivateField(roundTrippedRequest, "query"));
-            assertEquals(readPrivateField(request, "format"), readPrivateField(roundTrippedRequest, "format"));
-            assertNull(readPrivateField(roundTrippedRequest, "explainMode"));
-            assertNull(readPrivateField(roundTrippedRequest, "jsonContent"));
-            assertEquals(readPrivateField(request, "path"), readPrivateField(roundTrippedRequest, "path"));
-            assertTrue((Boolean) readPrivateField(roundTrippedRequest, "sanitize"));
-            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "profile"));
-            assertFalse((Boolean) readPrivateField(roundTrippedRequest, "analyze"));
-            assertNull(readPrivateField(roundTrippedRequest, "queryId"));
-            assertNull(readPrivateField(roundTrippedRequest, "partialResult"));
+            assertEquals(request.getParentTask(), TaskId.readFromStream(input));
+            assertEquals("source = logs | stats count() as count by span(timestamp, 1m) as bucket", input.readOptionalString());
+            assertEquals("jdbc", input.readOptionalString());
+            assertNull(input.readOptionalString()); // explainMode
+            assertNull(input.readOptionalString()); // jsonContent
+            assertEquals("/_plugins/_ppl", input.readOptionalString());
+            assertTrue(input.readBoolean()); // sanitize
+            assertEquals(1, input.readVInt()); // JsonStyle.COMPACT
+            assertFalse(input.readBoolean()); // profile
+            assertFalse(input.readBoolean()); // analyze
+            assertNull(input.readOptionalString()); // queryId
+            assertNull(input.readOptionalBoolean()); // partialResult
             assertEquals(-1, input.read());
         }
     }
@@ -321,12 +323,6 @@ public class PPLDirectQueryExecutorTests extends OpenSearchTestCase {
 
     private static Constructor<?> pplTransportRequestConstructor() throws Exception {
         Constructor<?> constructor = pplTransportRequestClass().getDeclaredConstructor(String.class, String.class, String.class);
-        constructor.setAccessible(true);
-        return constructor;
-    }
-
-    private static Constructor<?> pplTransportRequestStreamConstructor() throws Exception {
-        Constructor<?> constructor = pplTransportRequestClass().getDeclaredConstructor(StreamInput.class);
         constructor.setAccessible(true);
         return constructor;
     }


### PR DESCRIPTION
Advances the plugin to OpenSearch 3.9.0-SNAPSHOT and fixes the compatibility failures exposed by that upgrade. This replaces #1760 because the automated version branch overwrites follow-up fixes when it refreshes.

- Restore the Jackson 2 core dependency required by PPL response parsing and Random Cut Forest serialization alongside OpenSearch’s Jackson 3 dependencies.
- Match SQL 3.9’s PPL request wire format, including the analyze and partial-result fields. Remove the unused inbound request adapter and verify the outbound bytes directly.
- Close both regular and certificate-authenticated admin HTTPS connection pools before the test framework shuts down HTTP reactors, preventing selector assertions and leaked threads.
- Exercise historical PPL analysis through the real SQL plugin and assert the returned feature names and values. This covers 23 previously missed executor lines, including date-range and grouped-query parsing.
- Give the null/empty-feature job tests a valid timestamp mapping so they reach the intended feature validation.
- Handle an unmapped detector-type aggregation in the stats API without returning HTTP 500. A regression test exercises both an empty config index and a document without a detector type.

Validation: the full `./gradlew build` passed locally on Java 21, including the complete integration and unit suites, packaging, Spotless, and coverage verification. The unmapped detector-type regression first reproduced CI's exact aggregation cast error; all five stats transport tests pass with the fix. The stats and historical PPL REST tests also passed over HTTPS with resource sharing enabled using CI's failing seed, locale, and time zone. Earlier focused validation covered both HTTPS configurations and historical PPL execution on a three-node Java 25 cluster. The existing CI matrix and coverage thresholds are unchanged.

Supersedes #1760.

Dependency and TLS review evidence:

- The resolved artifact is `com.fasterxml.jackson.core:jackson-core:2.22.2`, published by FasterXML. Its cached JAR matches the checksum published by Maven Central. The version comes from OpenSearch’s existing `versions.jackson` setting; Jackson 2 databind, annotations, and Random Cut Forest serialization already require this API.
- The admin HTTPS setup uses the same `TrustStore` certificate and client keystore as `SecureRestClientBuilder`, retains the default hostname verifier and TLS protocol/cipher settings, and preserves its connection/request timeouts. Its connection manager is retained so the test fixture can close active TLS connections before reactor shutdown.
- No test, coverage threshold, or security assertion has been disabled.
