### PR TITLE
Fix Jackson 2.x leftovers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     ext {
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.8.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.9.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')

--- a/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
+++ b/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java
@@ -48,8 +48,8 @@ import org.opensearch.timeseries.model.PPLSource;
 import org.opensearch.timeseries.util.SecurityClientUtil;
 import org.opensearch.transport.client.Client;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Executes restricted single-stream PPL detector queries at runtime through the


### PR DESCRIPTION
### Description
Fix Jackson 2.x leftovers
### Related Issues

See please https://build.ci.opensearch.org/job/distribution-build-opensearch/12194/consoleFull:

```
> Compilation failed; see the compiler output below.
  Note: Recompile with -Xlint:deprecation for details.
  /tmp/tmpsr2oxuhl/anomaly-detection/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java:227: error: cannot access Versioned
          JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
                                           ^
    class file for com.fasterxml.jackson.core.Versioned not found
  /tmp/tmpsr2oxuhl/anomaly-detection/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java:228: error: cannot access TreeNode
          if (!datarows.isArray() || datarows.isEmpty()) {
                       ^
    class file for com.fasterxml.jackson.core.TreeNode not found
  /tmp/tmpsr2oxuhl/anomaly-detection/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java:243: error: cannot access ObjectCodec
          JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
                                           ^
    class file for com.fasterxml.jackson.core.ObjectCodec not found
  /tmp/tmpsr2oxuhl/anomaly-detection/src/main/java/org/opensearch/timeseries/feature/PPLDirectQueryExecutor.java:308: error: cannot access JsonParser
          JsonNode datarows = OBJECT_MAPPER.readTree(responseBody).path("datarows");
                                           ^
    class file for com.fasterxml.jackson.core.JsonParser not found
  Note: Recompile with -Xlint:unchecked for details.
  Note: Some input files use or override a deprecated API.
  Note: Some input files use unchecked or unsafe operations.
  4 errors
```

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/anomaly-detection/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
